### PR TITLE
v0.6.5 — Modeling fractal models, CorMap similarity, WAXS area, slope guides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Per-peak Area reported in the WAXS Peak Fit tool.**  Added a derived
+  *Area* (integral under each peak profile, ∫I_peak(q)dq) alongside the
+  existing A / Q0 / FWHM / η parameters.  Computed in closed form for all
+  four supported shapes (Gauss, Lorentz, Pseudo-Voigt, LogNormal).
+  Linearised 1-σ uncertainty is propagated from the fitted-parameter
+  uncertainties.
+  - New helpers `peak_area()` and `peak_area_std()` in
+    [pyirena/core/waxs_peakfit.py](pyirena/core/waxs_peakfit.py).
+  - Saved as `area` + `area_std` scalar datasets in each
+    `entry/waxs_peakfit_results/peak_NN/` group of the HDF5 output
+    ([pyirena/io/nxcansas_waxs_peakfit.py](pyirena/io/nxcansas_waxs_peakfit.py)).
+    Older HDF5 files lacking these datasets are handled by recomputing the
+    area on load.
+  - Included in the Data Selector **Create Report** Markdown output
+    (per-peak table) and in the **Tabulate Results** CSV
+    (`WP_peak{N}_area`, `WP_peak{N}_area_std` columns).
+  - Included in the per-peak header line of the ASCII (`_waxs.dat`)
+    export written by [pyirena/io/ascii_export.py](pyirena/io/ascii_export.py).
+
 - **Similarity-based outlier rejection in the Data Manipulation Average tab.**
   Detects radiation-damaged frames before averaging using the CorMap test
   (Franke et al., *Nature Methods* 12, 419–422, 2015).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added (continued)
 
+- **Modeling tool: three new population types.**
+  The Modeling tool now supports six population types (up from three).
+  - **Guinier-Porod Level** (`guinier_porod`) — piecewise analytical model for non-spherical or
+    non-dilute scatterers (Hammouda 2010, *J. Appl. Cryst.* **43**, 716–719).
+    Parameters: G, Rg1, s1, P, Rg2, s2, RgCO; optional Born-Green correlations (ETA, PACK).
+    Setting Rg2 = 1e10 (default) gives single-level behaviour identical to standard GP.
+  - **Mass Fractal** (`mass_fractal`) — fractal aggregate scattering with sphere primary
+    particles (Teixeira 1988, *J. Appl. Cryst.* **21**, 781–785).
+    Parameters: Phi, Radius, Dv (fractal dimension), Ksi (correlation length), Eta, Contrast.
+  - **Surface Fractal** (`surface_fractal`) — scattering from a surface with fractal roughness
+    (Teixeira 1988).  Parameters: Surface, Ds (2–3), Ksi, Contrast; optional smooth Porod
+    transition to Q⁻⁴ above Qc.
+  All three types support fitting with bounds, MC uncertainty, HDF5/NXcanSAS output,
+  JSON state persistence, and headless batch use via `fit_modeling()`.
+
 - **Draggable power-law slope guide lines in the Unified Fit I(Q) graph.**
   Right-click the graph → *Add slope guide line* submenu.  Presets: n = −2, −3,
   −4 (Porod), −5, −6; a *Custom slope…* entry accepts any value in [−8, −0.5].

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,39 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **Unified Fit top axis now shows R = π/Q numerical labels.**
+  The `setStyle(showValues=False)` call that suppressed tick values on the
+  `RadiusAxisItem` was removed; axis behaviour now matches Simple Fits.
+
+- **Unified Fit: B limits correctly hidden when "No limits?" is checked after
+  unchecking "Estimate B from G/Rg/P".**
+  `UnifiedFitLevelWidget` now tracks the current limits-visibility state in
+  `_limits_visible` and consults it in `_on_estimate_b_changed`, so unchecking
+  "Estimate B" no longer re-shows B limit fields when "No limits?" is active.
+
+### Added
+
+- **d-spacing top axis (d = 2π/Q [Å]) on all WAXS plots.**
+  - New `DSpacingAxisItem` class in `pyirena/gui/sas_plot.py`.
+  - `make_sas_plot()` accepts a new `d_spacing_axis=True` keyword; when set and
+    `log_x=False`, the top axis shows d-spacing tick labels instead of R = π/Q.
+  - `DataMergeGraphWindow` passes `d_spacing_axis=True` in WAXS mode.
+  - `WAXSPeakFitGraphWindow` now includes the d-spacing top axis on its main plot.
+
+- **Clearer Save/Load parameter button labels across all tools.**
+  "Export Parameters" renamed to **"Save params to JSON"** and "Import Parameters"
+  renamed to **"Load params from JSON"** in Simple Fits, Sizes, Unified Fit,
+  Modeling, and WAXS Peak Fit panels to make the JSON-file destination explicit.
+
+- **Tooltips added to all main action buttons across all GUI panels.**
+  Buttons that previously had no tooltip now show a 1–2 line description of what
+  the button does, covering Unified Fit, Simple Fits, Sizes, Modeling, WAXS Peak
+  Fit, Data Merge, Data Manipulation, and Data Selector panels.
+
 ## [0.6.4]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,42 +5,26 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.6.5] — 2026-05-19
 
 ### Added
 
-- **Per-peak Area reported in the WAXS Peak Fit tool.**  Added a derived
-  *Area* (integral under each peak profile, ∫I_peak(q)dq) alongside the
-  existing A / Q0 / FWHM / η parameters.  Computed in closed form for all
-  four supported shapes (Gauss, Lorentz, Pseudo-Voigt, LogNormal).
-  Linearised 1-σ uncertainty is propagated from the fitted-parameter
-  uncertainties.
-  - New helpers `peak_area()` and `peak_area_std()` in
-    [pyirena/core/waxs_peakfit.py](pyirena/core/waxs_peakfit.py).
-  - Saved as `area` + `area_std` scalar datasets in each
-    `entry/waxs_peakfit_results/peak_NN/` group of the HDF5 output
-    ([pyirena/io/nxcansas_waxs_peakfit.py](pyirena/io/nxcansas_waxs_peakfit.py)).
-    Older HDF5 files lacking these datasets are handled by recomputing the
-    area on load.
-  - Included in the Data Selector **Create Report** Markdown output
-    (per-peak table) and in the **Tabulate Results** CSV
-    (`WP_peak{N}_area`, `WP_peak{N}_area_std` columns).
-  - Included in the per-peak header line of the ASCII (`_waxs.dat`)
-    export written by [pyirena/io/ascii_export.py](pyirena/io/ascii_export.py).
-  - **HDF5 Viewer → Collect Values** pulldown now lists `Area` and
-    `Area_err` (in addition to the existing Q0/A/FWHM/η entries) when
-    *Type* = *WAXS Peak Fit*
-    ([pyirena/gui/hdf5viewer/plot_controls.py](pyirena/gui/hdf5viewer/plot_controls.py),
-    [pyirena/gui/hdf5viewer/pyirena_readers.py](pyirena/gui/hdf5viewer/pyirena_readers.py)).
-  - **HDF5 Viewer → Export to Igor → Build results table** writes a
-    `peak_Area_P{n}` wave for every peak in addition to the existing
-    Q0/A/FWHM/η waves, via a new per-subgroup scalar entry in
-    [pyirena/io/schema.py](pyirena/io/schema.py).  The per-peak
-    `SADModelIntPeak{n}` wave note also gains `Area` and `Area_err`
-    fields ([pyirena/io/h5xp_extractor.py](pyirena/io/h5xp_extractor.py)).
-  - Older HDF5 files written before the `area` dataset existed are
-    handled transparently in all readers by recomputing the value from
-    the stored A / Q0 / FWHM / η parameters.
+- **Modeling tool: three new population types** (Modeling tool grows from 3 to 6 types).
+  All three types support fitting with bounds, MC uncertainty, HDF5/NXcanSAS output,
+  JSON state persistence, and headless batch use via `fit_modeling()`.
+  - **Guinier-Porod Level** (`guinier_porod`) — piecewise analytical model for non-spherical
+    or non-dilute scatterers (Hammouda 2010, *J. Appl. Cryst.* **43**, 716–719).
+    Parameters: G, Rg1, s1, P, Rg2, s2, RgCO; optional Born-Green correlations (ETA, PACK).
+    Default Rg2 = 1e10 gives single-level behaviour; a finite Rg2 activates the low-Q regime.
+  - **Mass Fractal** (`mass_fractal`) — fractal aggregate scattering (Teixeira 1988,
+    *J. Appl. Cryst.* **21**, 781–785).  Primary particles are spheroids with aspect ratio
+    β (default 1 = sphere).  β ≠ 1 uses the orientation-averaged spheroid form factor
+    (50-point Gauss-Legendre quadrature over particle orientation), eliminating the
+    unphysical Bessel-function oscillations of the monodisperse sphere.
+    Parameters: Phi, Radius, Beta, Dv, Ksi, Eta, Contrast.
+  - **Surface Fractal** (`surface_fractal`) — scattering from a surface with fractal
+    roughness (Teixeira 1988).  Parameters: Surface, Ds (2–3), Ksi, Contrast;
+    optional smooth Porod transition to Q⁻⁴ above Qc via error-function blending.
 
 - **Similarity-based outlier rejection in the Data Manipulation Average tab.**
   Detects radiation-damaged frames before averaging using the CorMap test
@@ -51,16 +35,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     frame 0 is always accepted — standard bioSAXS approach) and **Majority
     vote** (compare each frame vs. the median of all frames; more robust when
     the first frame itself may be damaged).
-  - P-value threshold is user-adjustable (default 0.01).  Lower threshold =
-    stricter acceptance (fewer frames kept); higher = looser.
+  - P-value threshold is user-adjustable (default 0.01).
   - Results table with colour-coded rows (green = accepted, red = rejected)
     appears after clicking **Check Similarity**; **Auto-reject** button
     removes outliers from the selection in one click.
-  - Similarity settings (method, reference, p-value) are persisted in the
-    application state.
-  - Extensible registry (`SIMILARITY_METHODS` dict in `similarity.py`): add a
-    new method by registering a function — the GUI dropdown updates
-    automatically.
+  - Similarity settings (method, reference, p-value) are persisted in state.
+  - Extensible registry (`SIMILARITY_METHODS` dict): add a new method by
+    registering a function — the GUI dropdown updates automatically.
 
 - **`average_data()` headless API gains similarity filtering.**
   New keyword arguments: `similarity_check=False`, `similarity_p_min=0.01`,
@@ -68,69 +49,49 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `similarity_check=True`, frames failing the p-value test are discarded
   before averaging and reported in the return dict (`'rejected'` list).
 
-### Added (continued)
+- **Per-peak Area reported in the WAXS Peak Fit tool.**  Integral under each
+  peak profile (∫I_peak(q)dq) computed in closed form for all four peak shapes
+  (Gauss, Lorentz, Pseudo-Voigt, LogNormal); linearised 1-σ uncertainty propagated
+  from fitted-parameter uncertainties.
+  - Saved as `area` + `area_std` in HDF5; older files recomputed transparently on load.
+  - Included in Data Selector report, Tabulate Results CSV, and ASCII export.
+  - **Data Explorer → Collect Values** pulldown lists `Area` and `Area_err` for WAXS Peak Fit.
+  - **Data Explorer → Export to Igor** writes a `peak_Area_P{n}` wave for every peak.
 
-- **Modeling tool: three new population types.**
-  The Modeling tool now supports six population types (up from three).
-  - **Guinier-Porod Level** (`guinier_porod`) — piecewise analytical model for non-spherical or
-    non-dilute scatterers (Hammouda 2010, *J. Appl. Cryst.* **43**, 716–719).
-    Parameters: G, Rg1, s1, P, Rg2, s2, RgCO; optional Born-Green correlations (ETA, PACK).
-    Setting Rg2 = 1e10 (default) gives single-level behaviour identical to standard GP.
-  - **Mass Fractal** (`mass_fractal`) — fractal aggregate scattering (Teixeira 1988,
-    *J. Appl. Cryst.* **21**, 781–785).  Primary particles are spheroids with aspect ratio
-    β (1 = sphere).  β ≠ 1 uses the orientation-averaged spheroid form factor (Gauss-Legendre
-    quadrature over particle orientation) which eliminates the unphysical Bessel oscillations
-    present in the monodisperse sphere form factor.
-    Parameters: Phi, Radius, Beta, Dv, Ksi, Eta, Contrast.
-  - **Surface Fractal** (`surface_fractal`) — scattering from a surface with fractal roughness
-    (Teixeira 1988).  Parameters: Surface, Ds (2–3), Ksi, Contrast; optional smooth Porod
-    transition to Q⁻⁴ above Qc.
-  All three types support fitting with bounds, MC uncertainty, HDF5/NXcanSAS output,
-  JSON state persistence, and headless batch use via `fit_modeling()`.
+- **d-spacing top axis (d = 2π/Q [Å]) on all WAXS linear-scale plots.**
+  New `DSpacingAxisItem` in `sas_plot.py`; `make_sas_plot()` gains a `d_spacing_axis=True`
+  keyword.  Active on the Data Merge WAXS plot and the WAXS Peak Fit main plot.
 
 - **Draggable power-law slope guide lines in the Unified Fit I(Q) graph.**
   Right-click the graph → *Add slope guide line* submenu.  Presets: n = −2, −3,
-  −4 (Porod), −5, −6; a *Custom slope…* entry accepts any value in [−8, −0.5].
-  - Lines are drawn as dashed colored lines with a label (*n = −4*) at the right
-    end.  Each successive line cycles through a distinct colour palette.
-  - Drag any line vertically to slide it along the intensity axis and align it
-    with your data.  The line stays geometrically exact at every zoom level.
-  - Right-click a single line to *Change slope…* or *Remove*.
-  - Right-click the background → *Remove all slope lines* to clear all at once.
-  - Implemented as `SlopeLine` (`pg.GraphicsObject` subclass) and
-    `add_slope_line_menu()` helper in `pyirena/gui/sas_plot.py` — ready to be
-    added to other tools once the Unified Fit implementation is validated.
+  −4 (Porod), −5, −6; *Custom slope…* accepts any value in [−8, −0.5].
+  Lines carry a label, cycle through a colour palette, drag vertically, and can be
+  individually removed or cleared in bulk.  Implemented as `SlopeLine` in `sas_plot.py`.
+
+- **Clearer Save/Load parameter button labels across all tools.**
+  "Export Parameters" → **"Save params to JSON"**; "Import Parameters" →
+  **"Load params from JSON"** in Simple Fits, Sizes, Unified Fit, Modeling, and
+  WAXS Peak Fit.
+
+- **Tooltips added to all main action buttons across all GUI panels.**
+  Covers Unified Fit, Simple Fits, Sizes, Modeling, WAXS Peak Fit, Data Merge,
+  Data Manipulation, and Data Selector.
 
 ### Fixed
 
+- **Modeling: "No limits?" checkbox now hides Min/Max columns for Guinier-Porod,
+  Mass Fractal, and Surface Fractal populations.**  `set_no_limits()` was missing
+  the five new row-store dicts; the fitting engine already applied unconstrained
+  Nelder-Mead for all types — this was a GUI-only gap.
+
 - **Unified Fit top axis now shows R = π/Q numerical labels.**
-  The `setStyle(showValues=False)` call that suppressed tick values on the
-  `RadiusAxisItem` was removed; axis behaviour now matches Simple Fits.
+  `setStyle(showValues=False)` on the `RadiusAxisItem` was removed; behaviour
+  now matches Simple Fits.
 
 - **Unified Fit: B limits correctly hidden when "No limits?" is checked after
-  unchecking "Estimate B from G/Rg/P".**
-  `UnifiedFitLevelWidget` now tracks the current limits-visibility state in
-  `_limits_visible` and consults it in `_on_estimate_b_changed`, so unchecking
-  "Estimate B" no longer re-shows B limit fields when "No limits?" is active.
-
-### Added
-
-- **d-spacing top axis (d = 2π/Q [Å]) on all WAXS plots.**
-  - New `DSpacingAxisItem` class in `pyirena/gui/sas_plot.py`.
-  - `make_sas_plot()` accepts a new `d_spacing_axis=True` keyword; when set and
-    `log_x=False`, the top axis shows d-spacing tick labels instead of R = π/Q.
-  - `DataMergeGraphWindow` passes `d_spacing_axis=True` in WAXS mode.
-  - `WAXSPeakFitGraphWindow` now includes the d-spacing top axis on its main plot.
-
-- **Clearer Save/Load parameter button labels across all tools.**
-  "Export Parameters" renamed to **"Save params to JSON"** and "Import Parameters"
-  renamed to **"Load params from JSON"** in Simple Fits, Sizes, Unified Fit,
-  Modeling, and WAXS Peak Fit panels to make the JSON-file destination explicit.
-
-- **Tooltips added to all main action buttons across all GUI panels.**
-  Buttons that previously had no tooltip now show a 1–2 line description of what
-  the button does, covering Unified Fit, Simple Fits, Sizes, Modeling, WAXS Peak
-  Fit, Data Merge, Data Manipulation, and Data Selector panels.
+  unchecking "Estimate B from G/Rg/P".**  `UnifiedFitLevelWidget` now tracks
+  the limits-visibility state in `_limits_visible` and consults it in
+  `_on_estimate_b_changed`.
 
 ## [0.6.4]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Similarity-based outlier rejection in the Data Manipulation Average tab.**
+  Detects radiation-damaged frames before averaging using the CorMap test
+  (Franke et al., *Nature Methods* 12, 419–422, 2015).
+  - Pure NumPy/Python implementation in `pyirena/core/similarity.py` — no
+    silx or freesas dependency.
+  - Two reference modes: **First frame** (compare each frame vs. frame 0;
+    frame 0 is always accepted — standard bioSAXS approach) and **Majority
+    vote** (compare each frame vs. the median of all frames; more robust when
+    the first frame itself may be damaged).
+  - P-value threshold is user-adjustable (default 0.01).  Lower threshold =
+    stricter acceptance (fewer frames kept); higher = looser.
+  - Results table with colour-coded rows (green = accepted, red = rejected)
+    appears after clicking **Check Similarity**; **Auto-reject** button
+    removes outliers from the selection in one click.
+  - Similarity settings (method, reference, p-value) are persisted in the
+    application state.
+  - Extensible registry (`SIMILARITY_METHODS` dict in `similarity.py`): add a
+    new method by registering a function — the GUI dropdown updates
+    automatically.
+
+- **`average_data()` headless API gains similarity filtering.**
+  New keyword arguments: `similarity_check=False`, `similarity_p_min=0.01`,
+  `similarity_method='cormap'`, `similarity_reference='first'`.  When
+  `similarity_check=True`, frames failing the p-value test are discarded
+  before averaging and reported in the return dict (`'rejected'` list).
+
 ### Added (continued)
 
 - **Draggable power-law slope guide lines in the Unified Fit I(Q) graph.**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added (continued)
+
+- **Draggable power-law slope guide lines in the Unified Fit I(Q) graph.**
+  Right-click the graph → *Add slope guide line* submenu.  Presets: n = −2, −3,
+  −4 (Porod), −5, −6; a *Custom slope…* entry accepts any value in [−8, −0.5].
+  - Lines are drawn as dashed colored lines with a label (*n = −4*) at the right
+    end.  Each successive line cycles through a distinct colour palette.
+  - Drag any line vertically to slide it along the intensity axis and align it
+    with your data.  The line stays geometrically exact at every zoom level.
+  - Right-click a single line to *Change slope…* or *Remove*.
+  - Right-click the background → *Remove all slope lines* to clear all at once.
+  - Implemented as `SlopeLine` (`pg.GraphicsObject` subclass) and
+    `add_slope_line_menu()` helper in `pyirena/gui/sas_plot.py` — ready to be
+    added to other tools once the Unified Fit implementation is validated.
+
 ### Fixed
 
 - **Unified Fit top axis now shows R = π/Q numerical labels.**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,9 +43,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     non-dilute scatterers (Hammouda 2010, *J. Appl. Cryst.* **43**, 716–719).
     Parameters: G, Rg1, s1, P, Rg2, s2, RgCO; optional Born-Green correlations (ETA, PACK).
     Setting Rg2 = 1e10 (default) gives single-level behaviour identical to standard GP.
-  - **Mass Fractal** (`mass_fractal`) — fractal aggregate scattering with sphere primary
-    particles (Teixeira 1988, *J. Appl. Cryst.* **21**, 781–785).
-    Parameters: Phi, Radius, Dv (fractal dimension), Ksi (correlation length), Eta, Contrast.
+  - **Mass Fractal** (`mass_fractal`) — fractal aggregate scattering (Teixeira 1988,
+    *J. Appl. Cryst.* **21**, 781–785).  Primary particles are spheroids with aspect ratio
+    β (1 = sphere).  β ≠ 1 uses the orientation-averaged spheroid form factor (Gauss-Legendre
+    quadrature over particle orientation) which eliminates the unphysical Bessel oscillations
+    present in the monodisperse sphere form factor.
+    Parameters: Phi, Radius, Beta, Dv, Ksi, Eta, Contrast.
   - **Surface Fractal** (`surface_fractal`) — scattering from a surface with fractal roughness
     (Teixeira 1988).  Parameters: Surface, Ds (2–3), Ksi, Contrast; optional smooth Porod
     transition to Q⁻⁴ above Qc.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     (`WP_peak{N}_area`, `WP_peak{N}_area_std` columns).
   - Included in the per-peak header line of the ASCII (`_waxs.dat`)
     export written by [pyirena/io/ascii_export.py](pyirena/io/ascii_export.py).
+  - **HDF5 Viewer → Collect Values** pulldown now lists `Area` and
+    `Area_err` (in addition to the existing Q0/A/FWHM/η entries) when
+    *Type* = *WAXS Peak Fit*
+    ([pyirena/gui/hdf5viewer/plot_controls.py](pyirena/gui/hdf5viewer/plot_controls.py),
+    [pyirena/gui/hdf5viewer/pyirena_readers.py](pyirena/gui/hdf5viewer/pyirena_readers.py)).
+  - **HDF5 Viewer → Export to Igor → Build results table** writes a
+    `peak_Area_P{n}` wave for every peak in addition to the existing
+    Q0/A/FWHM/η waves, via a new per-subgroup scalar entry in
+    [pyirena/io/schema.py](pyirena/io/schema.py).  The per-peak
+    `SADModelIntPeak{n}` wave note also gains `Area` and `Area_err`
+    fields ([pyirena/io/h5xp_extractor.py](pyirena/io/h5xp_extractor.py)).
+  - Older HDF5 files written before the `area` dataset existed are
+    handled transparently in all readers by recomputing the value from
+    the stored A / Q0 / FWHM / η parameters.
 
 - **Similarity-based outlier rejection in the Data Manipulation Average tab.**
   Detects radiation-damaged frames before averaging using the CorMap test

--- a/docs/batch_api.md
+++ b/docs/batch_api.md
@@ -483,8 +483,7 @@ result = fit_modeling(
 2. **Loads data** — same format detection as `fit_unified` (`.h5`/`.hdf5` via
    NXcanSAS, `.dat`/`.txt` via text reader).
 3. **Builds populations** — deserializes each population dict from the config into
-   the appropriate dataclass (`SizeDistPopulation`, `UnifiedLevelPopulation`, or
-   `DiffractionPeakPopulation`) based on the `pop_type` field.
+   the appropriate dataclass based on the `pop_type` field.
 4. **Runs the fit** — `ModelingEngine.fit()` using `scipy.optimize.least_squares`
    (TRF with bounds) or Nelder-Mead when `no_limits=True`.
 5. **MC uncertainty** *(if `with_uncertainty=True`)* — re-fits `n_mc_runs` noise-perturbed
@@ -505,7 +504,7 @@ result = fit_modeling(
 
 ### Population types
 
-The Modeling tool supports three population types, each stored in the config with
+The Modeling tool supports six population types, each stored in the config with
 a `pop_type` field:
 
 | `pop_type` | Dataclass | Description |
@@ -513,8 +512,11 @@ a `pop_type` field:
 | `size_dist` | `SizeDistPopulation` | Parametric size distribution (Gauss, LogNormal, LSW, Schulz-Zimm, Ardell) convolved with a form factor and optional structure factor |
 | `unified_level` | `UnifiedLevelPopulation` | Beaucage Unified Fit level: G·exp(−q²Rg²/3) + B·Q*⁻ᴾ + optional Born-Green correlations |
 | `diffraction_peak` | `DiffractionPeakPopulation` | Gaussian, Lorentzian, or pseudo-Voigt peak at Q₀ |
+| `guinier_porod` | `GuinierPorodPopulation` | Piecewise Guinier-Porod model (Hammouda 2010); 6 shape params G, Rg1, s1, P, Rg2, s2 + optional RgCO and Born-Green correlations |
+| `mass_fractal` | `MassFractalPopulation` | Mass fractal aggregate (Teixeira 1988); sphere primary particles; params Phi, Radius, Dv, Ksi, Eta, Contrast |
+| `surface_fractal` | `SurfaceFractalPopulation` | Surface fractal (Teixeira 1988); params Surface, Ds, Ksi, Contrast + optional Porod transition at Qc |
 
-Up to 5 populations of any type can be combined in a single fit.
+Up to 10 populations of any type can be combined in a single fit.
 
 ### Returns
 

--- a/docs/batch_api.md
+++ b/docs/batch_api.md
@@ -18,11 +18,12 @@ is no need to write configuration code by hand.
 7. [API reference — `fit_modeling`](#fit_modeling)
 8. [API reference — `fit_saxs_morph`](#fit_saxs_morph)
 9. [API reference — `merge_data`](#merge_data)
-10. [API reference — `fit_pyirena`](#fit_pyirena)
-11. [Return structures](#return-structures)
-12. [Error handling](#error-handling)
-13. [Batch processing patterns](#batch-processing-patterns)
-14. [Extending with new tools](#extending-with-new-tools)
+10. [API reference — `average_data`](#average_data)
+11. [API reference — `fit_pyirena`](#fit_pyirena)
+12. [Return structures](#return-structures)
+13. [Error handling](#error-handling)
+14. [Batch processing patterns](#batch-processing-patterns)
+15. [Extending with new tools](#extending-with-new-tools)
 
 ---
 
@@ -900,6 +901,222 @@ python scripts/batch_merge.py \
 ```
 
 Run `python scripts/batch_merge.py --help` for full option reference.
+
+---
+
+## `average_data`
+
+```python
+from pyirena.batch import average_data
+
+result = average_data(
+    data_files,                         # list[str | Path] — files to average
+    output_folder=None,                 # str | Path | None — where to save
+    verbose=True,                       # bool — print progress to stdout
+    similarity_check=False,             # bool — run similarity filter first
+    similarity_p_min=0.01,              # float — rejection threshold (0–1)
+    similarity_method='cormap',         # str — test algorithm (see below)
+    similarity_reference='first',       # str — 'first' or 'majority'
+    similarity_normalize_scale=True,    # bool — normalise amplitude before comparing
+)
+```
+
+`average_data` does **not** use a JSON config file.  All parameters are
+passed directly.  The GUI saves its similarity settings to pyIrena's internal
+state file (auto-restored on next launch) but those settings are not read
+by the batch function — pipeline scripts should hard-code or compute the
+values they want, or read them from a user-defined config dict.
+
+### What it does, step by step
+
+1. **Loads** each file in `data_files` — accepts `.h5`/`.hdf5`/`.hdf`
+   (NXcanSAS or generic HDF5) and `.dat`/`.txt` (column-delimited text).
+   Files that fail to load are skipped with a warning.
+2. **Similarity filter** *(if `similarity_check=True`)* — runs the CorMap
+   test (or another registered method) on all loaded datasets and marks
+   frames with `p_value < similarity_p_min` as rejected.  Rejected frames
+   are logged (when `verbose=True`) and excluded before averaging.
+   If fewer than 2 frames remain, the function returns `None`.
+3. **Averages** — interpolates every dataset onto the first accepted frame's
+   Q grid (log-log), then computes:
+   ```
+   I_avg   = mean(I_i)
+   dI_avg  = max( sqrt(sum(dI_i^2)) / N,  std(I_i) )  per Q point
+   ```
+   Only Q points valid in **all** datasets contribute to the result.
+4. **Saves** to a NXcanSAS HDF5 file in `output_folder` (created if absent).
+   The file includes an `entry/data_manipulation_results` NXprocess provenance
+   group recording the operation, number of datasets, and timestamp.
+5. **Returns** a result dict (see below).
+
+### Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `data_files` | `list[str \| Path]` | required | Ordered list of files to average.  Order matters only when `similarity_reference='first'`. |
+| `output_folder` | `str`, `Path`, or `None` | `None` | Output directory.  If `None`, a folder `{first_file_folder}_manip/` is created next to the first input file. |
+| `verbose` | `bool` | `True` | Print per-frame similarity results and final summary to stdout. |
+| `similarity_check` | `bool` | `False` | Enable similarity filtering.  When `True`, frames with p < `similarity_p_min` are excluded before averaging. |
+| `similarity_p_min` | `float` | `0.01` | P-value rejection threshold.  Frames with p below this are discarded.  Typical range: 0.001 (strict) – 0.05 (loose). |
+| `similarity_method` | `str` | `'cormap'` | Test algorithm.  Currently only `'cormap'` (Franke et al., 2015) is registered.  Additional methods can be added to `pyirena/core/similarity.py`. |
+| `similarity_reference` | `str` | `'first'` | `'first'` — compare each frame vs. frame #1, which is always kept.  Standard bioSAXS approach when the first exposure is known clean.  `'majority'` — compare each frame vs. the **median** of all frames; more robust when the first frame may also be damaged or when damage is not monotonically increasing. |
+| `similarity_normalize_scale` | `bool` | `True` | Recommended: `True`.  Before comparing, rescales each frame to match the reference amplitude using the geometric-median intensity ratio.  This removes flux-drift and absorption differences so that CorMap detects *shape* changes only — the relevant signature of radiation damage.  Set `False` only when data are on a perfectly calibrated absolute scale and you want amplitude changes to count as damage. |
+
+### Returns
+
+`dict` on success, `None` on fatal error (no files loaded, fewer than 2
+frames survive similarity filtering, save error, etc.).
+
+```python
+{
+    'success':    bool,              # True when result was saved
+    'operation':  'avg',
+    'output_file': Path,            # full path to the written NXcanSAS file
+    'message':    str,              # human-readable summary line
+    'n_datasets': int,              # number of frames that were averaged
+    'rejected':   list[tuple],      # [(filename, p_value), ...] — frames
+                                    # discarded by similarity filter; [] when
+                                    # similarity_check=False
+}
+```
+
+### Examples
+
+#### Simple average, no filtering
+
+```python
+from pathlib import Path
+from pyirena.batch import average_data
+
+files = sorted(Path("frames/").glob("sample_*.h5"))
+result = average_data(files, output_folder="averaged/")
+if result:
+    print(f"Averaged {result['n_datasets']} frames → {result['output_file'].name}")
+```
+
+#### Automatic radiation-damage rejection
+
+```python
+from pathlib import Path
+from pyirena.batch import average_data
+
+files = sorted(Path("frames/").glob("sample_*.h5"))
+
+result = average_data(
+    files,
+    output_folder="averaged/",
+    similarity_check=True,
+    similarity_p_min=0.01,
+    similarity_reference='first',   # first frame known clean
+    similarity_normalize_scale=True,
+    verbose=True,                   # prints [OK] / [REJECT] per frame
+)
+
+if result:
+    print(f"Averaged {result['n_datasets']} of {len(files)} frames")
+    for fname, p in result['rejected']:
+        print(f"  REJECTED  {fname}  (p={p:.4f})")
+```
+
+#### Majority-vote reference (robust when first frame may be damaged)
+
+```python
+result = average_data(
+    files,
+    output_folder="averaged/",
+    similarity_check=True,
+    similarity_p_min=0.01,
+    similarity_reference='majority',  # compare each vs. median of all
+    similarity_normalize_scale=True,
+)
+```
+
+#### Pipeline: process many sample folders
+
+```python
+from pathlib import Path
+from pyirena.batch import average_data
+
+# Each sub-folder contains sequential exposures for one sample
+data_root = Path("raw/")
+out_root  = Path("averaged/")
+
+# Similarity settings determined empirically on test data
+SIM_PARAMS = dict(
+    similarity_check=True,
+    similarity_p_min=0.01,
+    similarity_reference='first',
+    similarity_normalize_scale=True,
+)
+
+for sample_dir in sorted(data_root.iterdir()):
+    if not sample_dir.is_dir():
+        continue
+    frames = sorted(sample_dir.glob("*.h5"))
+    if len(frames) < 2:
+        continue
+
+    out_dir = out_root / sample_dir.name
+    result = average_data(frames, output_folder=out_dir, **SIM_PARAMS)
+
+    if result is None:
+        print(f"FAILED  {sample_dir.name}")
+    else:
+        n_kept = result['n_datasets']
+        n_total = len(frames)
+        n_rej = len(result['rejected'])
+        print(f"OK  {sample_dir.name}: {n_kept}/{n_total} frames "
+              f"({n_rej} rejected)")
+```
+
+#### In-memory usage (no file written, just get the averaged arrays)
+
+```python
+from pyirena.batch import _load_data
+from pyirena.core.data_manipulation import DataManipulation
+from pyirena.core.similarity import check_similarity
+from pathlib import Path
+
+files = sorted(Path("frames/").glob("*.h5"))
+
+# Load data
+datasets, names = [], []
+for fp in files:
+    d = _load_data(fp)
+    if d is None:
+        continue
+    datasets.append((d['Q'], d['Intensity'], d.get('Error', d['Intensity']*0.05), d.get('dQ')))
+    names.append(fp.name)
+
+# Check similarity
+results = check_similarity(datasets, filenames=names,
+                           reference='first', p_min=0.01)
+accepted = [datasets[r.idx] for r in results if r.accepted]
+
+# Average accepted frames
+avg = DataManipulation.average(accepted, reference_index=0)
+q, I, dI = avg.q, avg.I, avg.dI
+```
+
+### Choosing a p-value threshold
+
+The p-value is the probability that two truly identical curves would
+produce a run of same-sign residuals at least as long as the observed one
+by random chance alone.  Low p → curves differ → likely damaged.
+
+| Threshold | Effect |
+|-----------|--------|
+| 0.001 | Strict: only reject severe outliers (large, obvious damage) |
+| 0.010 | Moderate: good default starting point |
+| 0.050 | Loose: rejects borderline frames; cleaner average but fewer frames used |
+
+**Recommended calibration workflow:**
+
+1. Run with `verbose=True` on a clean sample (known undamaged exposures).
+   Note the lowest p-value observed.  Set `similarity_p_min` just below that.
+2. Run on a sample known to contain damaged frames.  Raise the threshold
+   until the damaged frames appear in `result['rejected']`.
+3. Fix the threshold in your pipeline configuration.
 
 ---
 

--- a/docs/data_manipulation_gui.md
+++ b/docs/data_manipulation_gui.md
@@ -138,21 +138,24 @@ Rebinning uses log-log interpolation with relative-uncertainty propagation.
 
 ### Average
 
-Average multiple datasets to improve statistics.  Common in bioSAXS where
-users collect sequential exposures and discard radiation-damaged frames.
+Average multiple datasets to improve statistics.  Common in any experiment
+where sequential exposures are collected and radiation-damaged frames must
+be identified and discarded before averaging.
 
 **Workflow:**
 
 1. Select multiple files in the file list (Ctrl+click or Shift+click).
 2. All selected datasets are plotted with distinct colours and averaged
    automatically.
-3. **Right-click on the graph** to access:
+3. Optionally run the **Similarity analysis** to flag damaged frames
+   automatically (see below).
+4. **Right-click on the graph** for manual removal:
    - **Remove dataset** --- submenu with colour-coded entries matching the plot.
    - **Remove all after** --- remove a dataset and everything measured after it.
-4. The average recomputes automatically after each removal.
+5. The average recomputes automatically after each removal.
 
 The average is computed on the first selected file's Q grid.  Other datasets
-are log-log interpolated onto that grid.
+are log-log interpolated onto that grid before averaging.
 
 **Uncertainty:** the larger of propagated error and sample spread:
 
@@ -164,6 +167,38 @@ This is robust: propagated error dominates for consistent data, while the
 spread correctly reflects systematic drift (e.g. radiation damage).
 
 **Output suffix:** `_avg`
+
+#### Similarity analysis — automatic radiation damage detection
+
+The **Similarity analysis** group inside the Average tab uses the
+**CorMap test** (Franke et al., *Nature Methods* 12, 419–422, 2015) to
+compute a p-value for each frame.  A low p-value means the frame differs
+from the reference beyond what random noise alone can explain — the
+hallmark of radiation damage or a transient contamination event (e.g. a
+bubble in the beam path).
+
+| Control | Description |
+|---------|-------------|
+| **Method** | Test algorithm.  Currently *CorMap (Franke 2015)*.  Additional methods can be registered in `pyirena/core/similarity.py`. |
+| **Reference** | *First frame* — each dataset is compared to dataset #1, which is always accepted.  Standard bioSAXS approach.  Use when the first exposure is known to be clean.  *Majority vote* — each dataset is compared to the **median** of all datasets; more robust when the first frame may itself be damaged or when damage is not monotonically increasing. |
+| **P-value threshold** | Frames with p-value below this are flagged as *Rejected* (default 0.01).  Lower threshold = stricter (fewer rejections); higher = looser (more rejections but cleaner average). |
+| **Normalize scale** | Recommended: **on**.  Rescales each frame to match the reference amplitude before comparing, removing flux-drift and absorption differences so that CorMap detects *shape* changes only.  Turn off only when data are on an identical absolute scale and you want scale changes to count as damage. |
+
+**Check Similarity** runs the test and shows a colour-coded results table:
+green rows are accepted, red rows are rejected.
+The status bar reports `N results for M files` — if N < M, some files
+could not be loaded.
+
+**Auto-reject N below threshold** deselects all rejected frames in one
+click and re-computes the average.  Manual right-click removal on the
+graph still works independently.
+
+> **How to choose a p-value threshold**
+> Run the tool on a clean test dataset (frames you know are undamaged) and
+> note the lowest p-value you see.  Set the threshold just below that value
+> so good frames are accepted.  Then test on a dataset known to contain
+> damaged frames and raise the threshold until they are rejected.  Typical
+> starting values: 0.001 (strict) or 0.010 (moderate).
 
 ### Subtract (buffer)
 
@@ -252,16 +287,27 @@ result = manipulate_data(
 ### `average_data()`
 
 ```python
-from pyirena import average_data
+from pyirena.batch import average_data
 
 result = average_data(
     data_files=["frame_001.h5", "frame_002.h5", "frame_003.h5"],
     output_folder="./output",
+    # optional similarity filtering:
+    similarity_check=True,
+    similarity_p_min=0.01,
+    similarity_reference='first',      # 'first' or 'majority'
+    similarity_normalize_scale=True,
 )
 ```
 
-Both functions return a dict with keys `success`, `operation`, `output_file`,
-and `message`, or `None` on fatal errors.
+See the [full `average_data` API reference](batch_api.md#average_data) in
+`batch_api.md` for all parameters, return value structure, and pipeline
+examples.
+
+`manipulate_data()` returns a dict with keys `success`, `operation`,
+`output_file`, and `message`, or `None` on fatal errors.  `average_data()`
+returns the same plus `rejected` (list of `(filename, p_value)` pairs for
+frames discarded by the similarity filter).
 
 ---
 

--- a/docs/modeling_gui.md
+++ b/docs/modeling_gui.md
@@ -233,7 +233,10 @@ Optional Born-Green correlations: `I /= (1 + PACK · F(Q, ETA))`.
 
 Implements the Teixeira (1988) mass fractal aggregate scattering model
 (*J. Appl. Cryst.* **21**, 781–785).
-Primary particles are spheres; the fractal aggregate structure is described analytically.
+Primary particles are spheroids with aspect ratio β; the fractal aggregate structure is described analytically.
+β = 1 gives the monodisperse sphere form factor (Bessel function oscillations in the Porod region);
+β ≠ 1 uses the orientation-averaged spheroid form factor which eliminates those oscillations.
+A modest β ≈ 0.5–2 is often sufficient to obtain a physically smooth I(Q).
 
 **Formula:**
 ```
@@ -255,7 +258,8 @@ The factor `1e-4` is the Igor-convention contrast unit conversion
 | Parameter | Default | Limits | Fitted | Description |
 |-----------|---------|--------|--------|-------------|
 | Phi | 0.001 | 1e-8 … 1 | Yes | Volume fraction of primary particles |
-| Radius [Å] | 50.0 | 0.1 … 1e6 | Yes | Primary particle radius |
+| Radius [Å] | 50.0 | 0.1 … 1e6 | Yes | Primary particle equatorial radius |
+| Aspect ratio β | 1.0 | 0.01 … 100 | No | Spheroid aspect ratio (1 = sphere, < 1 = oblate, > 1 = prolate) |
 | Fractal dim. Dv | 2.5 | 1 … 3 | Yes | Mass fractal dimension |
 | Ksi [Å] | 500.0 | 1 … 1e7 | Yes | Fractal correlation length (aggregate size) |
 | Eta | 0.5 | 0.3 … 0.8 | No | Volume filling factor within the aggregate |

--- a/docs/modeling_gui.md
+++ b/docs/modeling_gui.md
@@ -2,7 +2,8 @@
 
 The Modeling tool performs parametric forward-modeling of small-angle scattering data.
 It sums contributions from up to 10 independent **populations**, each of which can be a
-Size Distribution, a Unified Fit Level (Beaucage equation), or a Diffraction Peak.
+Size Distribution, a Unified Fit Level (Beaucage equation), a Diffraction Peak,
+a Guinier-Porod Level, a Mass Fractal, or a Surface Fractal.
 The total model I(Q) is fitted to experimental data using non-linear least squares.
 
 ---
@@ -16,6 +17,9 @@ The total model I(Q) is fitted to experimental data using non-linear least squar
    - [Size Distribution](#41-size-distribution)
    - [Unified Fit Level](#42-unified-fit-level)
    - [Diffraction Peak](#43-diffraction-peak)
+   - [Guinier-Porod Level](#44-guinier-porod-level)
+   - [Mass Fractal](#45-mass-fractal)
+   - [Surface Fractal](#46-surface-fractal)
 5. [Distributions](#distributions)
 6. [Form Factors](#form-factors)
 7. [Structure Factors](#structure-factors)
@@ -96,15 +100,18 @@ python -m pyirena.gui.modeling_panel path/to/file.h5
 
 ## Population types
 
-Each population tab has a **Population type** combo at the top with three options:
+Each population tab has a **Population type** combo at the top with six options:
 
 | Type | Description |
 |------|-------------|
 | **Size Distribution** | Parametric size distribution convolved with a form factor G-matrix |
 | **Unified Fit Level** | Single Beaucage level: Guinier + power-law (+ optional Born-Green correlations) |
 | **Diffraction Peak** | Gaussian, Lorentzian, or pseudo-Voigt peak at a chosen Q₀ |
+| **Guinier-Porod Level** | Piecewise Guinier-Porod model for non-spherical / non-dilute systems |
+| **Mass Fractal** | Fractal aggregate scattering (sphere primary particles + fractal S(Q)) |
+| **Surface Fractal** | Scattering from a surface with fractal roughness |
 
-Switching population type preserves the parameters of all three types independently —
+Switching population type preserves the parameters of all six types independently —
 switching back restores the values from before.
 
 ### 4.1 Size Distribution
@@ -184,6 +191,103 @@ Models a single scattering peak at position Q₀.
 | Amplitude [cm⁻¹] | Peak height | Yes |
 | Width σ [Å⁻¹] | Gaussian/Lorentzian width | Yes |
 | η (mixing) | Voigt mixing ratio (0=Gaussian, 1=Lorentzian) | No |
+
+### 4.4 Guinier-Porod Level
+
+Implements the Guinier-Porod piecewise scattering model
+(Hammouda 2010, *J. Appl. Cryst.* **43**, 716–719).
+Suitable for non-spherical or elongated scatterers, and for systems where the low-Q
+slope deviates from the Guinier-regime flat behaviour.
+
+**Formula:** Three regimes joined at crossover Q values:
+```
+Q1 = sqrt((P − s1)(3 − s1)/2) / Rg1
+D  = G · exp(−(P−s1)/2) · ((3−s1)(P−s1)/2)^((P−s1)/2) / Rg1^(P−s1)
+Q2 = sqrt((1 − s2) / (2Rg2²/(3−s2) − 2Rg1²/(3−s1)))  [0 if non-finite]
+G2 = G · exp(−Q2²·(Rg1²/(3−s1) − Rg2²/(3−s2))) · Q2^(s2−s1)
+
+I(Q) = G2/Q^s2 · exp(−Q²Rg2²/(3−s2))   Q < Q2  (active only if Q2 > 0)
+I(Q) = G/Q^s1 · exp(−Q²Rg1²/(3−s1))    Q2 ≤ Q < Q1
+I(Q) = D/Q^P                             Q ≥ Q1
+```
+Setting Rg2 = 1e10 (default) collapses Q2 to zero — single-level behaviour.
+
+Optional: `I *= exp(−RgCO²·Q²/3)` (RgCO > 0).
+Optional Born-Green correlations: `I /= (1 + PACK · F(Q, ETA))`.
+
+**Parameters:**
+
+| Parameter | Default | Limits | Fitted | Description |
+|-----------|---------|--------|--------|-------------|
+| G [cm⁻¹] | 1.0 | 1e-10 … 1e10 | Yes | Guinier amplitude |
+| Rg1 [Å] | 10.0 | 0.1 … 1e6 | Yes | Radius of gyration (high-Q level) |
+| Slope s1 | 0.0 | 0 … 3 | No | Low-Q slope (0=sphere, 1=rod, 2=lamella) |
+| Power P | 4.0 | 0 … 6 | No | Porod exponent at high Q |
+| Rg2 [Å] | 1e10 | 0.1 … 1e12 | No | Rg of second (lower-Q) level; 1e10=inactive |
+| Slope s2 | 0.0 | 0 … 3 | No | Low-Q slope of second level |
+| RgCO [Å] | 0.0 | 0 … 1e6 | No | Cutoff Rg (0 = no cutoff) |
+| ETA [Å] | 10.0 | 0.1 … 1e6 | No | Born-Green correlation length |
+| PACK | 0.0 | 0 … 16 | No | Born-Green packing factor |
+
+### 4.5 Mass Fractal
+
+Implements the Teixeira (1988) mass fractal aggregate scattering model
+(*J. Appl. Cryst.* **21**, 781–785).
+Primary particles are spheres; the fractal aggregate structure is described analytically.
+
+**Formula:**
+```
+V  = (4/3)·π·Radius³
+P(Q) = (3·(sin(qR) − qR·cos(qR)) / (qR)³)²        sphere form factor
+
+Bracket = Eta · 8 · (Ksi / (2·Radius))^Dv
+
+I(Q) = Phi · Contrast · 1e-4 · V
+       · [Bracket · sin((Dv−1)·atan(Q·Ksi)) / ((Dv−1)·Q·Ksi·(1+(Q·Ksi)²)^((Dv−1)/2))
+          + (1−Eta)²]
+       · P(Q)
+```
+The factor `1e-4` is the Igor-convention contrast unit conversion
+(contrast in Å⁻⁴ units → cm⁻⁴ scale). Eta (volume filling factor) is typically 0.3–0.8.
+
+**Parameters:**
+
+| Parameter | Default | Limits | Fitted | Description |
+|-----------|---------|--------|--------|-------------|
+| Phi | 0.001 | 1e-8 … 1 | Yes | Volume fraction of primary particles |
+| Radius [Å] | 50.0 | 0.1 … 1e6 | Yes | Primary particle radius |
+| Fractal dim. Dv | 2.5 | 1 … 3 | Yes | Mass fractal dimension |
+| Ksi [Å] | 500.0 | 1 … 1e7 | Yes | Fractal correlation length (aggregate size) |
+| Eta | 0.5 | 0.3 … 0.8 | No | Volume filling factor within the aggregate |
+| Contrast | 1.0 | 0 … 1e10 | No | Scattering contrast (Δρ)² |
+
+### 4.6 Surface Fractal
+
+Implements the Teixeira (1988) surface fractal scattering model
+(*J. Appl. Cryst.* **21**, 781–785).
+Describes scattering from a surface with fractal roughness (2 ≤ Ds ≤ 3).
+
+**Formula:**
+```
+I(Q) = π · Contrast · 1e20 · Ksi⁴ · 1e-32 · Surface · Γ(5−Ds)
+       · sin((3−Ds)·atan(Q·Ksi))
+       / ((1+(Q·Ksi)²)^((5−Ds)/2) · Q·Ksi)
+```
+Limiting slopes: `I(Q) ~ Q^(Ds−6)` for Q·Ksi >> 1 (fractal regime, slope −3 to −4).
+
+**Optional Porod transition:** Above Qc, smoothly blends to `A·Q⁻⁴` using an error-function
+step, with continuity condition `A = I(Qc)·Qc⁴`.
+
+**Parameters:**
+
+| Parameter | Default | Limits | Fitted | Description |
+|-----------|---------|--------|--------|-------------|
+| Surface [cm⁻¹] | 1e4 | 1 … 1e12 | Yes | Surface area per unit volume |
+| Fractal dim. Ds | 2.5 | 2 … 3 | Yes | Surface fractal dimension |
+| Ksi [Å] | 500.0 | 1 … 1e7 | Yes | Correlation length (upper cutoff of fractal regime) |
+| Contrast | 1.0 | 0 … 1e10 | No | Scattering contrast |
+| Qc [Å⁻¹] | 0.1 | 0.001 … 10 | No | Crossover to Porod Q⁻⁴ (enabled by checkbox) |
+| QcWidth | 0.1 | 0.01 … 1 | No | Width of erf blending as fraction of Qc |
 
 ---
 

--- a/pyirena/__init__.py
+++ b/pyirena/__init__.py
@@ -29,7 +29,7 @@ References:
     Beaucage, G. (1996). J. Appl. Cryst. 29, 134-146
 """
 
-__version__ = "0.6.4"
+__version__ = "0.6.5"
 __author__ = "Jan Ilavsky"
 __email__ = "ilavsky@aps.anl.gov"
 

--- a/pyirena/batch.py
+++ b/pyirena/batch.py
@@ -2168,6 +2168,10 @@ def average_data(
     data_files,
     output_folder=None,
     verbose: bool = True,
+    similarity_check: bool = False,
+    similarity_p_min: float = 0.01,
+    similarity_method: str = 'cormap',
+    similarity_reference: str = 'first',
 ) -> Optional[Dict]:
     """Average multiple SAS datasets.
 
@@ -2179,10 +2183,23 @@ def average_data(
         Where to save.  If None, uses ``{first_file_folder}_manip``.
     verbose : bool
         Print progress.
+    similarity_check : bool
+        When True, run a similarity analysis before averaging and discard
+        outliers (likely radiation-damaged frames).
+    similarity_p_min : float
+        P-value threshold for rejection (0–1).  Frames with p < threshold are
+        discarded.  Typical range: 0.001–0.05.
+    similarity_method : str
+        Similarity algorithm.  Currently ``'cormap'`` (Franke 2015).
+    similarity_reference : str
+        ``'first'`` — compare each frame vs. frame 0 (frame 0 always kept);
+        ``'majority'`` — compare each frame vs. the mean of all frames.
 
     Returns
     -------
     dict or None
+        On success includes ``'rejected'``: list of ``(filename, p_value)``
+        pairs for frames that were discarded by the similarity filter.
     """
     from pyirena.core.data_manipulation import DataManipulation
     from pyirena.io.nxcansas_data_manipulation import save_manipulated_data
@@ -2192,33 +2209,60 @@ def average_data(
         return None
 
     datasets = []
-    first_data = None
+    loaded_files = []   # Path objects parallel to datasets
+    loaded_data = []    # raw dicts parallel to datasets
     for fp in files:
         d = _load_data(fp)
         if d is None:
             continue
-        if first_data is None:
-            first_data = d
         q, I = d['Q'], d['Intensity']
         dI = d.get('Error', I * 0.05)
         dQ = d.get('dQ')
         datasets.append((q, I, dI, dQ))
+        loaded_files.append(fp)
+        loaded_data.append(d)
 
     if len(datasets) < 2:
         print("[pyirena.batch] Need at least 2 datasets to average")
         return None
 
+    # --- Optional similarity filter ---
+    rejected_pairs: list[tuple[str, float]] = []
+    if similarity_check:
+        from pyirena.core.similarity import check_similarity
+        filenames = [fp.name for fp in loaded_files]
+        sim_results = check_similarity(
+            datasets,
+            filenames=filenames,
+            method=similarity_method,
+            reference=similarity_reference,
+            p_min=similarity_p_min,
+        )
+        if verbose:
+            for r in sim_results:
+                tag = "OK    " if r.accepted else "REJECT"
+                print(f"  [{tag}] {r.filename}  p={r.p_value:.4f}"
+                      f"  C={r.longest_run}  N={r.n_points}")
+        accepted_idx = [r.idx for r in sim_results if r.accepted]
+        rejected_pairs = [(r.filename, r.p_value) for r in sim_results if not r.accepted]
+        datasets = [datasets[i] for i in accepted_idx]
+        loaded_files = [loaded_files[i] for i in accepted_idx]
+        loaded_data = [loaded_data[i] for i in accepted_idx]
+        if len(datasets) < 2:
+            print("[pyirena.batch] Too few datasets remain after similarity filtering.")
+            return None
+
     result = DataManipulation.average(datasets, reference_index=0)
 
     if output_folder is None:
-        output_folder = str(files[0].parent) + '_manip'
+        output_folder = str(loaded_files[0].parent) + '_manip'
     output_folder = Path(output_folder)
 
     try:
         out_path = save_manipulated_data(
             output_folder=output_folder,
-            source_path=files[0],
-            source_is_nxcansas=first_data.get('is_nxcansas', False),
+            source_path=loaded_files[0],
+            source_is_nxcansas=loaded_data[0].get('is_nxcansas', False),
             q=result.q, I=result.I, dI=result.dI, dQ=result.dQ,
             operation=result.operation,
             provenance=result.metadata,
@@ -2237,4 +2281,5 @@ def average_data(
         'output_file': out_path,
         'message': msg,
         'n_datasets': len(datasets),
+        'rejected': rejected_pairs,
     }

--- a/pyirena/batch.py
+++ b/pyirena/batch.py
@@ -1786,7 +1786,7 @@ def fit_modeling(
             pop = MassFractalPopulation()
             pop.enabled = bool(pd.get('enabled', True))
             pop.label = pd.get('label', '')
-            for key in ['Phi', 'Radius', 'Dv', 'Ksi', 'Eta', 'Contrast']:
+            for key in ['Phi', 'Radius', 'Beta', 'Dv', 'Ksi', 'Eta', 'Contrast']:
                 setattr(pop, key, float(pd.get(key, getattr(pop, key))))
                 setattr(pop, f'fit_{key}', bool(pd.get(f'fit_{key}', getattr(pop, f'fit_{key}'))))
                 lim = pd.get(f'{key}_limits', list(getattr(pop, f'{key}_limits')))

--- a/pyirena/batch.py
+++ b/pyirena/batch.py
@@ -2172,6 +2172,7 @@ def average_data(
     similarity_p_min: float = 0.01,
     similarity_method: str = 'cormap',
     similarity_reference: str = 'first',
+    similarity_normalize_scale: bool = True,
 ) -> Optional[Dict]:
     """Average multiple SAS datasets.
 
@@ -2193,7 +2194,11 @@ def average_data(
         Similarity algorithm.  Currently ``'cormap'`` (Franke 2015).
     similarity_reference : str
         ``'first'`` — compare each frame vs. frame 0 (frame 0 always kept);
-        ``'majority'`` — compare each frame vs. the mean of all frames.
+        ``'majority'`` — compare each frame vs. the median of all frames.
+    similarity_normalize_scale : bool
+        When True (default), rescale each frame to match the reference before
+        comparing.  Removes flux-drift / absorption differences so that only
+        shape differences are detected.
 
     Returns
     -------
@@ -2237,6 +2242,7 @@ def average_data(
             method=similarity_method,
             reference=similarity_reference,
             p_min=similarity_p_min,
+            normalize_scale=similarity_normalize_scale,
         )
         if verbose:
             for r in sim_results:

--- a/pyirena/batch.py
+++ b/pyirena/batch.py
@@ -1732,6 +1732,7 @@ def fit_modeling(
     from pyirena.core.modeling import (
         ModelingEngine, ModelingConfig,
         SizeDistPopulation, UnifiedLevelPopulation, DiffractionPeakPopulation,
+        GuinierPorodPopulation, MassFractalPopulation, SurfaceFractalPopulation,
     )
     from pyirena.io.nxcansas_modeling import save_modeling_results
 
@@ -1764,6 +1765,43 @@ def fit_modeling(
                 setattr(pop, f'fit_{key}', bool(pd.get(f'fit_{key}', getattr(pop, f'fit_{key}'))))
                 lim = pd.get(f'{key}_limits', list(getattr(pop, f'{key}_limits')))
                 setattr(pop, f'{key}_limits', tuple(lim))
+            return pop
+        if pt == 'guinier_porod':
+            pop = GuinierPorodPopulation()
+            pop.enabled = bool(pd.get('enabled', True))
+            pop.label = pd.get('label', '')
+            for key in ['G', 'Rg1', 's1', 'P', 'Rg2', 's2', 'RgCO']:
+                setattr(pop, key, float(pd.get(key, getattr(pop, key))))
+                setattr(pop, f'fit_{key}', bool(pd.get(f'fit_{key}', getattr(pop, f'fit_{key}'))))
+                lim = pd.get(f'{key}_limits', list(getattr(pop, f'{key}_limits')))
+                setattr(pop, f'{key}_limits', tuple(lim))
+            pop.correlations = bool(pd.get('correlations', False))
+            for key in ['ETA', 'PACK']:
+                setattr(pop, key, float(pd.get(key, getattr(pop, key))))
+                setattr(pop, f'fit_{key}', bool(pd.get(f'fit_{key}', getattr(pop, f'fit_{key}'))))
+                lim = pd.get(f'{key}_limits', list(getattr(pop, f'{key}_limits')))
+                setattr(pop, f'{key}_limits', tuple(lim))
+            return pop
+        if pt == 'mass_fractal':
+            pop = MassFractalPopulation()
+            pop.enabled = bool(pd.get('enabled', True))
+            pop.label = pd.get('label', '')
+            for key in ['Phi', 'Radius', 'Dv', 'Ksi', 'Eta', 'Contrast']:
+                setattr(pop, key, float(pd.get(key, getattr(pop, key))))
+                setattr(pop, f'fit_{key}', bool(pd.get(f'fit_{key}', getattr(pop, f'fit_{key}'))))
+                lim = pd.get(f'{key}_limits', list(getattr(pop, f'{key}_limits')))
+                setattr(pop, f'{key}_limits', tuple(lim))
+            return pop
+        if pt == 'surface_fractal':
+            pop = SurfaceFractalPopulation()
+            pop.enabled = bool(pd.get('enabled', True))
+            pop.label = pd.get('label', '')
+            for key in ['Surface', 'Ds', 'Ksi', 'Contrast', 'Qc', 'QcWidth']:
+                setattr(pop, key, float(pd.get(key, getattr(pop, key))))
+                setattr(pop, f'fit_{key}', bool(pd.get(f'fit_{key}', getattr(pop, f'fit_{key}'))))
+                lim = pd.get(f'{key}_limits', list(getattr(pop, f'{key}_limits')))
+                setattr(pop, f'{key}_limits', tuple(lim))
+            pop.use_porod_transition = bool(pd.get('use_porod_transition', False))
             return pop
         # default: size_dist
         return SizeDistPopulation(

--- a/pyirena/core/modeling.py
+++ b/pyirena/core/modeling.py
@@ -244,6 +244,9 @@ class MassFractalPopulation:
     Radius:   float = 50.0
     fit_Radius: bool = True
     Radius_limits: tuple = (0.1, 1e6)
+    Beta:     float = 1.0    # aspect ratio (1=sphere, <1=oblate, >1=prolate)
+    fit_Beta: bool = False
+    Beta_limits: tuple = (0.01, 100.0)
     Dv:       float = 2.5
     fit_Dv: bool = True
     Dv_limits: tuple = (1.0, 3.0)
@@ -492,39 +495,98 @@ def _guinier_porod_intensity(
     return I
 
 
+def _chi_s_mf(Beta: float) -> float:
+    """CHiS factor for a spheroid (IR1V_CaculateChiS from IR1_Fractals.ipf)."""
+    if Beta < 1.0 - 1e-6:
+        return (1.0 / (2.0 * Beta)) * (
+            1.0 + (Beta ** 2 / np.sqrt(1.0 - Beta ** 2))
+            * np.log((1.0 + np.sqrt(1.0 - Beta ** 2)) / Beta)
+        )
+    if Beta > 1.0 + 1e-6:
+        return (1.0 / (2.0 * Beta)) * (
+            1.0 + (Beta ** 2 / np.sqrt(Beta ** 2 - 1.0))
+            * np.arcsin(np.sqrt(Beta ** 2 - 1.0) / Beta)
+        )
+    return 1.0   # sphere
+
+
+def _spheroid_ff2_avg(
+    q: np.ndarray, R: float, Beta: float, n_pts: int = 50,
+) -> np.ndarray:
+    """Orientation-averaged spheroid |F(q)|² via Gauss-Legendre quadrature.
+
+    Ports IR1V_CalculateFSquared from IR1_Fractals.ipf.
+    Integration variable x = cos(theta), 0..1.
+    P(q) = 9 * [∫₀¹ h(qR√(1+(β²-1)x²)) dx]²  where h(z) = (sin z - z cos z)/z³
+    """
+    from scipy.special import roots_legendre
+    xi, wi = roots_legendre(n_pts)
+    x = (xi + 1.0) / 2.0          # map [-1,1] → [0,1]
+    w = wi / 2.0                   # Jacobian
+
+    # effective radius factor u = sqrt(1 + (Beta²-1)·x²), shape (n_pts,)
+    u = np.sqrt(np.maximum(1.0 + (Beta ** 2 - 1.0) * x ** 2, 0.0))
+
+    # qRu: shape (n_q, n_pts)
+    qRu = np.outer(q, R * u)
+
+    # h(z) = (sin z - z cos z)/z³,  h(0) = 1/3
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        h = np.where(
+            qRu < 1e-6,
+            1.0 / 3.0,
+            (np.sin(qRu) - qRu * np.cos(qRu)) / np.maximum(qRu ** 3, 1e-200),
+        )
+
+    integral = h @ w          # (n_q, n_pts) @ (n_pts,) → (n_q,)
+    return 9.0 * integral ** 2
+
+
 def _mass_fractal_intensity(
     q: np.ndarray, pop: 'MassFractalPopulation',
 ) -> np.ndarray:
     """Mass fractal aggregate scattering (Teixeira 1988).
 
-    Sphere primary particles (Beta=1 → ChiS=1, RC=2·Radius).
+    Primary particles are spheroids with aspect ratio Beta (1 = sphere).
+    For Beta ≠ 1 uses orientation-averaged spheroid form factor via GL quadrature.
     """
-    R   = max(pop.Radius, 1e-10)
-    Dv  = float(np.clip(pop.Dv, 1.001, 2.999))   # avoid singularities at exact integers
-    Ksi = max(pop.Ksi, 1e-10)
+    R    = max(pop.Radius, 1e-10)
+    Dv   = float(np.clip(pop.Dv, 1.001, 2.999))
+    Ksi  = max(pop.Ksi, 1e-10)
+    Beta = max(getattr(pop, 'Beta', 1.0), 1e-3)
 
-    V  = (4.0 / 3.0) * np.pi * R ** 3
-    # For sphere Beta=1: ChiS=1, RC=2R
-    RC      = 2.0 * R
-    Bracket = pop.Eta * RC ** 3 / R ** 3 * (Ksi / RC) ** Dv   # = Eta*8*(Ksi/2R)^Dv
+    # Spheroid volume (4/3)·π·R²·(Beta·R) = (4/3)·π·R³·Beta
+    V = (4.0 / 3.0) * np.pi * R ** 3 * Beta
+
+    # CHiS and RC generalise the sphere case (Beta=1 → ChiS=1, RC=2R)
+    ChiS = _chi_s_mf(Beta)
+    RC   = R * np.sqrt(2.0) / ChiS * np.sqrt(1.0 + ((2.0 + Beta ** 2) / 3.0) * ChiS ** 2)
+    RC   = max(RC, 1e-10)
+
+    Bracket = pop.Eta * RC ** 3 / (Beta * R ** 3) * (Ksi / RC) ** Dv
 
     qKsi = q * Ksi
-    # Fractal structure factor: sin((Dv-1)*atan(qKsi)) / ((Dv-1)*qKsi*(1+(qKsi)^2)^((Dv-1)/2))
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
         sf_num   = np.sin((Dv - 1.0) * np.arctan(qKsi))
         sf_denom = (Dv - 1.0) * qKsi * (1.0 + qKsi ** 2) ** ((Dv - 1.0) / 2.0)
         frac_sf  = np.where(qKsi < 1e-6, 1.0, sf_num / np.maximum(sf_denom, 1e-100))
 
+    # Form factor: sphere path avoids integration overhead for Beta ≈ 1
+    if abs(Beta - 1.0) < 0.01:
         qR  = q * R
-        ff2 = np.where(
-            qR < 1e-6,
-            1.0,
-            (3.0 * (np.sin(qR) - qR * np.cos(qR)) / np.maximum(qR ** 3, 1e-100)) ** 2,
-        )
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            ff2 = np.where(
+                qR < 1e-6,
+                1.0,
+                (3.0 * (np.sin(qR) - qR * np.cos(qR)) / np.maximum(qR ** 3, 1e-100)) ** 2,
+            )
+    else:
+        ff2 = _spheroid_ff2_avg(q, R, Beta)
 
-    I = pop.Phi * pop.Contrast * 1e-4 * V * (Bracket * frac_sf + (1.0 - pop.Eta) ** 2) * ff2
-    return I
+    return pop.Phi * pop.Contrast * 1e-4 * V * (Bracket * frac_sf + (1.0 - pop.Eta) ** 2) * ff2
 
 
 def _surface_fractal_intensity(
@@ -684,8 +746,9 @@ def compute_derived(radius_grid, vol_dist, num_dist, pop) -> dict:
         return {'G': pop.G, 'Rg1': pop.Rg1, 's1': pop.s1, 'P': pop.P,
                 'Rg2': pop.Rg2, 's2': pop.s2}
     if pop_type == 'mass_fractal':
-        return {'Phi': pop.Phi, 'Radius': pop.Radius, 'Dv': pop.Dv,
-                'Ksi': pop.Ksi, 'Eta': pop.Eta}
+        return {'Phi': pop.Phi, 'Radius': pop.Radius,
+                'Beta': getattr(pop, 'Beta', 1.0),
+                'Dv': pop.Dv, 'Ksi': pop.Ksi, 'Eta': pop.Eta}
     if pop_type == 'surface_fractal':
         return {'Surface': pop.Surface, 'Ds': pop.Ds, 'Ksi': pop.Ksi}
     # size_dist
@@ -1101,7 +1164,7 @@ class ModelingEngine:
                 continue
 
             if pop_type == 'mass_fractal':
-                for name in ['Phi', 'Radius', 'Dv', 'Ksi', 'Eta', 'Contrast']:
+                for name in ['Phi', 'Radius', 'Beta', 'Dv', 'Ksi', 'Eta', 'Contrast']:
                     if getattr(pop, f'fit_{name}', False):
                         lim = getattr(pop, f'{name}_limits')
                         x0.append(getattr(pop, name))

--- a/pyirena/core/modeling.py
+++ b/pyirena/core/modeling.py
@@ -189,6 +189,109 @@ class DiffractionPeakPopulation:
 
 
 @dataclass
+class GuinierPorodPopulation:
+    """Guinier-Porod piecewise scattering model (Hammouda 2010, J. Appl. Cryst. 43, 716).
+
+    Always 6 shape parameters: G, Rg1, s1, P, Rg2, s2.
+    Default Rg2=1e10 collapses the low-Q regime (single-level behaviour).
+    Optional: RgCO cutoff; Born-Green correlations (ETA, PACK).
+    """
+    pop_type: str = 'guinier_porod'
+    enabled: bool = True
+    G:   float = 1.0
+    fit_G: bool = True
+    G_limits: tuple = (1e-10, 1e10)
+    Rg1: float = 10.0
+    fit_Rg1: bool = True
+    Rg1_limits: tuple = (0.1, 1e6)
+    s1:  float = 0.0
+    fit_s1: bool = False
+    s1_limits: tuple = (0.0, 3.0)
+    P:   float = 4.0
+    fit_P: bool = False
+    P_limits: tuple = (0.0, 6.0)
+    Rg2: float = 1e10
+    fit_Rg2: bool = False
+    Rg2_limits: tuple = (0.1, 1e12)
+    s2:  float = 0.0
+    fit_s2: bool = False
+    s2_limits: tuple = (0.0, 3.0)
+    RgCO: float = 0.0
+    fit_RgCO: bool = False
+    RgCO_limits: tuple = (0.0, 1e6)
+    correlations: bool = False
+    ETA:  float = 10.0
+    fit_ETA: bool = False
+    ETA_limits: tuple = (0.1, 1e6)
+    PACK: float = 0.0
+    fit_PACK: bool = False
+    PACK_limits: tuple = (0.0, 16.0)
+    label: str = ''
+
+
+@dataclass
+class MassFractalPopulation:
+    """Mass fractal aggregate scattering (Teixeira 1988, J. Appl. Cryst. 21, 781).
+
+    Sphere primary particles (Beta=1) with a fractal structure factor.
+    Phi · Contrast · V · [S_fractal(Q) + (1-Eta)²] · |F(qR)|²
+    """
+    pop_type: str = 'mass_fractal'
+    enabled: bool = True
+    Phi:      float = 0.001
+    fit_Phi: bool = True
+    Phi_limits: tuple = (1e-8, 1.0)
+    Radius:   float = 50.0
+    fit_Radius: bool = True
+    Radius_limits: tuple = (0.1, 1e6)
+    Dv:       float = 2.5
+    fit_Dv: bool = True
+    Dv_limits: tuple = (1.0, 3.0)
+    Ksi:      float = 500.0
+    fit_Ksi: bool = True
+    Ksi_limits: tuple = (1.0, 1e7)
+    Eta:      float = 0.5
+    fit_Eta: bool = False
+    Eta_limits: tuple = (0.3, 0.8)
+    Contrast: float = 1.0
+    fit_Contrast: bool = False
+    Contrast_limits: tuple = (0.0, 1e10)
+    label: str = ''
+
+
+@dataclass
+class SurfaceFractalPopulation:
+    """Surface fractal scattering (Teixeira 1988, J. Appl. Cryst. 21, 781).
+
+    π · Contrast · Ksi⁴ · Surface · Γ(5-Ds) · sin((3-Ds)·atan(Q·Ksi))
+      / ((1+(Q·Ksi)²)^((5-Ds)/2) · Q·Ksi)
+    Optional smooth Porod transition to Q⁻⁴ above Qc.
+    """
+    pop_type: str = 'surface_fractal'
+    enabled: bool = True
+    Surface:  float = 1e4
+    fit_Surface: bool = True
+    Surface_limits: tuple = (1.0, 1e12)
+    Ds:       float = 2.5
+    fit_Ds: bool = True
+    Ds_limits: tuple = (2.0, 3.0)
+    Ksi:      float = 500.0
+    fit_Ksi: bool = True
+    Ksi_limits: tuple = (1.0, 1e7)
+    Contrast: float = 1.0
+    fit_Contrast: bool = False
+    Contrast_limits: tuple = (0.0, 1e10)
+    use_porod_transition: bool = False
+    Qc:       float = 0.1
+    fit_Qc: bool = False
+    Qc_limits: tuple = (0.001, 10.0)
+    QcWidth:  float = 0.1
+    fit_QcWidth: bool = False
+    QcWidth_limits: tuple = (0.01, 1.0)
+    label: str = ''
+
+
+@dataclass
 class ModelingConfig:
     """Global configuration for a Modeling fit."""
     populations: list = field(default_factory=list)   # list of SizeDistPopulation
@@ -339,6 +442,127 @@ def _diffraction_peak_intensity(
     return pop.amplitude * (eta * l + (1.0 - eta) * g)
 
 
+def _guinier_porod_intensity(
+    q: np.ndarray, pop: 'GuinierPorodPopulation',
+) -> np.ndarray:
+    """Guinier-Porod piecewise model (Hammouda 2010).
+
+    6 shape params: G, Rg1, s1, P, Rg2, s2.
+    Rg2=1e10 default collapses the Q2 crossover (single-level behaviour).
+    """
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        Rg1 = max(pop.Rg1, 1e-10)
+        # Guard against s1 == P (D→0/0) or P <= s1
+        P_eff = pop.P if pop.P > pop.s1 + 1e-6 else pop.s1 + 1e-6
+
+        Q1 = np.sqrt((P_eff - pop.s1) * (3.0 - pop.s1) / 2.0) / Rg1
+        Q1 = max(Q1, 1e-30)
+        D  = (pop.G * np.exp(-(P_eff - pop.s1) / 2.0)
+              * ((3.0 - pop.s1) * (P_eff - pop.s1) / 2.0) ** ((P_eff - pop.s1) / 2.0)
+              / Rg1 ** (P_eff - pop.s1))
+
+        # Build middle + high-Q regime
+        q_s1 = np.where(q < 1e-20, 1.0, q ** pop.s1)
+        guinier1  = pop.G / np.maximum(q_s1, 1e-100) * np.exp(-q ** 2 * Rg1 ** 2 / (3.0 - pop.s1))
+        powerlaw  = D / np.maximum(q, 1e-100) ** P_eff
+        I = np.where(q < Q1, guinier1, powerlaw)
+
+        # Second Guinier-Porod regime (active only when Q2 > 0 and Q2 < Q1)
+        Rg2 = max(pop.Rg2, 1e-10)
+        denom = 2.0 / (3.0 - pop.s2) * Rg2 ** 2 - 2.0 / (3.0 - pop.s1) * Rg1 ** 2
+        if abs(denom) > 1e-30:
+            Q2sq = (1.0 - pop.s2) / denom
+            if Q2sq > 0:
+                Q2 = np.sqrt(Q2sq)
+                if 0 < Q2 < Q1:
+                    G2 = (pop.G
+                          * np.exp(-Q2 ** 2 * (Rg1 ** 2 / (3.0 - pop.s1)
+                                               - Rg2 ** 2 / (3.0 - pop.s2)))
+                          * Q2 ** (pop.s2 - pop.s1))
+                    q_s2 = np.where(q < 1e-20, 1.0, q ** pop.s2)
+                    guinier2 = G2 / np.maximum(q_s2, 1e-100) * np.exp(
+                        -q ** 2 * Rg2 ** 2 / (3.0 - pop.s2))
+                    I = np.where(q < Q2, guinier2, I)
+
+    if pop.RgCO > 0:
+        I = I * np.exp(-pop.RgCO ** 2 * q ** 2 / 3.0)
+    if pop.correlations and pop.PACK > 0:
+        I = I / (1.0 + pop.PACK * _sphere_amplitude(q, pop.ETA))
+    return I
+
+
+def _mass_fractal_intensity(
+    q: np.ndarray, pop: 'MassFractalPopulation',
+) -> np.ndarray:
+    """Mass fractal aggregate scattering (Teixeira 1988).
+
+    Sphere primary particles (Beta=1 → ChiS=1, RC=2·Radius).
+    """
+    R   = max(pop.Radius, 1e-10)
+    Dv  = float(np.clip(pop.Dv, 1.001, 2.999))   # avoid singularities at exact integers
+    Ksi = max(pop.Ksi, 1e-10)
+
+    V  = (4.0 / 3.0) * np.pi * R ** 3
+    # For sphere Beta=1: ChiS=1, RC=2R
+    RC      = 2.0 * R
+    Bracket = pop.Eta * RC ** 3 / R ** 3 * (Ksi / RC) ** Dv   # = Eta*8*(Ksi/2R)^Dv
+
+    qKsi = q * Ksi
+    # Fractal structure factor: sin((Dv-1)*atan(qKsi)) / ((Dv-1)*qKsi*(1+(qKsi)^2)^((Dv-1)/2))
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        sf_num   = np.sin((Dv - 1.0) * np.arctan(qKsi))
+        sf_denom = (Dv - 1.0) * qKsi * (1.0 + qKsi ** 2) ** ((Dv - 1.0) / 2.0)
+        frac_sf  = np.where(qKsi < 1e-6, 1.0, sf_num / np.maximum(sf_denom, 1e-100))
+
+        qR  = q * R
+        ff2 = np.where(
+            qR < 1e-6,
+            1.0,
+            (3.0 * (np.sin(qR) - qR * np.cos(qR)) / np.maximum(qR ** 3, 1e-100)) ** 2,
+        )
+
+    I = pop.Phi * pop.Contrast * 1e-4 * V * (Bracket * frac_sf + (1.0 - pop.Eta) ** 2) * ff2
+    return I
+
+
+def _surface_fractal_intensity(
+    q: np.ndarray, pop: 'SurfaceFractalPopulation',
+) -> np.ndarray:
+    """Surface fractal scattering (Teixeira 1988).
+
+    Uses gammaln for numerical stability near Ds→3.
+    Optional smooth Porod transition above Qc (erf blending).
+    """
+    from scipy.special import gammaln, erf as scipy_erf
+
+    Ksi = max(pop.Ksi, 1e-10)
+    Ds  = float(np.clip(pop.Ds, 2.001, 2.999))
+
+    qKsi = q * Ksi
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        sf_num   = np.sin((3.0 - Ds) * np.arctan(qKsi))
+        sf_denom = (1.0 + qKsi ** 2) ** ((5.0 - Ds) / 2.0) * qKsi
+        gamma_val = np.exp(gammaln(5.0 - Ds))
+        I = (np.pi * pop.Contrast * 1e20 * Ksi ** 4 * 1e-32
+             * pop.Surface * gamma_val
+             * np.where(qKsi < 1e-6, 0.0,
+                        sf_num / np.maximum(sf_denom, 1e-100)))
+
+    if pop.use_porod_transition and pop.Qc > 0:
+        sigma = pop.Qc * pop.QcWidth / 2.3548
+        if sigma > 1e-10:
+            step1 = 0.5 * (1.0 + scipy_erf((pop.Qc - q) / (np.sqrt(2.0) * sigma)))
+            # Continuity: A = I(Qc) * Qc^4
+            i_qc  = np.interp(pop.Qc, q, I)
+            A_por = i_qc * pop.Qc ** 4
+            I = I * step1 + A_por * np.maximum(q, 1e-30) ** -4 * (1.0 - step1)
+
+    return I
+
+
 def apply_structure_factor(
     I_raw: np.ndarray,
     q: np.ndarray,
@@ -456,6 +680,14 @@ def compute_derived(radius_grid, vol_dist, num_dist, pop) -> dict:
             'amplitude': pop.amplitude,
             'width': pop.width,
         }
+    if pop_type == 'guinier_porod':
+        return {'G': pop.G, 'Rg1': pop.Rg1, 's1': pop.s1, 'P': pop.P,
+                'Rg2': pop.Rg2, 's2': pop.s2}
+    if pop_type == 'mass_fractal':
+        return {'Phi': pop.Phi, 'Radius': pop.Radius, 'Dv': pop.Dv,
+                'Ksi': pop.Ksi, 'Eta': pop.Eta}
+    if pop_type == 'surface_fractal':
+        return {'Surface': pop.Surface, 'Ds': pop.Ds, 'Ksi': pop.Ksi}
     # size_dist
     dr = bin_widths(radius_grid)
     vol_tot = np.sum(vol_dist * dr)
@@ -777,6 +1009,15 @@ class ModelingEngine:
                 elif pop_type == 'diffraction_peak':
                     I_pop = _diffraction_peak_intensity(q, pop)
                     rg, vd, nd = None, None, None
+                elif pop_type == 'guinier_porod':
+                    I_pop = _guinier_porod_intensity(q, pop)
+                    rg, vd, nd = None, None, None
+                elif pop_type == 'mass_fractal':
+                    I_pop = _mass_fractal_intensity(q, pop)
+                    rg, vd, nd = None, None, None
+                elif pop_type == 'surface_fractal':
+                    I_pop = _surface_fractal_intensity(q, pop)
+                    rg, vd, nd = None, None, None
                 else:  # size_dist
                     I_pop, vd, nd = self.calculate_pop_intensity(
                         pop, q,
@@ -843,6 +1084,47 @@ class ModelingEngine:
                     keys.append(('pop', i, 'peak', 'eta_voigt'))
                 continue
 
+            if pop_type == 'guinier_porod':
+                for name in ['G', 'Rg1', 's1', 'P', 'Rg2', 's2', 'RgCO']:
+                    if getattr(pop, f'fit_{name}', False):
+                        lim = getattr(pop, f'{name}_limits')
+                        x0.append(getattr(pop, name))
+                        lo.append(lim[0]); hi.append(lim[1])
+                        keys.append(('pop', i, 'gp', name))
+                if pop.correlations:
+                    for name in ['ETA', 'PACK']:
+                        if getattr(pop, f'fit_{name}', False):
+                            lim = getattr(pop, f'{name}_limits')
+                            x0.append(getattr(pop, name))
+                            lo.append(lim[0]); hi.append(lim[1])
+                            keys.append(('pop', i, 'gp', name))
+                continue
+
+            if pop_type == 'mass_fractal':
+                for name in ['Phi', 'Radius', 'Dv', 'Ksi', 'Eta', 'Contrast']:
+                    if getattr(pop, f'fit_{name}', False):
+                        lim = getattr(pop, f'{name}_limits')
+                        x0.append(getattr(pop, name))
+                        lo.append(lim[0]); hi.append(lim[1])
+                        keys.append(('pop', i, 'mf', name))
+                continue
+
+            if pop_type == 'surface_fractal':
+                for name in ['Surface', 'Ds', 'Ksi', 'Contrast']:
+                    if getattr(pop, f'fit_{name}', False):
+                        lim = getattr(pop, f'{name}_limits')
+                        x0.append(getattr(pop, name))
+                        lo.append(lim[0]); hi.append(lim[1])
+                        keys.append(('pop', i, 'sf', name))
+                if pop.use_porod_transition:
+                    for name in ['Qc', 'QcWidth']:
+                        if getattr(pop, f'fit_{name}', False):
+                            lim = getattr(pop, f'{name}_limits')
+                            x0.append(getattr(pop, name))
+                            lo.append(lim[0]); hi.append(lim[1])
+                            keys.append(('pop', i, 'sf', name))
+                continue
+
             # size_dist — Distribution params
             for name in D.DIST_PARAM_NAMES.get(pop.dist_type, []):
                 if pop.dist_params_fit.get(name, False):
@@ -901,9 +1183,7 @@ class ModelingEngine:
             else:
                 _, i, group, name = key
                 pop = config.populations[i]
-                if group == 'uf':
-                    setattr(pop, name, float(val))
-                elif group == 'peak':
+                if group in ('uf', 'gp', 'mf', 'sf', 'peak'):
                     setattr(pop, name, float(val))
                 elif group == 'dist':
                     pop.dist_params[name] = float(val)

--- a/pyirena/core/similarity.py
+++ b/pyirena/core/similarity.py
@@ -1,0 +1,279 @@
+"""
+Similarity analysis for SAXS datasets — outlier / radiation-damage detection.
+
+Implements the CorMap test (Franke et al., Nature Methods 12, 419-422, 2015),
+based on the Schilling (1990) "Longest Run of Heads" probability formula.
+
+The module is intentionally free of intra-package imports so it can be used
+independently and extended with additional methods without coupling to the
+averaging engine.
+
+Extension pattern
+-----------------
+Add a new method function with signature::
+
+    def _run_my_method(datasets, filenames, reference, p_min) -> list[SimilarityResult]
+
+then register it in :data:`SIMILARITY_METHODS`::
+
+    SIMILARITY_METHODS['my_method'] = _run_my_method
+
+The GUI method dropdown is populated from ``SIMILARITY_METHODS.keys()``.
+"""
+
+from __future__ import annotations
+
+import math
+from functools import lru_cache
+from typing import NamedTuple, Optional
+
+import numpy as np
+
+
+# ---------------------------------------------------------------------------
+#  Public result type
+# ---------------------------------------------------------------------------
+
+class SimilarityResult(NamedTuple):
+    idx: int        # position in the input datasets list
+    filename: str   # display name; '' when not provided
+    p_value: float  # 0–1; low p → curves differ → likely radiation damaged
+    longest_run: int  # C: observed longest run of same-sign residuals
+    n_points: int     # N: number of Q points compared
+    accepted: bool    # True when p_value >= p_min
+
+
+# ---------------------------------------------------------------------------
+#  CorMap internals
+# ---------------------------------------------------------------------------
+
+def _longest_run(arr: np.ndarray) -> int:
+    """Return the longest run of consecutive same-sign finite values."""
+    finite = arr[np.isfinite(arr)]
+    signs = np.sign(finite).astype(int)
+    if len(signs) == 0:
+        return 0
+    changes = np.where(np.diff(signs) != 0)[0] + 1
+    runs = np.diff(np.concatenate(([0], changes, [len(signs)])))
+    return int(runs.max()) if len(runs) else 0
+
+
+@lru_cache(maxsize=None)
+def _A(n: int, c: int) -> int:
+    """Count binary sequences of length n with no run of same symbol >= c.
+
+    Schilling (1990), Recurrence 2.  Memoised via lru_cache.
+    """
+    if n <= 0:
+        return 1
+    if n < c:
+        return 1 << n  # 2^n
+    return sum(_A(n - 1 - j, c) for j in range(c))
+
+
+def _cormap_p_value(n: int, c: int) -> float:
+    """P(longest run of same-sign residuals >= c | n i.i.d. ±1 trials).
+
+    Low p-value means the observed run is unlikely to arise by chance, i.e.
+    the two curves are statistically different.
+    """
+    if n <= 0 or c <= 1:
+        return 1.0
+    # B(n, c) = number of sequences with no run of + OR - of length >= c
+    # delta = sequences where the longest run IS >= c
+    delta = (1 << n) - 2 * _A(n - 1, c - 1)
+    if delta <= 0:
+        return 0.0
+    # Convert to float in log space to handle very large integers safely
+    try:
+        return min(math.exp2(math.log2(float(delta)) - n), 1.0)
+    except (ValueError, OverflowError):
+        return 0.0
+
+
+def _interp_loglog(q_ref: np.ndarray, q_src: np.ndarray, I_src: np.ndarray) -> np.ndarray:
+    """Interpolate I_src(q_src) onto q_ref in log-log space."""
+    return np.exp(
+        np.interp(
+            np.log(q_ref),
+            np.log(q_src),
+            np.log(np.maximum(I_src, 1e-300)),
+            left=np.nan,
+            right=np.nan,
+        )
+    )
+
+
+def _compare_pair(
+    q1: np.ndarray, I1: np.ndarray,
+    q2: np.ndarray, I2: np.ndarray,
+) -> tuple[int, int, float]:
+    """Compare two SAXS curves with CorMap on their common Q range.
+
+    Returns (N, C, p_value).
+    """
+    q_lo = max(float(q1[0]), float(q2[0]))
+    q_hi = min(float(q1[-1]), float(q2[-1]))
+    if q_lo >= q_hi:
+        return 0, 0, 1.0
+
+    mask = (q1 >= q_lo) & (q1 <= q_hi)
+    q_ref = q1[mask]
+    I1_ref = I1[mask]
+    if len(q_ref) < 2:
+        return 0, 0, 1.0
+
+    I2_ref = _interp_loglog(q_ref, q2, I2)
+    diff = I2_ref - I1_ref
+
+    C = _longest_run(diff)
+    N = int(np.sum(np.isfinite(diff)))
+    return N, C, _cormap_p_value(N, C)
+
+
+def _build_majority_reference(
+    datasets: list,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Compute a median reference curve from all datasets on the first Q grid.
+
+    Median is used instead of mean so that a single large outlier does not
+    bias the reference and cause all other datasets to be rejected (the
+    "swamping" problem with outlier detection).
+    """
+    q_ref = datasets[0][0]
+    I_stack = []
+    for i, (q, I, *_) in enumerate(datasets):
+        if i == 0:
+            I_stack.append(I.copy())
+        else:
+            I_interp = _interp_loglog(q_ref, q, I)
+            I_stack.append(I_interp)
+    I_median = np.nanmedian(np.vstack(I_stack), axis=0)
+    return q_ref, I_median
+
+
+# ---------------------------------------------------------------------------
+#  CorMap method driver
+# ---------------------------------------------------------------------------
+
+def _run_cormap(
+    datasets: list,
+    filenames: list[str],
+    reference: str,
+    p_min: float,
+) -> list[SimilarityResult]:
+    """Run CorMap similarity check on *datasets*.
+
+    Parameters
+    ----------
+    datasets:
+        List of ``(q, I, dI, dQ)`` tuples (same format as
+        ``DataManipulation.average()``).
+    filenames:
+        Display names, parallel to *datasets*.
+    reference:
+        ``'first'`` — compare every frame against frame 0 (frame 0 always
+        accepted with p=1.0); ``'majority'`` — compare every frame against the
+        mean of all frames (frame 0 is also tested).
+    p_min:
+        Rejection threshold; frame rejected when ``p_value < p_min``.
+    """
+    results: list[SimilarityResult] = []
+
+    if reference == 'majority':
+        q_ref, I_ref = _build_majority_reference(datasets)
+        for i, (q, I, *_) in enumerate(datasets):
+            N, C, p = _compare_pair(q_ref, I_ref, q, I)
+            results.append(SimilarityResult(
+                idx=i, filename=filenames[i],
+                p_value=p, longest_run=C, n_points=N,
+                accepted=(p >= p_min),
+            ))
+    else:  # 'first'
+        # Frame 0 is the reference — always accepted
+        q0, I0 = datasets[0][0], datasets[0][1]
+        results.append(SimilarityResult(
+            idx=0, filename=filenames[0],
+            p_value=1.0, longest_run=0, n_points=0,
+            accepted=True,
+        ))
+        for i, (q, I, *_) in enumerate(datasets[1:], start=1):
+            N, C, p = _compare_pair(q0, I0, q, I)
+            results.append(SimilarityResult(
+                idx=i, filename=filenames[i],
+                p_value=p, longest_run=C, n_points=N,
+                accepted=(p >= p_min),
+            ))
+
+    return results
+
+
+# ---------------------------------------------------------------------------
+#  Extensibility registry  (add new methods here)
+# ---------------------------------------------------------------------------
+
+SIMILARITY_METHODS: dict[str, callable] = {
+    'cormap': _run_cormap,
+    # 'my_method': _run_my_method,
+}
+
+#: Human-readable labels for the GUI dropdown, keyed by method name.
+SIMILARITY_METHOD_LABELS: dict[str, str] = {
+    'cormap': 'CorMap (Franke 2015)',
+}
+
+
+# ---------------------------------------------------------------------------
+#  Public entry point
+# ---------------------------------------------------------------------------
+
+def check_similarity(
+    datasets: list,
+    filenames: Optional[list[str]] = None,
+    method: str = 'cormap',
+    reference: str = 'first',
+    p_min: float = 0.01,
+) -> list[SimilarityResult]:
+    """Assess pairwise similarity of SAXS datasets and flag outliers.
+
+    Parameters
+    ----------
+    datasets:
+        List of ``(q, I, dI, dQ)`` tuples — the same format accepted by
+        ``DataManipulation.average()``.
+    filenames:
+        Optional display names, one per dataset.  Defaults to ``''``.
+    method:
+        Key into :data:`SIMILARITY_METHODS`.  Currently ``'cormap'``.
+    reference:
+        ``'first'`` (compare each frame vs. frame 0; frame 0 always accepted)
+        or ``'majority'`` (compare each frame vs. the mean of all frames).
+    p_min:
+        P-value threshold.  Frames with ``p_value < p_min`` are marked as
+        rejected (``accepted=False``).  Typical range: 0.001–0.05.
+
+    Returns
+    -------
+    list[SimilarityResult]
+        One entry per dataset, in input order.
+    """
+    if filenames is None:
+        filenames = [''] * len(datasets)
+    if len(filenames) != len(datasets):
+        raise ValueError("filenames must have the same length as datasets")
+    if method not in SIMILARITY_METHODS:
+        raise ValueError(f"Unknown similarity method {method!r}; "
+                         f"available: {list(SIMILARITY_METHODS)}")
+    if reference not in ('first', 'majority'):
+        raise ValueError(f"reference must be 'first' or 'majority', got {reference!r}")
+    if not datasets:
+        return []
+    if len(datasets) == 1:
+        q, I, *_ = datasets[0]
+        return [SimilarityResult(
+            idx=0, filename=filenames[0],
+            p_value=1.0, longest_run=0, n_points=len(q),
+            accepted=True,
+        )]
+
+    return SIMILARITY_METHODS[method](datasets, filenames, reference, p_min)

--- a/pyirena/core/similarity.py
+++ b/pyirena/core/similarity.py
@@ -107,8 +107,21 @@ def _interp_loglog(q_ref: np.ndarray, q_src: np.ndarray, I_src: np.ndarray) -> n
 def _compare_pair(
     q1: np.ndarray, I1: np.ndarray,
     q2: np.ndarray, I2: np.ndarray,
+    normalize_scale: bool = True,
 ) -> tuple[int, int, float]:
     """Compare two SAXS curves with CorMap on their common Q range.
+
+    Parameters
+    ----------
+    normalize_scale:
+        When True (default), I2 is rescaled so that the geometric-median
+        intensity ratio I2/I1 equals 1 before comparing.  This removes overall
+        amplitude differences caused by flux drift or absorption variation so
+        that CorMap tests for *shape* differences only — the relevant signature
+        of radiation damage.  Without this, even a 0.1% systematic scale
+        difference between perfectly similar frames produces a run of length N
+        and p ≈ 0.  Disable only when the data are already on an absolute,
+        identically-normalised scale and you want to detect scale changes too.
 
     Returns (N, C, p_value).
     """
@@ -124,8 +137,16 @@ def _compare_pair(
         return 0, 0, 1.0
 
     I2_ref = _interp_loglog(q_ref, q2, I2)
-    diff = I2_ref - I1_ref
 
+    if normalize_scale:
+        valid = np.isfinite(I2_ref) & (I1_ref > 0) & (I2_ref > 0)
+        if valid.sum() >= 2:
+            log_ratio = np.log(I2_ref[valid]) - np.log(I1_ref[valid])
+            scale = math.exp(float(np.median(log_ratio)))
+            if scale > 0:
+                I2_ref = I2_ref / scale
+
+    diff = I2_ref - I1_ref
     C = _longest_run(diff)
     N = int(np.sum(np.isfinite(diff)))
     return N, C, _cormap_p_value(N, C)
@@ -161,29 +182,15 @@ def _run_cormap(
     filenames: list[str],
     reference: str,
     p_min: float,
+    normalize_scale: bool = True,
 ) -> list[SimilarityResult]:
-    """Run CorMap similarity check on *datasets*.
-
-    Parameters
-    ----------
-    datasets:
-        List of ``(q, I, dI, dQ)`` tuples (same format as
-        ``DataManipulation.average()``).
-    filenames:
-        Display names, parallel to *datasets*.
-    reference:
-        ``'first'`` — compare every frame against frame 0 (frame 0 always
-        accepted with p=1.0); ``'majority'`` — compare every frame against the
-        mean of all frames (frame 0 is also tested).
-    p_min:
-        Rejection threshold; frame rejected when ``p_value < p_min``.
-    """
+    """Run CorMap similarity check on *datasets*."""
     results: list[SimilarityResult] = []
 
     if reference == 'majority':
         q_ref, I_ref = _build_majority_reference(datasets)
         for i, (q, I, *_) in enumerate(datasets):
-            N, C, p = _compare_pair(q_ref, I_ref, q, I)
+            N, C, p = _compare_pair(q_ref, I_ref, q, I, normalize_scale)
             results.append(SimilarityResult(
                 idx=i, filename=filenames[i],
                 p_value=p, longest_run=C, n_points=N,
@@ -198,7 +205,7 @@ def _run_cormap(
             accepted=True,
         ))
         for i, (q, I, *_) in enumerate(datasets[1:], start=1):
-            N, C, p = _compare_pair(q0, I0, q, I)
+            N, C, p = _compare_pair(q0, I0, q, I, normalize_scale)
             results.append(SimilarityResult(
                 idx=i, filename=filenames[i],
                 p_value=p, longest_run=C, n_points=N,
@@ -233,6 +240,7 @@ def check_similarity(
     method: str = 'cormap',
     reference: str = 'first',
     p_min: float = 0.01,
+    normalize_scale: bool = True,
 ) -> list[SimilarityResult]:
     """Assess pairwise similarity of SAXS datasets and flag outliers.
 
@@ -247,10 +255,16 @@ def check_similarity(
         Key into :data:`SIMILARITY_METHODS`.  Currently ``'cormap'``.
     reference:
         ``'first'`` (compare each frame vs. frame 0; frame 0 always accepted)
-        or ``'majority'`` (compare each frame vs. the mean of all frames).
+        or ``'majority'`` (compare each frame vs. the median of all frames).
     p_min:
         P-value threshold.  Frames with ``p_value < p_min`` are marked as
         rejected (``accepted=False``).  Typical range: 0.001–0.05.
+    normalize_scale:
+        When True (default), each dataset is rescaled to the reference before
+        comparing signs.  This removes flux-drift and absorption differences
+        so that CorMap detects *shape* changes only.  Set to False only when
+        data are already on a perfectly calibrated absolute scale and scale
+        changes are themselves a damage signature.
 
     Returns
     -------
@@ -276,4 +290,4 @@ def check_similarity(
             accepted=True,
         )]
 
-    return SIMILARITY_METHODS[method](datasets, filenames, reference, p_min)
+    return SIMILARITY_METHODS[method](datasets, filenames, reference, p_min, normalize_scale)

--- a/pyirena/core/waxs_peakfit.py
+++ b/pyirena/core/waxs_peakfit.py
@@ -182,6 +182,155 @@ def eval_peak(q: np.ndarray, shape: str, params: Dict) -> np.ndarray:
     raise ValueError(f"Unknown peak shape: {shape!r}")
 
 
+# Closed-form integrals of the supported peak shapes (∫ peak(q) dq from
+# −∞ to +∞, in the same units as I·Q — typically cm⁻¹·Å⁻¹).
+#
+#   Gauss   : A·FWHM·√(π/(4·ln2))      = A·FWHM·_GAUSS_AREA_K
+#   Lorentz : A·FWHM·π/2               = A·FWHM·_LORENTZ_AREA_K
+#   PVoigt  : A·FWHM·(η·π/2 + (1−η)·√(π/(4·ln2)))
+#   LogNorm : A·Q0·σ_ln·√(2π)·exp(σ_ln²/2)
+#             where σ_ln = arcsinh(FWHM/(2·Q0))/√(2·ln2)
+#             (because the GUI normalises the curve so height-at-mode = A)
+_GAUSS_AREA_K   = float(np.sqrt(np.pi / (4.0 * _LN2)))    # ≈ 1.0644670
+_LORENTZ_AREA_K = float(np.pi / 2.0)                       # ≈ 1.5707963
+
+
+def peak_area(shape: str, params: Dict) -> float:
+    """Return the analytic integral of one peak (area under the curve).
+
+    Parameters
+    ----------
+    shape : str
+        One of ``PEAK_SHAPES``.
+    params : dict
+        Either the GUI nested form ``{name: {"value": x, ...}}`` or the
+        flat form ``{name: x}``.  Required keys: ``A``, ``Q0``, ``FWHM``
+        plus ``eta`` for Pseudo-Voigt.
+
+    Returns
+    -------
+    float
+        Area in (intensity-units · Å⁻¹).  Returns NaN if the parameters are
+        non-physical (e.g. LogNormal with Q0 ≤ 0).
+    """
+    def _v(name, default=None):
+        if name not in params:
+            return default
+        v = params[name]
+        return float(v["value"]) if isinstance(v, dict) else float(v)
+
+    A    = _v("A",    0.0)
+    Q0   = _v("Q0",   0.0)
+    FWHM = _v("FWHM", 0.0)
+    if not (np.isfinite(A) and np.isfinite(FWHM)) or FWHM <= 0:
+        return float("nan")
+
+    if shape == "Gauss":
+        return A * FWHM * _GAUSS_AREA_K
+    if shape == "Lorentz":
+        return A * FWHM * _LORENTZ_AREA_K
+    if shape == "Pseudo-Voigt":
+        eta = float(np.clip(_v("eta", 0.5), 0.0, 1.0))
+        K   = eta * _LORENTZ_AREA_K + (1.0 - eta) * _GAUSS_AREA_K
+        return A * FWHM * K
+    if shape == "LogNormal":
+        if not np.isfinite(Q0) or Q0 <= 0:
+            return float("nan")
+        sigma_ln = float(np.arcsinh(FWHM / (2.0 * Q0)) / np.sqrt(2.0 * _LN2))
+        if sigma_ln <= 0:
+            return float("nan")
+        return A * Q0 * sigma_ln * np.sqrt(2.0 * np.pi) * np.exp(0.5 * sigma_ln ** 2)
+    raise ValueError(f"Unknown peak shape: {shape!r}")
+
+
+def peak_area_std(shape: str, params: Dict, params_std: Dict) -> float:
+    """Linearised 1-σ uncertainty on ``peak_area`` (error propagation).
+
+    Treats the per-parameter uncertainties as independent (no covariances) —
+    the same simplification already used elsewhere in this module when the
+    GUI presents fit results.
+
+    Parameters
+    ----------
+    shape : str
+        Peak shape name.
+    params : dict
+        Parameter dict (GUI or flat form), as for ``peak_area``.
+    params_std : dict
+        Per-parameter standard deviations, ``{name: float}``.  Missing or
+        non-finite entries contribute zero variance.
+
+    Returns
+    -------
+    float
+        1-σ uncertainty on the area, or NaN if the area itself is NaN.
+    """
+    def _v(name, default=0.0):
+        if name not in params:
+            return default
+        v = params[name]
+        return float(v["value"]) if isinstance(v, dict) else float(v)
+
+    def _s(name):
+        v = params_std.get(name, 0.0) if params_std else 0.0
+        try:
+            v = float(v)
+        except (TypeError, ValueError):
+            return 0.0
+        return v if np.isfinite(v) and v > 0 else 0.0
+
+    A      = _v("A")
+    Q0     = _v("Q0")
+    FWHM   = _v("FWHM")
+    sA     = _s("A")
+    sFWHM  = _s("FWHM")
+    if not (np.isfinite(A) and np.isfinite(FWHM)) or FWHM <= 0:
+        return float("nan")
+
+    if shape == "Gauss":
+        # area = A * FWHM * K  →  σ² = (FWHM·K·σ_A)² + (A·K·σ_FWHM)²
+        K = _GAUSS_AREA_K
+        return float(np.sqrt((FWHM * K * sA) ** 2 + (A * K * sFWHM) ** 2))
+    if shape == "Lorentz":
+        K = _LORENTZ_AREA_K
+        return float(np.sqrt((FWHM * K * sA) ** 2 + (A * K * sFWHM) ** 2))
+    if shape == "Pseudo-Voigt":
+        eta  = float(np.clip(_v("eta", 0.5), 0.0, 1.0))
+        sEta = _s("eta")
+        K    = eta * _LORENTZ_AREA_K + (1.0 - eta) * _GAUSS_AREA_K
+        dK_deta = _LORENTZ_AREA_K - _GAUSS_AREA_K
+        var = (FWHM * K * sA) ** 2 + (A * K * sFWHM) ** 2 \
+            + (A * FWHM * dK_deta * sEta) ** 2
+        return float(np.sqrt(var))
+    if shape == "LogNormal":
+        sQ0 = _s("Q0")
+        if not np.isfinite(Q0) or Q0 <= 0:
+            return float("nan")
+        # area(A, Q0, FWHM) = A · Q0 · σ_ln · √(2π) · exp(σ_ln²/2)
+        # with σ_ln = arcsinh(u)/√(2·ln2),  u = FWHM/(2·Q0).
+        s2ln2   = float(np.sqrt(2.0 * _LN2))
+        u       = FWHM / (2.0 * Q0)
+        sigma_ln = float(np.arcsinh(u) / s2ln2)
+        if sigma_ln <= 0:
+            return float("nan")
+        area    = A * Q0 * sigma_ln * np.sqrt(2.0 * np.pi) * np.exp(0.5 * sigma_ln ** 2)
+        # ∂σ_ln/∂u = 1 / (√(1+u²)·√(2·ln2))
+        dsigma_du = 1.0 / (np.sqrt(1.0 + u * u) * s2ln2)
+        # ∂u/∂FWHM = 1/(2·Q0);  ∂u/∂Q0 = −FWHM/(2·Q0²)
+        # Let f(σ) = σ·exp(σ²/2); f'(σ) = (1 + σ²)·exp(σ²/2)
+        f       = sigma_ln * np.exp(0.5 * sigma_ln ** 2)
+        df      = (1.0 + sigma_ln ** 2) * np.exp(0.5 * sigma_ln ** 2)
+        s2pi    = np.sqrt(2.0 * np.pi)
+        dA_dA    = Q0 * f * s2pi
+        # ∂area/∂FWHM = A·Q0·√(2π)·df·dσ/du·∂u/∂FWHM
+        dA_dFWHM = A * Q0 * s2pi * df * dsigma_du * (1.0 / (2.0 * Q0))
+        # ∂area/∂Q0  = A·√(2π)·[f + Q0·df·dσ/du·∂u/∂Q0]
+        dA_dQ0   = A * s2pi * (f + Q0 * df * dsigma_du * (-FWHM / (2.0 * Q0 ** 2)))
+        var = (dA_dA * sA) ** 2 + (dA_dFWHM * sFWHM) ** 2 + (dA_dQ0 * sQ0) ** 2
+        return float(np.sqrt(var))
+    raise ValueError(f"Unknown peak shape: {shape!r}")
+
+
 # ===========================================================================
 # Background functions
 # ===========================================================================

--- a/pyirena/gui/data_manipulation_panel.py
+++ b/pyirena/gui/data_manipulation_panel.py
@@ -25,7 +25,8 @@ try:
         QPushButton, QLabel, QLineEdit, QComboBox, QCheckBox,
         QListWidget, QMessageBox, QGroupBox, QFrame, QFileDialog,
         QAbstractItemView, QSizePolicy, QListWidgetItem,
-        QTabWidget, QSpinBox, QMenu,
+        QTabWidget, QSpinBox, QDoubleSpinBox, QMenu,
+        QTableWidget, QTableWidgetItem, QHeaderView,
     )
     from PySide6.QtCore import Qt, QUrl, QTimer
     from PySide6.QtGui import QDesktopServices, QDoubleValidator, QAction, QPixmap, QIcon, QColor
@@ -36,7 +37,8 @@ except ImportError:
             QPushButton, QLabel, QLineEdit, QComboBox, QCheckBox,
             QListWidget, QMessageBox, QGroupBox, QFrame, QFileDialog,
             QAbstractItemView, QSizePolicy, QListWidgetItem,
-            QTabWidget, QSpinBox, QMenu,
+            QTabWidget, QSpinBox, QDoubleSpinBox, QMenu,
+            QTableWidget, QTableWidgetItem, QHeaderView,
         )
         from PyQt6.QtCore import Qt, QUrl, QTimer
         from PyQt6.QtGui import QDesktopServices, QDoubleValidator, QAction, QPixmap, QIcon, QColor
@@ -558,6 +560,9 @@ class DataManipulationPanel(QWidget):
         self._denominator_file: Optional[str] = None  # for Divide tab
         self._out_folder: Optional[str] = None
 
+        # Similarity analysis results for Average tab (populated by _on_similarity_check)
+        self._sim_results: list = []
+
         # Throttle timer for auto-recalculate (500 ms)
         self._auto_timer = QTimer(self)
         self._auto_timer.setSingleShot(True)
@@ -760,22 +765,108 @@ class DataManipulationPanel(QWidget):
     # ------------------------------------------------------------------ #
 
     def _build_average_tab(self) -> None:
-        tab = QWidget()
-        layout = QHBoxLayout(tab)
-        layout.setContentsMargins(8, 8, 8, 8)
-        layout.setSpacing(12)
+        from pyirena.core.similarity import SIMILARITY_METHODS, SIMILARITY_METHOD_LABELS
 
+        tab = QWidget()
+        layout = QVBoxLayout(tab)
+        layout.setContentsMargins(8, 6, 8, 6)
+        layout.setSpacing(6)
+
+        # --- Top row: info + count ---
+        top_row = QHBoxLayout()
         info = QLabel(
-            "Select multiple files to average.\n"
+            "Select multiple files to average. "
             "Right-click on graph to remove bad datasets."
         )
         info.setStyleSheet("color: #555;")
-        layout.addWidget(info)
-
+        top_row.addWidget(info)
+        top_row.addStretch()
         self._avg_count_label = QLabel("0 files selected")
         self._avg_count_label.setStyleSheet("font-weight: bold; color: #2c3e50;")
-        layout.addWidget(self._avg_count_label)
+        top_row.addWidget(self._avg_count_label)
+        layout.addLayout(top_row)
 
+        # --- Similarity analysis group ---
+        sim_group = QGroupBox("Similarity analysis (radiation damage detection)")
+        sim_layout = QVBoxLayout(sim_group)
+        sim_layout.setContentsMargins(8, 6, 8, 6)
+        sim_layout.setSpacing(5)
+
+        # Row 1: method, reference, p-value
+        ctrl_row = QHBoxLayout()
+        ctrl_row.setSpacing(6)
+
+        ctrl_row.addWidget(QLabel("Method:"))
+        self._sim_method_combo = QComboBox()
+        for key in SIMILARITY_METHODS:
+            label = SIMILARITY_METHOD_LABELS.get(key, key)
+            self._sim_method_combo.addItem(label, userData=key)
+        self._sim_method_combo.setMaximumWidth(200)
+        ctrl_row.addWidget(self._sim_method_combo)
+
+        ctrl_row.addSpacing(10)
+        ctrl_row.addWidget(QLabel("Reference:"))
+        self._sim_ref_combo = QComboBox()
+        self._sim_ref_combo.addItem("First frame", userData='first')
+        self._sim_ref_combo.addItem("Majority vote", userData='majority')
+        self._sim_ref_combo.setMaximumWidth(130)
+        ctrl_row.addWidget(self._sim_ref_combo)
+
+        ctrl_row.addSpacing(10)
+        ctrl_row.addWidget(QLabel("P-value threshold:"))
+        self._sim_p_spin = QDoubleSpinBox()
+        self._sim_p_spin.setRange(1e-6, 1.0)
+        self._sim_p_spin.setDecimals(4)
+        self._sim_p_spin.setSingleStep(0.001)
+        self._sim_p_spin.setValue(0.01)
+        self._sim_p_spin.setMaximumWidth(90)
+        ctrl_row.addWidget(self._sim_p_spin)
+
+        ctrl_row.addStretch()
+        sim_layout.addLayout(ctrl_row)
+
+        # Row 2: action buttons
+        btn_row = QHBoxLayout()
+        btn_row.setSpacing(8)
+        self._sim_check_btn = QPushButton("Check Similarity")
+        self._sim_check_btn.setStyleSheet(
+            "background-color: #2980b9; color: white; font-weight: bold;"
+        )
+        self._sim_check_btn.setFixedHeight(26)
+        self._sim_check_btn.clicked.connect(self._on_similarity_check)
+        btn_row.addWidget(self._sim_check_btn)
+
+        self._sim_reject_btn = QPushButton("Auto-reject 0 below threshold")
+        self._sim_reject_btn.setStyleSheet(
+            "background-color: #c0392b; color: white; font-weight: bold;"
+        )
+        self._sim_reject_btn.setFixedHeight(26)
+        self._sim_reject_btn.setEnabled(False)
+        self._sim_reject_btn.clicked.connect(self._on_similarity_auto_reject)
+        btn_row.addWidget(self._sim_reject_btn)
+
+        btn_row.addStretch()
+        sim_layout.addLayout(btn_row)
+
+        # Results table (hidden until a check is run)
+        self._sim_results_table = QTableWidget(0, 3)
+        self._sim_results_table.setHorizontalHeaderLabels(["File", "p-value", "Status"])
+        self._sim_results_table.horizontalHeader().setSectionResizeMode(
+            0, QHeaderView.ResizeMode.Stretch
+        )
+        self._sim_results_table.horizontalHeader().setSectionResizeMode(
+            1, QHeaderView.ResizeMode.ResizeToContents
+        )
+        self._sim_results_table.horizontalHeader().setSectionResizeMode(
+            2, QHeaderView.ResizeMode.ResizeToContents
+        )
+        self._sim_results_table.setEditTriggers(QTableWidget.EditTrigger.NoEditTriggers)
+        self._sim_results_table.setSelectionMode(QTableWidget.SelectionMode.NoSelection)
+        self._sim_results_table.setMaximumHeight(160)
+        self._sim_results_table.setVisible(False)
+        sim_layout.addWidget(self._sim_results_table)
+
+        layout.addWidget(sim_group)
         layout.addStretch()
         self._tabs.addTab(tab, "Average")
 
@@ -1058,6 +1149,7 @@ class DataManipulationPanel(QWidget):
         if tab == _TAB_AVERAGE:
             n = len(self._fb.get_selected_filenames())
             self._avg_count_label.setText(f"{n} file(s) selected")
+            self._clear_similarity_results()
             self._schedule_auto_update()
         elif tab == _TAB_SUBTRACT:
             self._update_sub_labels()
@@ -1451,6 +1543,103 @@ class DataManipulationPanel(QWidget):
                 item.setSelected(False)
         self._on_selection_changed()
         self._preview_average(auto_triggered=True)
+
+    # ------------------------------------------------------------------ #
+    #  Average tab — similarity analysis                                   #
+    # ------------------------------------------------------------------ #
+
+    def _on_similarity_check(self) -> None:
+        """Run CorMap similarity analysis on the current Average selection."""
+        from pyirena.core.similarity import check_similarity, SIMILARITY_METHODS
+
+        selected = self._fb.get_selected_filenames()
+        if len(selected) < 2:
+            self._status.setText("Select at least 2 files to check similarity.")
+            return
+
+        datasets, filenames = [], []
+        for fname in selected:
+            data = self._get_or_load(fname)
+            if data is None:
+                continue
+            q = data['Q']
+            I = data['Intensity']
+            dI = data.get('Error', I * 0.05)
+            dQ = data.get('dQ')
+            datasets.append((q, I, dI, dQ))
+            filenames.append(fname)
+
+        if len(datasets) < 2:
+            self._status.setText("Could not load enough files for similarity check.")
+            return
+
+        method_key = self._sim_method_combo.currentData()
+        ref_key = self._sim_ref_combo.currentData()
+        p_min = self._sim_p_spin.value()
+
+        try:
+            self._sim_results = check_similarity(
+                datasets, filenames=filenames,
+                method=method_key, reference=ref_key, p_min=p_min,
+            )
+        except Exception as exc:
+            self._status.setText(f"Similarity check error: {exc}")
+            return
+
+        self._populate_sim_table()
+        n_rejected = sum(1 for r in self._sim_results if not r.accepted)
+        self._sim_reject_btn.setText(f"Auto-reject {n_rejected} below threshold")
+        self._sim_reject_btn.setEnabled(n_rejected > 0)
+        self._sim_results_table.setVisible(True)
+        self._status.setText(
+            f"Similarity check: {len(self._sim_results) - n_rejected} accepted, "
+            f"{n_rejected} rejected (p < {p_min:.4f})."
+        )
+
+    def _on_similarity_auto_reject(self) -> None:
+        """Deselect all rejected datasets and re-run the average preview."""
+        for r in self._sim_results:
+            if not r.accepted:
+                self._avg_remove_dataset(r.filename)
+        self._sim_results = []
+        self._sim_results_table.setVisible(False)
+        self._sim_reject_btn.setEnabled(False)
+
+    def _populate_sim_table(self) -> None:
+        """Fill the results QTableWidget from self._sim_results."""
+        self._sim_results_table.setRowCount(0)
+        for r in self._sim_results:
+            row = self._sim_results_table.rowCount()
+            self._sim_results_table.insertRow(row)
+
+            p_text = f"{r.p_value:.4f}" if r.n_points > 0 else "—"
+
+            if r.accepted:
+                status_text, fg, bg = "Accepted", QColor("#196f3d"), QColor("#d5f5e3")
+            else:
+                status_text, fg, bg = "Rejected", QColor("#922b21"), QColor("#fde8e8")
+
+            cells = [
+                QTableWidgetItem(r.filename),
+                QTableWidgetItem(p_text),
+                QTableWidgetItem(status_text),
+            ]
+            cells[1].setTextAlignment(Qt.AlignmentFlag.AlignCenter)
+            cells[2].setTextAlignment(Qt.AlignmentFlag.AlignCenter)
+            cells[2].setForeground(fg)
+            for col, item in enumerate(cells):
+                item.setBackground(bg)
+                self._sim_results_table.setItem(row, col, item)
+
+        self._sim_results_table.resizeRowsToContents()
+
+    def _clear_similarity_results(self) -> None:
+        """Invalidate stale similarity results when selection changes."""
+        self._sim_results = []
+        self._sim_results_table.setRowCount(0)
+        self._sim_results_table.setVisible(False)
+        self._sim_reject_btn.setText("Auto-reject 0 below threshold")
+        self._sim_reject_btn.setEnabled(False)
 
     def _preview_subtract(self) -> None:
         selected = self._fb.get_selected_filenames()
@@ -1898,6 +2087,16 @@ class DataManipulationPanel(QWidget):
         self._div_scale_edit.setText(str(s.get('divide_denominator_scale', 1.0)))
         self._div_bg_edit.setText(str(s.get('divide_denominator_background', 0.0)))
 
+        # Average tab — similarity settings
+        from pyirena.core.similarity import SIMILARITY_METHODS
+        method_keys = list(SIMILARITY_METHODS.keys())
+        saved_method = s.get('similarity_method', 'cormap')
+        method_idx = method_keys.index(saved_method) if saved_method in method_keys else 0
+        self._sim_method_combo.setCurrentIndex(method_idx)
+        saved_ref = s.get('similarity_reference', 'first')
+        self._sim_ref_combo.setCurrentIndex(0 if saved_ref == 'first' else 1)
+        self._sim_p_spin.setValue(float(s.get('similarity_p_min', 0.01)))
+
     def save_state(self) -> None:
         su_text = self._scale_unc_edit.text().strip()
         rqmin_text = self._rebin_qmin.text().strip()
@@ -1925,6 +2124,10 @@ class DataManipulationPanel(QWidget):
             # Divide
             'divide_denominator_scale': float(self._div_scale_edit.text() or 1),
             'divide_denominator_background': float(self._div_bg_edit.text() or 0),
+            # Average — similarity
+            'similarity_method': self._sim_method_combo.currentData(),
+            'similarity_reference': self._sim_ref_combo.currentData(),
+            'similarity_p_min': self._sim_p_spin.value(),
         })
         self._sm.save()
 

--- a/pyirena/gui/data_manipulation_panel.py
+++ b/pyirena/gui/data_manipulation_panel.py
@@ -26,7 +26,7 @@ try:
         QListWidget, QMessageBox, QGroupBox, QFrame, QFileDialog,
         QAbstractItemView, QSizePolicy, QListWidgetItem,
         QTabWidget, QSpinBox, QDoubleSpinBox, QMenu,
-        QTableWidget, QTableWidgetItem, QHeaderView,
+        QTableWidget, QTableWidgetItem, QHeaderView, QScrollArea,
     )
     from PySide6.QtCore import Qt, QUrl, QTimer
     from PySide6.QtGui import QDesktopServices, QDoubleValidator, QAction, QPixmap, QIcon, QColor
@@ -38,7 +38,7 @@ except ImportError:
             QListWidget, QMessageBox, QGroupBox, QFrame, QFileDialog,
             QAbstractItemView, QSizePolicy, QListWidgetItem,
             QTabWidget, QSpinBox, QDoubleSpinBox, QMenu,
-            QTableWidget, QTableWidgetItem, QHeaderView,
+            QTableWidget, QTableWidgetItem, QHeaderView, QScrollArea,
         )
         from PyQt6.QtCore import Qt, QUrl, QTimer
         from PyQt6.QtGui import QDesktopServices, QDoubleValidator, QAction, QPixmap, QIcon, QColor
@@ -767,8 +767,23 @@ class DataManipulationPanel(QWidget):
     def _build_average_tab(self) -> None:
         from pyirena.core.similarity import SIMILARITY_METHODS, SIMILARITY_METHOD_LABELS
 
+        # The tab itself is just a container for the scroll area.
+        # All visible content goes into `content_widget` inside the scroll area
+        # so that if the panel is small the user can scroll rather than losing
+        # controls to clipping.
         tab = QWidget()
-        layout = QVBoxLayout(tab)
+        tab_outer = QVBoxLayout(tab)
+        tab_outer.setContentsMargins(0, 0, 0, 0)
+
+        scroll = QScrollArea()
+        scroll.setWidgetResizable(True)
+        scroll.setFrameShape(QFrame.Shape.NoFrame)
+        tab_outer.addWidget(scroll)
+
+        content_widget = QWidget()
+        scroll.setWidget(content_widget)
+
+        layout = QVBoxLayout(content_widget)
         layout.setContentsMargins(8, 6, 8, 6)
         layout.setSpacing(6)
 
@@ -916,15 +931,13 @@ class DataManipulationPanel(QWidget):
         )
         self._sim_results_table.setEditTriggers(QTableWidget.EditTrigger.NoEditTriggers)
         self._sim_results_table.setSelectionMode(QTableWidget.SelectionMode.NoSelection)
-        self._sim_results_table.setVerticalScrollBarPolicy(
-            Qt.ScrollBarPolicy.ScrollBarAsNeeded
-        )
+        # No fixed/minimum height — table sizes to its content inside the
+        # scroll area; setFixedHeight() is called after each populate().
         self._sim_results_table.setVisible(False)
         sim_layout.addWidget(self._sim_results_table)
 
         layout.addWidget(sim_group)
-        # No addStretch() here — let sim_group fill available height so the
-        # table is not squished when it becomes visible.
+        layout.addStretch()   # pushes group to top inside scroll canvas
         self._tabs.addTab(tab, "Average")
 
     # ------------------------------------------------------------------ #

--- a/pyirena/gui/data_manipulation_panel.py
+++ b/pyirena/gui/data_manipulation_panel.py
@@ -792,7 +792,7 @@ class DataManipulationPanel(QWidget):
         sim_layout.setContentsMargins(8, 6, 8, 6)
         sim_layout.setSpacing(5)
 
-        # Row 1: method, reference, p-value
+        # Row 1: method, reference, p-value, normalize checkbox
         ctrl_row = QHBoxLayout()
         ctrl_row.setSpacing(6)
 
@@ -802,6 +802,12 @@ class DataManipulationPanel(QWidget):
             label = SIMILARITY_METHOD_LABELS.get(key, key)
             self._sim_method_combo.addItem(label, userData=key)
         self._sim_method_combo.setMaximumWidth(200)
+        self._sim_method_combo.setToolTip(
+            "Similarity test algorithm.\n"
+            "CorMap (Franke et al., Nature Methods 2015) detects whether the\n"
+            "longest run of same-sign residuals between two curves is longer\n"
+            "than expected by chance from random noise."
+        )
         ctrl_row.addWidget(self._sim_method_combo)
 
         ctrl_row.addSpacing(10)
@@ -810,6 +816,13 @@ class DataManipulationPanel(QWidget):
         self._sim_ref_combo.addItem("First frame", userData='first')
         self._sim_ref_combo.addItem("Majority vote", userData='majority')
         self._sim_ref_combo.setMaximumWidth(130)
+        self._sim_ref_combo.setToolTip(
+            "First frame: compare every dataset against dataset #1.\n"
+            "Dataset #1 is always accepted (use when you know the first\n"
+            "exposure is clean — the standard bioSAXS approach).\n\n"
+            "Majority vote: compare each dataset against the median of all\n"
+            "datasets. More robust when the first frame may itself be damaged."
+        )
         ctrl_row.addWidget(self._sim_ref_combo)
 
         ctrl_row.addSpacing(10)
@@ -820,7 +833,34 @@ class DataManipulationPanel(QWidget):
         self._sim_p_spin.setSingleStep(0.001)
         self._sim_p_spin.setValue(0.01)
         self._sim_p_spin.setMaximumWidth(90)
+        self._sim_p_spin.setToolTip(
+            "Datasets with p-value below this threshold are flagged as outliers.\n\n"
+            "p-value = probability that two truly identical curves would produce\n"
+            "a run of same-sign differences at least this long by random chance.\n"
+            "Low p → curves differ beyond noise → likely radiation damaged.\n\n"
+            "Typical values:\n"
+            "  0.001 — strict (reject only severe outliers)\n"
+            "  0.010 — moderate (recommended starting point)\n"
+            "  0.050 — loose (reject more; cleaner average but fewer frames)\n\n"
+            "Experiment on test data: looser threshold = better statistics\n"
+            "but potentially contaminated by bad frames."
+        )
         ctrl_row.addWidget(self._sim_p_spin)
+
+        ctrl_row.addSpacing(10)
+        self._sim_normalize_chk = QCheckBox("Normalize scale")
+        self._sim_normalize_chk.setChecked(True)
+        self._sim_normalize_chk.setToolTip(
+            "Recommended: ON for most SAXS data.\n\n"
+            "Before comparing, rescales each dataset to match the reference\n"
+            "intensity (using the geometric-median amplitude ratio). This removes\n"
+            "differences due to flux drift, absorption, or normalization variation\n"
+            "so CorMap tests for shape differences only — the relevant signature\n"
+            "of radiation damage.\n\n"
+            "Turn OFF only if data are already on identical absolute scale and\n"
+            "you want to detect pure intensity changes (scale damage) too."
+        )
+        ctrl_row.addWidget(self._sim_normalize_chk)
 
         ctrl_row.addStretch()
         sim_layout.addLayout(ctrl_row)
@@ -833,6 +873,11 @@ class DataManipulationPanel(QWidget):
             "background-color: #2980b9; color: white; font-weight: bold;"
         )
         self._sim_check_btn.setFixedHeight(26)
+        self._sim_check_btn.setToolTip(
+            "Run the selected similarity test on all currently selected files.\n"
+            "Results appear in the table below: green = accepted, red = rejected.\n"
+            "Results are cleared automatically when the file selection changes."
+        )
         self._sim_check_btn.clicked.connect(self._on_similarity_check)
         btn_row.addWidget(self._sim_check_btn)
 
@@ -842,15 +887,21 @@ class DataManipulationPanel(QWidget):
         )
         self._sim_reject_btn.setFixedHeight(26)
         self._sim_reject_btn.setEnabled(False)
+        self._sim_reject_btn.setToolTip(
+            "Remove all rejected (red) datasets from the selection and\n"
+            "re-compute the average preview with the remaining frames."
+        )
         self._sim_reject_btn.clicked.connect(self._on_similarity_auto_reject)
         btn_row.addWidget(self._sim_reject_btn)
 
         btn_row.addStretch()
         sim_layout.addLayout(btn_row)
 
-        # Results table (hidden until a check is run)
-        self._sim_results_table = QTableWidget(0, 3)
-        self._sim_results_table.setHorizontalHeaderLabels(["File", "p-value", "Status"])
+        # Results table (hidden until a check is run; scrollable, no max height)
+        self._sim_results_table = QTableWidget(0, 4)
+        self._sim_results_table.setHorizontalHeaderLabels(
+            ["File", "p-value", "Run / N pts", "Status"]
+        )
         self._sim_results_table.horizontalHeader().setSectionResizeMode(
             0, QHeaderView.ResizeMode.Stretch
         )
@@ -860,9 +911,12 @@ class DataManipulationPanel(QWidget):
         self._sim_results_table.horizontalHeader().setSectionResizeMode(
             2, QHeaderView.ResizeMode.ResizeToContents
         )
+        self._sim_results_table.horizontalHeader().setSectionResizeMode(
+            3, QHeaderView.ResizeMode.ResizeToContents
+        )
         self._sim_results_table.setEditTriggers(QTableWidget.EditTrigger.NoEditTriggers)
         self._sim_results_table.setSelectionMode(QTableWidget.SelectionMode.NoSelection)
-        self._sim_results_table.setMaximumHeight(160)
+        self._sim_results_table.setMinimumHeight(80)
         self._sim_results_table.setVisible(False)
         sim_layout.addWidget(self._sim_results_table)
 
@@ -1576,11 +1630,13 @@ class DataManipulationPanel(QWidget):
         method_key = self._sim_method_combo.currentData()
         ref_key = self._sim_ref_combo.currentData()
         p_min = self._sim_p_spin.value()
+        normalize = self._sim_normalize_chk.isChecked()
 
         try:
             self._sim_results = check_similarity(
                 datasets, filenames=filenames,
                 method=method_key, reference=ref_key, p_min=p_min,
+                normalize_scale=normalize,
             )
         except Exception as exc:
             self._status.setText(f"Similarity check error: {exc}")
@@ -1612,7 +1668,12 @@ class DataManipulationPanel(QWidget):
             row = self._sim_results_table.rowCount()
             self._sim_results_table.insertRow(row)
 
-            p_text = f"{r.p_value:.4f}" if r.n_points > 0 else "—"
+            if r.n_points > 0:
+                p_text = f"{r.p_value:.4f}"
+                run_text = f"{r.longest_run} / {r.n_points}"
+            else:
+                p_text = "— (ref)"
+                run_text = "—"
 
             if r.accepted:
                 status_text, fg, bg = "Accepted", QColor("#196f3d"), QColor("#d5f5e3")
@@ -1622,11 +1683,12 @@ class DataManipulationPanel(QWidget):
             cells = [
                 QTableWidgetItem(r.filename),
                 QTableWidgetItem(p_text),
+                QTableWidgetItem(run_text),
                 QTableWidgetItem(status_text),
             ]
-            cells[1].setTextAlignment(Qt.AlignmentFlag.AlignCenter)
-            cells[2].setTextAlignment(Qt.AlignmentFlag.AlignCenter)
-            cells[2].setForeground(fg)
+            for col in (1, 2, 3):
+                cells[col].setTextAlignment(Qt.AlignmentFlag.AlignCenter)
+            cells[3].setForeground(fg)
             for col, item in enumerate(cells):
                 item.setBackground(bg)
                 self._sim_results_table.setItem(row, col, item)
@@ -2096,6 +2158,7 @@ class DataManipulationPanel(QWidget):
         saved_ref = s.get('similarity_reference', 'first')
         self._sim_ref_combo.setCurrentIndex(0 if saved_ref == 'first' else 1)
         self._sim_p_spin.setValue(float(s.get('similarity_p_min', 0.01)))
+        self._sim_normalize_chk.setChecked(bool(s.get('similarity_normalize_scale', True)))
 
     def save_state(self) -> None:
         su_text = self._scale_unc_edit.text().strip()
@@ -2128,6 +2191,7 @@ class DataManipulationPanel(QWidget):
             'similarity_method': self._sim_method_combo.currentData(),
             'similarity_reference': self._sim_ref_combo.currentData(),
             'similarity_p_min': self._sim_p_spin.value(),
+            'similarity_normalize_scale': self._sim_normalize_chk.isChecked(),
         })
         self._sm.save()
 

--- a/pyirena/gui/data_manipulation_panel.py
+++ b/pyirena/gui/data_manipulation_panel.py
@@ -916,12 +916,15 @@ class DataManipulationPanel(QWidget):
         )
         self._sim_results_table.setEditTriggers(QTableWidget.EditTrigger.NoEditTriggers)
         self._sim_results_table.setSelectionMode(QTableWidget.SelectionMode.NoSelection)
-        self._sim_results_table.setMinimumHeight(80)
+        self._sim_results_table.setVerticalScrollBarPolicy(
+            Qt.ScrollBarPolicy.ScrollBarAsNeeded
+        )
         self._sim_results_table.setVisible(False)
         sim_layout.addWidget(self._sim_results_table)
 
         layout.addWidget(sim_group)
-        layout.addStretch()
+        # No addStretch() here — let sim_group fill available height so the
+        # table is not squished when it becomes visible.
         self._tabs.addTab(tab, "Average")
 
     # ------------------------------------------------------------------ #
@@ -1643,13 +1646,26 @@ class DataManipulationPanel(QWidget):
             return
 
         self._populate_sim_table()
+        n_results = len(self._sim_results)
         n_rejected = sum(1 for r in self._sim_results if not r.accepted)
+
+        # Size the table to show all rows without scrolling (cap at 300px)
+        self._sim_results_table.resizeRowsToContents()
+        hh = self._sim_results_table.horizontalHeader().height()
+        rows_h = sum(
+            self._sim_results_table.rowHeight(i)
+            for i in range(self._sim_results_table.rowCount())
+        )
+        table_h = min(hh + rows_h + 4, 300)
+        self._sim_results_table.setFixedHeight(table_h)
+
         self._sim_reject_btn.setText(f"Auto-reject {n_rejected} below threshold")
         self._sim_reject_btn.setEnabled(n_rejected > 0)
         self._sim_results_table.setVisible(True)
         self._status.setText(
-            f"Similarity check: {len(self._sim_results) - n_rejected} accepted, "
-            f"{n_rejected} rejected (p < {p_min:.4f})."
+            f"Similarity check: {n_results} results for {len(filenames)} files — "
+            f"{n_results - n_rejected} accepted, {n_rejected} rejected "
+            f"(p < {p_min:.4f})."
         )
 
     def _on_similarity_auto_reject(self) -> None:
@@ -1699,6 +1715,9 @@ class DataManipulationPanel(QWidget):
         """Invalidate stale similarity results when selection changes."""
         self._sim_results = []
         self._sim_results_table.setRowCount(0)
+        # Release the fixed height set by _on_similarity_check
+        self._sim_results_table.setMinimumHeight(0)
+        self._sim_results_table.setMaximumHeight(16777215)  # Qt QWIDGETSIZE_MAX
         self._sim_results_table.setVisible(False)
         self._sim_reject_btn.setText("Auto-reject 0 below threshold")
         self._sim_reject_btn.setEnabled(False)

--- a/pyirena/gui/data_manipulation_panel.py
+++ b/pyirena/gui/data_manipulation_panel.py
@@ -170,6 +170,7 @@ class _ManipFileBrowser(QWidget):
         fld_row = QHBoxLayout()
         self.folder_btn = QPushButton("Select Folder\u2026")
         self.folder_btn.setMinimumHeight(28)
+        self.folder_btn.setToolTip("Browse to the folder containing the data files to manipulate.")
         self.folder_btn.clicked.connect(self._select_folder)
         fld_row.addWidget(self.folder_btn)
         layout.addLayout(fld_row)
@@ -908,6 +909,7 @@ class DataManipulationPanel(QWidget):
         select_btn = QPushButton("Select Existing Folder\u2026")
         select_btn.setMinimumHeight(28)
         select_btn.setStyleSheet(_BTN_GREY)
+        select_btn.setToolTip("Choose an existing folder to save manipulated output files.")
         select_btn.clicked.connect(self._select_output_folder)
         layout.addWidget(select_btn)
 
@@ -917,6 +919,10 @@ class DataManipulationPanel(QWidget):
         self._save_btn.setMinimumHeight(34)
         self._save_btn.setStyleSheet(_BTN_GREEN)
         self._save_btn.setEnabled(False)
+        self._save_btn.setToolTip(
+            "Apply the current operation to the selected file(s) and save the result.\n"
+            "Output is written to the configured output folder with a suffix in the filename."
+        )
         self._save_btn.clicked.connect(self._apply_and_save)
         layout.addWidget(self._save_btn)
 
@@ -926,6 +932,10 @@ class DataManipulationPanel(QWidget):
         self._batch_btn.setMinimumHeight(34)
         self._batch_btn.setStyleSheet(_BTN_BLUE)
         self._batch_btn.setEnabled(False)
+        self._batch_btn.setToolTip(
+            "Apply the current operation to all selected files in the list and save all results.\n"
+            "Each file is processed independently using the current settings."
+        )
         self._batch_btn.clicked.connect(self._batch_run)
         layout.addWidget(self._batch_btn)
 

--- a/pyirena/gui/data_merge_panel.py
+++ b/pyirena/gui/data_merge_panel.py
@@ -135,6 +135,7 @@ class _DatasetSelectorWidget(QWidget):
         fld_row = QHBoxLayout()
         self.folder_btn = QPushButton("Select Folder…")
         self.folder_btn.setMinimumHeight(28)
+        self.folder_btn.setToolTip("Browse to the folder containing this dataset's data files.")
         self.folder_btn.clicked.connect(self._select_folder)
         fld_row.addWidget(self.folder_btn)
         layout.addLayout(fld_row)
@@ -308,6 +309,7 @@ class DataMergeGraphWindow(QWidget):
             y_label='I  (cm⁻¹)',
             log_x=self._log_mode,
             log_y=self._log_mode,
+            d_spacing_axis=not self._log_mode,
             parent_widget=self,
             jpeg_default_name='data_merge',
         )
@@ -342,6 +344,7 @@ class DataMergeGraphWindow(QWidget):
             y_label='I  (cm⁻¹)',
             log_x=self._log_mode,
             log_y=self._log_mode,
+            d_spacing_axis=not self._log_mode,
             parent_widget=self,
             jpeg_default_name='data_merge',
         )
@@ -788,6 +791,10 @@ class DataMergePanel(QWidget):
         self._optimize_btn.setMinimumHeight(30)
         self._optimize_btn.setStyleSheet(_BTN_GREEN)
         self._optimize_btn.setEnabled(False)
+        self._optimize_btn.setToolTip(
+            "Optimize scale (and optionally Q-shift) to minimise the residual in the overlap region.\n"
+            "Results are previewed on the graph; use 'Save Merged Data' to write the output file."
+        )
         self._optimize_btn.clicked.connect(self._optimize_merge)
         row2.addWidget(self._optimize_btn)
 
@@ -867,6 +874,10 @@ class DataMergePanel(QWidget):
         self._save_btn.setMinimumHeight(34)
         self._save_btn.setStyleSheet(_BTN_GREEN)
         self._save_btn.setEnabled(False)
+        self._save_btn.setToolTip(
+            "Save the merged dataset to an NXcanSAS/HDF5 file in the output folder.\n"
+            "Run 'Optimize Merge' first to scale and align the datasets."
+        )
         self._save_btn.clicked.connect(self._save_merged)
         layout.addWidget(self._save_btn)
 
@@ -876,6 +887,10 @@ class DataMergePanel(QWidget):
         self._batch_btn.setMinimumHeight(34)
         self._batch_btn.setStyleSheet(_BTN_BLUE)
         self._batch_btn.setEnabled(False)
+        self._batch_btn.setToolTip(
+            "Automatically merge all matched file pairs from the two dataset folders.\n"
+            "Files are matched by name prefix and saved to the output folder."
+        )
         self._batch_btn.clicked.connect(self._batch_merge)
         layout.addWidget(self._batch_btn)
 
@@ -884,12 +899,20 @@ class DataMergePanel(QWidget):
         save_cfg_btn = QPushButton("Save JSON Config…")
         save_cfg_btn.setMinimumHeight(28)
         save_cfg_btn.setStyleSheet(_BTN_GREY)
+        save_cfg_btn.setToolTip(
+            "Save the current merge settings (folders, Q range, scale mode) to a JSON file.\n"
+            "Use 'Load JSON Config…' to restore them in a future session."
+        )
         save_cfg_btn.clicked.connect(self._save_json_config)
         layout.addWidget(save_cfg_btn)
 
         load_cfg_btn = QPushButton("Load JSON Config…")
         load_cfg_btn.setMinimumHeight(28)
         load_cfg_btn.setStyleSheet(_BTN_GREY)
+        load_cfg_btn.setToolTip(
+            "Load merge settings from a previously saved JSON config file.\n"
+            "Use 'Save JSON Config…' to create a compatible file."
+        )
         load_cfg_btn.clicked.connect(self._load_json_config)
         layout.addWidget(load_cfg_btn)
 

--- a/pyirena/gui/data_selector.py
+++ b/pyirena/gui/data_selector.py
@@ -2088,6 +2088,7 @@ class TabulateResultsWindow(QWidget):
             QPushButton:hover { background-color: #138d75; }
             QPushButton:disabled { background-color: #bdc3c7; }
         """)
+        self.save_btn.setToolTip("Save the current results table to a CSV file for use in spreadsheets.")
         self.save_btn.clicked.connect(self._save_csv)
         self.save_btn.setEnabled(False)
 
@@ -2311,12 +2312,17 @@ class DataSelectorPanel(QWidget):
         folder_layout = QHBoxLayout()
         self.folder_button = QPushButton("Select Data Folder")
         self.folder_button.setMinimumHeight(40)
+        self.folder_button.setToolTip("Browse to a folder containing NXcanSAS/HDF5 data files.")
         self.folder_button.clicked.connect(self.select_folder)
         folder_layout.addWidget(self.folder_button)
 
         self.refresh_button = QPushButton("Refresh")
         self.refresh_button.setMinimumHeight(40)
         self.refresh_button.setMaximumWidth(100)
+        self.refresh_button.setToolTip(
+            "Re-scan the current folder and update the file list.\n"
+            "Use after adding or removing files from the folder."
+        )
         self.refresh_button.clicked.connect(self.refresh_file_list)
         self.refresh_button.setEnabled(False)
         folder_layout.addWidget(self.refresh_button)
@@ -2540,6 +2546,10 @@ class DataSelectorPanel(QWidget):
         self.plot_button = QPushButton("Create Graph")
         self.plot_button.setMinimumHeight(28)
         self.plot_button.setStyleSheet(_btn_sm_blue)
+        self.plot_button.setToolTip(
+            "Plot I(Q) for all selected files in a new graph window.\n"
+            "Select files in the list above, then click this button."
+        )
         self.plot_button.clicked.connect(self.plot_selected_files)
         self.plot_button.setEnabled(False)
 

--- a/pyirena/gui/data_selector.py
+++ b/pyirena/gui/data_selector.py
@@ -700,6 +700,28 @@ def _build_report(file_path: str,
                         ("Amplitude [cm⁻¹]", pop.get("amplitude")),
                         ("Width σ [Å⁻¹]", pop.get("width")),
                         ("η (Voigt)", pop.get("eta_voigt"))]
+            elif pt == 'guinier_porod':
+                rows = [("G [cm⁻¹]", pop.get("G")), ("Rg1 [Å]", pop.get("Rg1")),
+                        ("Slope s1", pop.get("s1")), ("Power P", pop.get("P")),
+                        ("Rg2 [Å]", pop.get("Rg2")), ("Slope s2", pop.get("s2")),
+                        ("RgCO [Å]", pop.get("RgCO") or None),
+                        ("ETA [Å]", pop.get("ETA") if pop.get("correlations") else None),
+                        ("PACK", pop.get("PACK") if pop.get("correlations") else None)]
+                rows = [(k, v) for k, v in rows if v is not None]
+            elif pt == 'mass_fractal':
+                rows = [("Phi (vol. frac.)", pop.get("Phi")),
+                        ("Radius [Å]", pop.get("Radius")),
+                        ("Fractal dim. Dv", pop.get("Dv")),
+                        ("Ksi [Å]", pop.get("Ksi")),
+                        ("Eta", pop.get("Eta")),
+                        ("Contrast", pop.get("Contrast"))]
+            elif pt == 'surface_fractal':
+                rows = [("Surface [cm⁻¹]", pop.get("Surface")),
+                        ("Fractal dim. Ds", pop.get("Ds")),
+                        ("Ksi [Å]", pop.get("Ksi")),
+                        ("Contrast", pop.get("Contrast")),
+                        ("Qc [Å⁻¹]", pop.get("Qc") if pop.get("use_porod_transition") else None)]
+                rows = [(k, v) for k, v in rows if v is not None]
             else:  # size_dist
                 rows = [("Distribution", pop.get("dist_type")),
                         ("Scale", pop.get("scale")),

--- a/pyirena/gui/data_selector.py
+++ b/pyirena/gui/data_selector.py
@@ -40,7 +40,7 @@ except ImportError:
 import re
 import numpy as np
 import pyqtgraph as pg
-from pyirena.gui.sas_plot import save_itx_from_plot
+from pyirena.gui.sas_plot import save_itx_from_plot, add_slope_line_menu
 
 # ── Shared colour palette for multi-file graphs ────────────────────────────
 def _gen_colors(n: int) -> list:
@@ -1241,6 +1241,7 @@ class GraphWindow(QWidget):
         self.plot.addLegend(offset=(-10, 10), labelTextSize='18pt', labelTextColor='k')
         _style_plot(self.plot)
         _add_jpeg_export(self, self.plot)
+        add_slope_line_menu(self.plot)
 
         # ── Per-session state for right-click toggles ──────────────────────
         self._plot_cache: list = []          # list of dicts, one per file
@@ -1429,6 +1430,7 @@ class UnifiedFitResultsWindow(QWidget):
         self.ax_main.showGrid(x=True, y=True, alpha=0.3)
         self.ax_main.addLegend(offset=(-10, 10), labelTextSize='18pt', labelTextColor='k')
         _style_plot(self.ax_main)
+        add_slope_line_menu(self.ax_main)
 
         # ── Bottom panel: residuals ────────────────────────────────────────
         self.ax_resid = self.gl.addPlot(
@@ -1587,6 +1589,7 @@ class SizeDistResultsWindow(QWidget):
         self.ax_main.showGrid(x=True, y=True, alpha=0.3)
         self.ax_main.addLegend(offset=(-10, 10), labelTextSize='18pt', labelTextColor='k')
         _style_plot(self.ax_main)
+        add_slope_line_menu(self.ax_main)
 
         # ── Middle: residuals ──────────────────────────────────────────────
         self.ax_resid = self.gl.addPlot(
@@ -1782,6 +1785,7 @@ class SimpleFitResultsWindow(QWidget):
         self.ax_main.showGrid(x=True, y=True, alpha=0.3)
         self.ax_main.addLegend(offset=(-10, 10), labelTextSize='18pt', labelTextColor='k')
         _style_plot(self.ax_main)
+        add_slope_line_menu(self.ax_main)
 
         # ── Bottom: residuals ──────────────────────────────────────────────
         self.ax_resid = self.gl.addPlot(

--- a/pyirena/gui/data_selector.py
+++ b/pyirena/gui/data_selector.py
@@ -650,6 +650,17 @@ def _build_report(file_path: str,
                 unit = ' Å⁻¹' if pname in ('Q0', 'FWHM') else ''
                 std_str = f"± {_wp_fmt(std_v, '.3g')}" if std_v is not None else "—"
                 L.append(f"| {pname}{unit} | {_wp_fmt(val_v, '.6g')} | {std_str} |")
+            # Derived: integral under the peak (area)
+            area_v = pk.get('area')
+            area_s = pk.get('area_std')
+            if area_v is None:
+                # Older HDF5 files (pre-Area) — compute on the fly so reports
+                # always carry the derived value.
+                from pyirena.core.waxs_peakfit import peak_area, peak_area_std
+                area_v = peak_area(shape, pk)
+                area_s = peak_area_std(shape, pk, pstd)
+            area_std_str = f"± {_wp_fmt(area_s, '.3g')}" if area_s is not None else "—"
+            L.append(f"| Area (∫ peak dq) | {_wp_fmt(area_v, '.6g')} | {area_std_str} |")
             L.append("")
 
     if modeling_results is not None:
@@ -3612,6 +3623,7 @@ class DataSelectorPanel(QWidget):
                     f'WP_peak{pk}_A',  f'WP_peak{pk}_A_std',
                     f'WP_peak{pk}_FWHM', f'WP_peak{pk}_FWHM_std',
                     f'WP_peak{pk}_eta', f'WP_peak{pk}_eta_std',
+                    f'WP_peak{pk}_area', f'WP_peak{pk}_area_std',
                 ]
 
         _mod_pop_cols = [
@@ -3661,7 +3673,8 @@ class DataSelectorPanel(QWidget):
             return v
 
         _wp_n_fixed_cols = 7  # WP_n_peaks … WP_q_max
-        _wp_peak_cols    = 9  # shape, Q0, Q0_std, A, A_std, FWHM, FWHM_std, eta, eta_std
+        _wp_peak_cols    = 11  # shape, Q0, Q0_std, A, A_std, FWHM, FWHM_std,
+                               # eta, eta_std, area, area_std
 
         rows = []
         for fname, uf, sz, sf, wp, mod, sm in loaded:
@@ -3765,6 +3778,16 @@ class DataSelectorPanel(QWidget):
                         if pk_idx < len(peaks_list):
                             pk   = peaks_list[pk_idx]
                             pstd = peaks_std[pk_idx] if pk_idx < len(peaks_std) else {}
+                            # Area: prefer stored scalar; recompute for older files
+                            area_v = pk.get('area')
+                            area_s = pk.get('area_std')
+                            if area_v is None:
+                                from pyirena.core.waxs_peakfit import (
+                                    peak_area, peak_area_std,
+                                )
+                                area_v = peak_area(pk.get('shape', 'Gauss'), pk)
+                                area_s = peak_area_std(pk.get('shape', 'Gauss'),
+                                                       pk, pstd)
                             row += [
                                 pk.get('shape'),
                                 _fmt(pk.get('Q0',   {}).get('value')),
@@ -3775,6 +3798,8 @@ class DataSelectorPanel(QWidget):
                                 _fmt(pstd.get('FWHM')),
                                 _fmt(pk.get('eta',  {}).get('value') if 'eta' in pk else None),
                                 _fmt(pstd.get('eta')),
+                                _fmt(area_v),
+                                _fmt(area_s),
                             ]
                         else:
                             row += [None] * _wp_peak_cols

--- a/pyirena/gui/hdf5viewer/graph_window.py
+++ b/pyirena/gui/hdf5viewer/graph_window.py
@@ -43,6 +43,7 @@ except ImportError:
     from PyQt6.QtGui import QColor, QIcon, QAction              # type: ignore[no-redef]
 
 from . import export as _export
+from pyirena.gui.sas_plot import add_slope_line_menu
 
 # ── Default color cycle (distinct, colorblind-friendly palette) ────────────
 _COLOR_CYCLE = [
@@ -215,6 +216,8 @@ class GraphWindow(QWidget):
         act_mpl = QAction("Open as matplotlib figure…", self)
         act_mpl.triggered.connect(lambda: _export.open_matplotlib(self))
         vb.menu.addAction(act_mpl)
+
+        add_slope_line_menu(self._plot)
 
     # ── Public API ─────────────────────────────────────────────────────────
 

--- a/pyirena/gui/hdf5viewer/plot_controls.py
+++ b/pyirena/gui/hdf5viewer/plot_controls.py
@@ -970,7 +970,8 @@ class PlotControlsPanel(QWidget):
             self._collect_index.setEnabled(False)
 
         elif type_text == "WAXS Peak Fit":
-            items = ["Q0", "A", "FWHM", "Q0_err", "A_err", "FWHM_err", "chi2"]
+            items = ["Q0", "A", "FWHM", "Area",
+                     "Q0_err", "A_err", "FWHM_err", "Area_err", "chi2"]
             self._collect_item.addItems(items)
             self._collect_index.setPrefix("Peak ")
             self._collect_index.setRange(1, 20)

--- a/pyirena/gui/hdf5viewer/pyirena_readers.py
+++ b/pyirena/gui/hdf5viewer/pyirena_readers.py
@@ -490,6 +490,19 @@ def _collect_waxs(filepath, item: str, peak: int) -> float | tuple | None:
                 return _read_scalar_value(grp, "chi_squared")
             peak_name = f"peak_{peak+1:02d}"
             pk_grp = grp[peak_name]
+            # ── Derived area (lives directly on the peak group, not in
+            #    pk_grp["params"]) ─────────────────────────────────────────
+            if item == "Area":
+                val = _waxs_peak_area(pk_grp)
+                if val is None or not np.isfinite(val):
+                    return None
+                err = _waxs_peak_area_std(pk_grp)
+                if err is not None and np.isfinite(err):
+                    return (float(val), float(err))
+                return float(val)
+            if item == "Area_err":
+                err = _waxs_peak_area_std(pk_grp)
+                return float(err) if (err is not None and np.isfinite(err)) else None
             # Explicit std request (e.g. "Q0_err")
             if item.endswith("_err"):
                 base = item[:-4]
@@ -504,6 +517,55 @@ def _collect_waxs(filepath, item: str, peak: int) -> float | tuple | None:
                 if np.isfinite(std):
                     return (val, std)
             return val
+    except Exception:
+        return None
+
+
+def _waxs_peak_area(pk_grp) -> float | None:
+    """Return the peak area for an open peak_NN h5py group.
+
+    Prefers the stored ``area`` scalar; falls back to computing it from the
+    fitted parameters for HDF5 files written before that dataset existed.
+    """
+    if "area" in pk_grp and isinstance(pk_grp["area"], h5py.Dataset):
+        try:
+            return float(pk_grp["area"][()])
+        except Exception:
+            pass
+    return _waxs_recompute_area(pk_grp, with_std=False)
+
+
+def _waxs_peak_area_std(pk_grp) -> float | None:
+    if "area_std" in pk_grp and isinstance(pk_grp["area_std"], h5py.Dataset):
+        try:
+            return float(pk_grp["area_std"][()])
+        except Exception:
+            pass
+    return _waxs_recompute_area(pk_grp, with_std=True)
+
+
+def _waxs_recompute_area(pk_grp, with_std: bool):
+    """Fallback for older HDF5 files lacking the ``area`` / ``area_std`` datasets."""
+    try:
+        from pyirena.core.waxs_peakfit import peak_area, peak_area_std
+        shape = str(pk_grp.attrs.get("shape", "Gauss"))
+        if isinstance(shape, bytes):
+            shape = shape.decode("utf-8", errors="ignore")
+        params: dict = {}
+        if "params" in pk_grp:
+            for pn in ("A", "Q0", "FWHM", "eta"):
+                if pn in pk_grp["params"]:
+                    params[pn] = float(pk_grp["params"][pn][()])
+        params_std: dict = {}
+        if "params_std" in pk_grp:
+            for pn, ds in pk_grp["params_std"].items():
+                try:
+                    params_std[pn] = float(ds[()])
+                except Exception:
+                    pass
+        if with_std:
+            return float(peak_area_std(shape, params, params_std))
+        return float(peak_area(shape, params))
     except Exception:
         return None
 

--- a/pyirena/gui/modeling_panel.py
+++ b/pyirena/gui/modeling_panel.py
@@ -989,7 +989,10 @@ class PopulationTab(QWidget):
     def set_no_limits(self, no_limits: bool):
         """Show/hide min/max columns based on global 'No limits' checkbox."""
         for store in (self._row_widgets, self._ff_rows, self._sf_rows,
-                      self._uf_rows, self._uf_corr_rows, self._peak_rows):
+                      self._uf_rows, self._uf_corr_rows, self._peak_rows,
+                      self._gp_rows, self._gp_corr_rows,
+                      self._mf_rows,
+                      self._sf2_rows, self._sf2_porod_rows):
             for key, (lbl, val_edit, fit_cb, lo_edit, hi_edit) in store.items():
                 lo_edit.setVisible(not no_limits)
                 hi_edit.setVisible(not no_limits)

--- a/pyirena/gui/modeling_panel.py
+++ b/pyirena/gui/modeling_panel.py
@@ -1631,6 +1631,7 @@ class ModelingPanel(QWidget):
         help_btn.setFixedSize(60, 22)
         help_btn.setStyleSheet(
             'background:#c0392b;color:white;font-size:11px;border-radius:3px;')
+        help_btn.setToolTip("Open the pyIrena Modeling tool documentation in a browser.")
         help_btn.clicked.connect(self._open_help)
         title_row.addWidget(help_btn)
         lay.addLayout(title_row)
@@ -1645,6 +1646,7 @@ class ModelingPanel(QWidget):
         file_row.addWidget(self.file_edit)
         btn_open = QPushButton('Open…')
         btn_open.setFixedWidth(60)
+        btn_open.setToolTip("Open an NXcanSAS/HDF5 file to load I(Q) data for modeling.")
         btn_open.clicked.connect(self._open_file)
         file_row.addWidget(btn_open)
         lay.addLayout(file_row)
@@ -1714,6 +1716,10 @@ class ModelingPanel(QWidget):
             'QPushButton:hover {background: #42b86a;}'
             'QPushButton:disabled {background: #bdc3c7;}'
         )
+        self.btn_graph.setToolTip(
+            "Compute and display the current model curve without fitting.\n"
+            "Use this to preview the model before running a fit."
+        )
         self.btn_graph.clicked.connect(self.graph_model)
         self.btn_graph.setEnabled(False)
 
@@ -1724,6 +1730,10 @@ class ModelingPanel(QWidget):
             ' border-radius: 4px;}'
             'QPushButton:hover {background: #229954;}'
             'QPushButton:disabled {background: #bdc3c7;}'
+        )
+        self.btn_fit.setToolTip(
+            "Fit the population model to the loaded data using the current parameters.\n"
+            "Checked parameters are varied; unchecked parameters are held fixed."
         )
         self.btn_fit.clicked.connect(self.run_fit)
         self.btn_fit.setEnabled(False)
@@ -1760,6 +1770,10 @@ class ModelingPanel(QWidget):
             ' border-radius: 4px;}'
             'QPushButton:hover {background: #1abc9c;}'
             'QPushButton:disabled {background: #bdc3c7;}'
+        )
+        self.btn_mc.setToolTip(
+            "Estimate parameter uncertainties by repeating the fit on noise-perturbed data.\n"
+            "Set 'Passes' to control how many Monte Carlo replicates are used."
         )
         self.btn_mc.clicked.connect(self.calc_uncertainty_mc)
         self.btn_mc.setEnabled(False)
@@ -1824,10 +1838,12 @@ class ModelingPanel(QWidget):
 
         # Row 3: Export Parameters + Import Parameters
         out3 = QHBoxLayout()
-        out3.addWidget(_mkbtn('Export Parameters', 'lgreen', self.export_json,
-                              'Export current parameters to a pyIrena JSON config file.'))
-        out3.addWidget(_mkbtn('Import Parameters', 'lgreen', self._import_parameters,
-                              'Import parameters from a pyIrena JSON config file.'))
+        out3.addWidget(_mkbtn('Save params to JSON', 'lgreen', self.export_json,
+                              'Save current Modeling parameters to a pyIrena JSON file.\n'
+                              "Use 'Load params from JSON' to restore them later."))
+        out3.addWidget(_mkbtn('Load params from JSON', 'lgreen', self._import_parameters,
+                              'Load Modeling parameters from a previously saved pyIrena JSON file.\n'
+                              "Use 'Save params to JSON' to create a compatible file."))
         lay.addLayout(out3)
 
         scroll.setWidget(inner)

--- a/pyirena/gui/modeling_panel.py
+++ b/pyirena/gui/modeling_panel.py
@@ -62,7 +62,7 @@ from pyirena.core.modeling import (
 )
 from pyirena.gui.sas_plot import (
     make_sas_plot, plot_iq_data, set_robust_y_range, add_plot_annotation,
-    RadiusAxisItem, save_itx_from_plot,
+    RadiusAxisItem, save_itx_from_plot, add_slope_line_menu,
 )
 from pyirena.gui.unified_fit import ScrubbableLineEdit, _SafeInfiniteLine
 from pyirena.io.nxcansas_modeling import save_modeling_results, load_modeling_results
@@ -1217,6 +1217,7 @@ class ModelingGraphWindow(QWidget):
         self.iq_plot.setTitle('Modeling — I(Q)', size='12pt', color='k')
         self.iq_plot.addLegend(offset=(-10, 10), labelTextSize='9pt', labelTextColor='k')
         self._style_axes(self.iq_plot, show_top_values=True)
+        add_slope_line_menu(self.iq_plot)
 
         # ── Residuals plot ────────────────────────────────────────────────
         self.resid_plot = self.gl.addPlot(row=1, col=0)

--- a/pyirena/gui/modeling_panel.py
+++ b/pyirena/gui/modeling_panel.py
@@ -166,6 +166,7 @@ GP_CORR_PARAMS = [
 MF_PARAMS = [
     ('Phi',      'Phi (vol. frac.)',   0.001, 1e-8, 1.0,   True),
     ('Radius',   'Radius [Å]',        50.0,  0.1,  1e6,   True),
+    ('Beta',     'Aspect ratio β',     1.0,  0.01, 100.0, False),
     ('Dv',       'Fractal dim. Dv',    2.5,  1.0,  3.0,   True),
     ('Ksi',      'Ksi [Å]',          500.0,  1.0,  1e7,   True),
     ('Eta',      'Eta (fill factor)',  0.5,  0.3,  0.8,   False),

--- a/pyirena/gui/modeling_panel.py
+++ b/pyirena/gui/modeling_panel.py
@@ -59,6 +59,7 @@ from pyirena.core.distributions import DIST_PARAM_NAMES, DIST_LABELS, DIST_DEFAU
 from pyirena.core.modeling import (
     ModelingEngine, ModelingConfig, SizeDistPopulation, ModelingResult,
     UnifiedLevelPopulation, DiffractionPeakPopulation,
+    GuinierPorodPopulation, MassFractalPopulation, SurfaceFractalPopulation,
 )
 from pyirena.gui.sas_plot import (
     make_sas_plot, plot_iq_data, set_robust_y_range, add_plot_annotation,
@@ -146,6 +147,43 @@ PEAK_PARAMS = [
     ('eta_voigt', 'η (mixing)',         0.5,  0.0,   1.0,   False),
 ]
 
+# Guinier-Porod Level parameter definitions: (key, display_label, default, lo, hi, fit_default)
+GP_PARAMS = [
+    ('G',    'G [cm⁻¹]',       1.0,  1e-10, 1e10,  True),
+    ('Rg1',  'Rg1 [Å]',       10.0,  0.1,   1e6,   True),
+    ('s1',   'Slope s1',        0.0,  0.0,   3.0,   False),
+    ('P',    'Power P',         4.0,  0.0,   6.0,   False),
+    ('Rg2',  'Rg2 [Å]',       1e10,  0.1,   1e12,  False),
+    ('s2',   'Slope s2',        0.0,  0.0,   3.0,   False),
+    ('RgCO', 'RgCO [Å]',       0.0,  0.0,   1e6,   False),
+]
+GP_CORR_PARAMS = [
+    ('ETA',  'ETA [Å]',       10.0,  0.1,   1e6,   False),
+    ('PACK', 'Packing factor',  0.0,  0.0,   16.0,  False),
+]
+
+# Mass Fractal parameter definitions
+MF_PARAMS = [
+    ('Phi',      'Phi (vol. frac.)',   0.001, 1e-8, 1.0,   True),
+    ('Radius',   'Radius [Å]',        50.0,  0.1,  1e6,   True),
+    ('Dv',       'Fractal dim. Dv',    2.5,  1.0,  3.0,   True),
+    ('Ksi',      'Ksi [Å]',          500.0,  1.0,  1e7,   True),
+    ('Eta',      'Eta (fill factor)',  0.5,  0.3,  0.8,   False),
+    ('Contrast', 'Contrast',           1.0,  0.0,  1e10,  False),
+]
+
+# Surface Fractal parameter definitions
+SF_PARAMS = [
+    ('Surface',  'Surface [cm⁻¹]',    1e4,  1.0,  1e12,  True),
+    ('Ds',       'Fractal dim. Ds',    2.5,  2.0,  3.0,   True),
+    ('Ksi',      'Ksi [Å]',          500.0, 1.0,  1e7,   True),
+    ('Contrast', 'Contrast',           1.0,  0.0,  1e10,  False),
+]
+SF_POROD_PARAMS = [
+    ('Qc',      'Qc [Å⁻¹]',          0.1,  0.001, 10.0,  False),
+    ('QcWidth', 'Qc width (frac.)',    0.1,  0.01,  1.0,   False),
+]
+
 # All possible derived-quantity rows (shown in Derived Results panel)
 _ALL_DERIVED_ROWS = [
     ('vol_mean_r',      'Vol-mean radius (Å)'),
@@ -160,6 +198,17 @@ _ALL_DERIVED_ROWS = [
     ('amplitude',       'Amplitude [cm⁻¹]'),
     ('width',           'Width σ [Å⁻¹]'),
     ('invariant',       'Invariant [cm⁻⁴]'),
+    # GP
+    ('Rg1',             'Rg1 [Å]'),
+    ('s1',              'Slope s1'),
+    # MF
+    ('Phi',             'Phi (vol. frac.)'),
+    ('Radius',          'Radius [Å]'),
+    ('Dv',              'Fractal dim. Dv'),
+    ('Ksi',             'Ksi [Å]'),
+    # SF
+    ('Surface',         'Surface [cm⁻¹]'),
+    ('Ds',              'Fractal dim. Ds'),
 ]
 
 # ──────────────────────────────────────────────────────────────────────────────
@@ -216,6 +265,11 @@ class PopulationTab(QWidget):
         self._uf_rows: dict = {}
         self._uf_corr_rows: dict = {}
         self._peak_rows: dict = {}
+        self._gp_rows: dict = {}
+        self._gp_corr_rows: dict = {}
+        self._mf_rows: dict = {}
+        self._sf2_rows: dict = {}        # surface fractal main rows
+        self._sf2_porod_rows: dict = {}  # surface fractal Porod transition rows
         self._dist_param_cache: dict = {}   # {dist_type: {key: (val, fit, lo, hi)}}
         self._last_dist_type: str = 'lognormal'
 
@@ -254,9 +308,12 @@ class PopulationTab(QWidget):
         type_row = QHBoxLayout()
         type_row.addWidget(QLabel('Population type:'))
         self.pop_type_combo = QComboBox()
-        for key, label in [('size_dist', 'Size Distribution'),
-                            ('unified_level', 'Unified Fit Level'),
-                            ('diffraction_peak', 'Diffraction Peak')]:
+        for key, label in [('size_dist',       'Size Distribution'),
+                            ('unified_level',   'Unified Fit Level'),
+                            ('diffraction_peak','Diffraction Peak'),
+                            ('guinier_porod',   'Guinier-Porod Level'),
+                            ('mass_fractal',    'Mass Fractal'),
+                            ('surface_fractal', 'Surface Fractal')]:
             self.pop_type_combo.addItem(label, key)
         self.pop_type_combo.currentIndexChanged.connect(self._on_pop_type_changed)
         type_row.addWidget(self.pop_type_combo)
@@ -280,6 +337,24 @@ class PopulationTab(QWidget):
         self._build_peak_panel()
         self._peak_panel.setVisible(False)
         c.addWidget(self._peak_panel)
+
+        # ── Guinier-Porod Level panel ──────────────────────────────────────
+        self._gp_panel = QWidget()
+        self._build_gp_panel()
+        self._gp_panel.setVisible(False)
+        c.addWidget(self._gp_panel)
+
+        # ── Mass Fractal panel ─────────────────────────────────────────────
+        self._mf_panel = QWidget()
+        self._build_mf_panel()
+        self._mf_panel.setVisible(False)
+        c.addWidget(self._mf_panel)
+
+        # ── Surface Fractal panel ──────────────────────────────────────────
+        self._sf2_panel = QWidget()
+        self._build_sf2_panel()
+        self._sf2_panel.setVisible(False)
+        c.addWidget(self._sf2_panel)
 
         # ── Derived results (read-only, filled after fit) ───────────────────
         self._derived_group = QGroupBox('Derived Results')
@@ -531,6 +606,98 @@ class PopulationTab(QWidget):
         # eta_voigt is hidden unless pseudo-Voigt
         self._update_peak_eta_visibility()
 
+    def _build_gp_panel(self):
+        """Build Guinier-Porod Level controls inside self._gp_panel."""
+        c = QVBoxLayout(self._gp_panel)
+        c.setContentsMargins(0, 0, 0, 0)
+        c.setSpacing(4)
+
+        gp_group = QGroupBox('Guinier-Porod Level Parameters')
+        gp_lay = QVBoxLayout(gp_group)
+        gp_grid = QGridLayout()
+        gp_grid.setSpacing(2)
+        self._build_param_header(gp_grid, 0)
+        for row_i, (key, label, default, lo, hi, fit_default) in enumerate(GP_PARAMS, start=1):
+            self._add_param_row(gp_grid, row_i, key, label,
+                                default, fit_default, lo, hi, self._gp_rows)
+        gp_lay.addLayout(gp_grid)
+        c.addWidget(gp_group)
+
+        corr_row = QHBoxLayout()
+        self.gp_corr_cb = QCheckBox('Correlations (Born-Green)')
+        self.gp_corr_cb.stateChanged.connect(self._on_gp_corr_changed)
+        corr_row.addWidget(self.gp_corr_cb)
+        corr_row.addStretch()
+        c.addLayout(corr_row)
+
+        self._gp_corr_group = QGroupBox('Correlation Parameters')
+        corr_lay = QVBoxLayout(self._gp_corr_group)
+        corr_grid = QGridLayout()
+        corr_grid.setSpacing(2)
+        self._build_param_header(corr_grid, 0)
+        for row_i, (key, label, default, lo, hi, fit_default) in enumerate(GP_CORR_PARAMS, start=1):
+            self._add_param_row(corr_grid, row_i, key, label,
+                                default, fit_default, lo, hi, self._gp_corr_rows)
+        corr_lay.addLayout(corr_grid)
+        self._gp_corr_group.setVisible(False)
+        c.addWidget(self._gp_corr_group)
+        c.addStretch()
+
+    def _build_mf_panel(self):
+        """Build Mass Fractal controls inside self._mf_panel."""
+        c = QVBoxLayout(self._mf_panel)
+        c.setContentsMargins(0, 0, 0, 0)
+        c.setSpacing(4)
+
+        mf_group = QGroupBox('Mass Fractal Parameters')
+        mf_lay = QVBoxLayout(mf_group)
+        mf_grid = QGridLayout()
+        mf_grid.setSpacing(2)
+        self._build_param_header(mf_grid, 0)
+        for row_i, (key, label, default, lo, hi, fit_default) in enumerate(MF_PARAMS, start=1):
+            self._add_param_row(mf_grid, row_i, key, label,
+                                default, fit_default, lo, hi, self._mf_rows)
+        mf_lay.addLayout(mf_grid)
+        c.addWidget(mf_group)
+        c.addStretch()
+
+    def _build_sf2_panel(self):
+        """Build Surface Fractal controls inside self._sf2_panel."""
+        c = QVBoxLayout(self._sf2_panel)
+        c.setContentsMargins(0, 0, 0, 0)
+        c.setSpacing(4)
+
+        sf_group = QGroupBox('Surface Fractal Parameters')
+        sf_lay = QVBoxLayout(sf_group)
+        sf_grid = QGridLayout()
+        sf_grid.setSpacing(2)
+        self._build_param_header(sf_grid, 0)
+        for row_i, (key, label, default, lo, hi, fit_default) in enumerate(SF_PARAMS, start=1):
+            self._add_param_row(sf_grid, row_i, key, label,
+                                default, fit_default, lo, hi, self._sf2_rows)
+        sf_lay.addLayout(sf_grid)
+        c.addWidget(sf_group)
+
+        porod_row = QHBoxLayout()
+        self.sf2_porod_cb = QCheckBox('Porod transition at Qc')
+        self.sf2_porod_cb.stateChanged.connect(self._on_sf2_porod_changed)
+        porod_row.addWidget(self.sf2_porod_cb)
+        porod_row.addStretch()
+        c.addLayout(porod_row)
+
+        self._sf2_porod_group = QGroupBox('Porod Transition Parameters')
+        porod_lay = QVBoxLayout(self._sf2_porod_group)
+        porod_grid = QGridLayout()
+        porod_grid.setSpacing(2)
+        self._build_param_header(porod_grid, 0)
+        for row_i, (key, label, default, lo, hi, fit_default) in enumerate(SF_POROD_PARAMS, start=1):
+            self._add_param_row(porod_grid, row_i, key, label,
+                                default, fit_default, lo, hi, self._sf2_porod_rows)
+        porod_lay.addLayout(porod_grid)
+        self._sf2_porod_group.setVisible(False)
+        c.addWidget(self._sf2_porod_group)
+        c.addStretch()
+
     def _build_param_header(self, grid: QGridLayout, start_row: int):
         hdr_style = 'font-weight: bold; font-size: 10px;'
         for col, text in enumerate(['Parameter', 'Value', 'Fit?', 'Min', 'Max']):
@@ -667,12 +834,27 @@ class PopulationTab(QWidget):
         self._size_dist_panel.setVisible(pt == 'size_dist')
         self._uf_panel.setVisible(pt == 'unified_level')
         self._peak_panel.setVisible(pt == 'diffraction_peak')
+        self._gp_panel.setVisible(pt == 'guinier_porod')
+        self._mf_panel.setVisible(pt == 'mass_fractal')
+        self._sf2_panel.setVisible(pt == 'surface_fractal')
         self._emit_changed()
 
     def _on_uf_corr_changed(self, _=None):
         if self._building:
             return
         self._uf_corr_group.setVisible(self.uf_corr_cb.isChecked())
+        self._emit_changed()
+
+    def _on_gp_corr_changed(self, _=None):
+        if self._building:
+            return
+        self._gp_corr_group.setVisible(self.gp_corr_cb.isChecked())
+        self._emit_changed()
+
+    def _on_sf2_porod_changed(self, _=None):
+        if self._building:
+            return
+        self._sf2_porod_group.setVisible(self.sf2_porod_cb.isChecked())
         self._emit_changed()
 
     def _on_peak_type_changed(self, _=None):
@@ -821,6 +1003,12 @@ class PopulationTab(QWidget):
             return self._read_uf_population()
         if pt == 'diffraction_peak':
             return self._read_peak_population()
+        if pt == 'guinier_porod':
+            return self._read_gp_population()
+        if pt == 'mass_fractal':
+            return self._read_mf_population()
+        if pt == 'surface_fractal':
+            return self._read_sf2_population()
         return self._read_size_dist_population()
 
     def _read_size_dist_population(self) -> SizeDistPopulation:
@@ -925,11 +1113,20 @@ class PopulationTab(QWidget):
             self._size_dist_panel.setVisible(pt == 'size_dist')
             self._uf_panel.setVisible(pt == 'unified_level')
             self._peak_panel.setVisible(pt == 'diffraction_peak')
+            self._gp_panel.setVisible(pt == 'guinier_porod')
+            self._mf_panel.setVisible(pt == 'mass_fractal')
+            self._sf2_panel.setVisible(pt == 'surface_fractal')
 
             if pt == 'unified_level':
                 self._load_uf_population(pop)
             elif pt == 'diffraction_peak':
                 self._load_peak_population(pop)
+            elif pt == 'guinier_porod':
+                self._load_gp_population(pop)
+            elif pt == 'mass_fractal':
+                self._load_mf_population(pop)
+            elif pt == 'surface_fractal':
+                self._load_sf2_population(pop)
             else:
                 self._load_size_dist_population(pop)
         finally:
@@ -1026,6 +1223,117 @@ class PopulationTab(QWidget):
             hi_edit.setText(_fmt(lim[1]))
         self.label_edit.setText(pop.label)
 
+    # ── Guinier-Porod read/load ───────────────────────────────────────────────
+
+    def _read_gp_population(self) -> GuinierPorodPopulation:
+        """Read GP widgets → GuinierPorodPopulation dataclass."""
+        pop = GuinierPorodPopulation()
+        pop.enabled = self.use_cb.isChecked()
+        for key, (lbl, val_edit, fit_cb, lo_edit, hi_edit) in self._gp_rows.items():
+            setattr(pop, key, _parse(val_edit.text(), getattr(pop, key)))
+            setattr(pop, f'fit_{key}', fit_cb.isChecked())
+            lo = _parse(lo_edit.text(), 0.0)
+            hi = _parse(hi_edit.text(), 1e10)
+            setattr(pop, f'{key}_limits', (lo, hi))
+        pop.correlations = self.gp_corr_cb.isChecked()
+        for key, (lbl, val_edit, fit_cb, lo_edit, hi_edit) in self._gp_corr_rows.items():
+            setattr(pop, key, _parse(val_edit.text(), getattr(pop, key)))
+            setattr(pop, f'fit_{key}', fit_cb.isChecked())
+            lo = _parse(lo_edit.text(), 0.0)
+            hi = _parse(hi_edit.text(), 1e10)
+            setattr(pop, f'{key}_limits', (lo, hi))
+        pop.label = self.label_edit.text().strip()
+        return pop
+
+    def _load_gp_population(self, pop: GuinierPorodPopulation):
+        """Load GP dataclass into widgets (caller manages _building)."""
+        self.use_cb.setChecked(pop.enabled)
+        self._content.setEnabled(pop.enabled)
+        for key, (lbl, val_edit, fit_cb, lo_edit, hi_edit) in self._gp_rows.items():
+            val_edit.setText(_fmt(getattr(pop, key, 1.0)))
+            fit_cb.setChecked(getattr(pop, f'fit_{key}', False))
+            lim = getattr(pop, f'{key}_limits', (0.0, 1e10))
+            lo_edit.setText(_fmt(lim[0]))
+            hi_edit.setText(_fmt(lim[1]))
+        self.gp_corr_cb.setChecked(pop.correlations)
+        self._gp_corr_group.setVisible(pop.correlations)
+        for key, (lbl, val_edit, fit_cb, lo_edit, hi_edit) in self._gp_corr_rows.items():
+            val_edit.setText(_fmt(getattr(pop, key, 1.0)))
+            fit_cb.setChecked(getattr(pop, f'fit_{key}', False))
+            lim = getattr(pop, f'{key}_limits', (0.0, 1e10))
+            lo_edit.setText(_fmt(lim[0]))
+            hi_edit.setText(_fmt(lim[1]))
+        self.label_edit.setText(pop.label)
+
+    # ── Mass Fractal read/load ────────────────────────────────────────────────
+
+    def _read_mf_population(self) -> MassFractalPopulation:
+        """Read MF widgets → MassFractalPopulation dataclass."""
+        pop = MassFractalPopulation()
+        pop.enabled = self.use_cb.isChecked()
+        for key, (lbl, val_edit, fit_cb, lo_edit, hi_edit) in self._mf_rows.items():
+            setattr(pop, key, _parse(val_edit.text(), getattr(pop, key)))
+            setattr(pop, f'fit_{key}', fit_cb.isChecked())
+            lo = _parse(lo_edit.text(), 0.0)
+            hi = _parse(hi_edit.text(), 1e10)
+            setattr(pop, f'{key}_limits', (lo, hi))
+        pop.label = self.label_edit.text().strip()
+        return pop
+
+    def _load_mf_population(self, pop: MassFractalPopulation):
+        """Load MF dataclass into widgets (caller manages _building)."""
+        self.use_cb.setChecked(pop.enabled)
+        self._content.setEnabled(pop.enabled)
+        for key, (lbl, val_edit, fit_cb, lo_edit, hi_edit) in self._mf_rows.items():
+            val_edit.setText(_fmt(getattr(pop, key, 1.0)))
+            fit_cb.setChecked(getattr(pop, f'fit_{key}', False))
+            lim = getattr(pop, f'{key}_limits', (0.0, 1e10))
+            lo_edit.setText(_fmt(lim[0]))
+            hi_edit.setText(_fmt(lim[1]))
+        self.label_edit.setText(pop.label)
+
+    # ── Surface Fractal read/load ─────────────────────────────────────────────
+
+    def _read_sf2_population(self) -> SurfaceFractalPopulation:
+        """Read surface fractal widgets → SurfaceFractalPopulation dataclass."""
+        pop = SurfaceFractalPopulation()
+        pop.enabled = self.use_cb.isChecked()
+        for key, (lbl, val_edit, fit_cb, lo_edit, hi_edit) in self._sf2_rows.items():
+            setattr(pop, key, _parse(val_edit.text(), getattr(pop, key)))
+            setattr(pop, f'fit_{key}', fit_cb.isChecked())
+            lo = _parse(lo_edit.text(), 0.0)
+            hi = _parse(hi_edit.text(), 1e10)
+            setattr(pop, f'{key}_limits', (lo, hi))
+        pop.use_porod_transition = self.sf2_porod_cb.isChecked()
+        for key, (lbl, val_edit, fit_cb, lo_edit, hi_edit) in self._sf2_porod_rows.items():
+            setattr(pop, key, _parse(val_edit.text(), getattr(pop, key)))
+            setattr(pop, f'fit_{key}', fit_cb.isChecked())
+            lo = _parse(lo_edit.text(), 0.0)
+            hi = _parse(hi_edit.text(), 1e10)
+            setattr(pop, f'{key}_limits', (lo, hi))
+        pop.label = self.label_edit.text().strip()
+        return pop
+
+    def _load_sf2_population(self, pop: SurfaceFractalPopulation):
+        """Load surface fractal dataclass into widgets (caller manages _building)."""
+        self.use_cb.setChecked(pop.enabled)
+        self._content.setEnabled(pop.enabled)
+        for key, (lbl, val_edit, fit_cb, lo_edit, hi_edit) in self._sf2_rows.items():
+            val_edit.setText(_fmt(getattr(pop, key, 1.0)))
+            fit_cb.setChecked(getattr(pop, f'fit_{key}', False))
+            lim = getattr(pop, f'{key}_limits', (0.0, 1e10))
+            lo_edit.setText(_fmt(lim[0]))
+            hi_edit.setText(_fmt(lim[1]))
+        self.sf2_porod_cb.setChecked(pop.use_porod_transition)
+        self._sf2_porod_group.setVisible(pop.use_porod_transition)
+        for key, (lbl, val_edit, fit_cb, lo_edit, hi_edit) in self._sf2_porod_rows.items():
+            val_edit.setText(_fmt(getattr(pop, key, 0.1)))
+            fit_cb.setChecked(getattr(pop, f'fit_{key}', False))
+            lim = getattr(pop, f'{key}_limits', (0.0, 1e10))
+            lo_edit.setText(_fmt(lim[0]))
+            hi_edit.setText(_fmt(lim[1]))
+        self.label_edit.setText(pop.label)
+
     # ── UF / Peak panel state dicts (for full state preservation) ────────────
 
     def _read_uf_state_dict(self) -> dict:
@@ -1087,7 +1395,89 @@ class PopulationTab(QWidget):
             lo_edit.setText(_fmt(lim[0]))
             hi_edit.setText(_fmt(lim[1]))
 
-    # ── Full state (all three panels) for state persistence ──────────────────
+    # ── GP / MF / SF panel state dicts ──────────────────────────────────────
+
+    def _read_gp_state_dict(self) -> dict:
+        _gp0 = GuinierPorodPopulation()
+        d = {'correlations': self.gp_corr_cb.isChecked()}
+        for key, (lbl, val_edit, fit_cb, lo_edit, hi_edit) in self._gp_rows.items():
+            d[key] = _parse(val_edit.text(), getattr(_gp0, key))
+            d[f'fit_{key}'] = fit_cb.isChecked()
+            d[f'{key}_limits'] = [_parse(lo_edit.text(), 0.0), _parse(hi_edit.text(), 1e10)]
+        for key, (lbl, val_edit, fit_cb, lo_edit, hi_edit) in self._gp_corr_rows.items():
+            d[key] = _parse(val_edit.text(), getattr(_gp0, key))
+            d[f'fit_{key}'] = fit_cb.isChecked()
+            d[f'{key}_limits'] = [_parse(lo_edit.text(), 0.0), _parse(hi_edit.text(), 1e10)]
+        return d
+
+    def _load_gp_state(self, d: dict):
+        _gp0 = GuinierPorodPopulation()
+        corr = d.get('correlations', False)
+        self.gp_corr_cb.setChecked(corr)
+        self._gp_corr_group.setVisible(corr)
+        for key, (lbl, val_edit, fit_cb, lo_edit, hi_edit) in self._gp_rows.items():
+            val_edit.setText(_fmt(d.get(key, getattr(_gp0, key))))
+            fit_cb.setChecked(d.get(f'fit_{key}', getattr(_gp0, f'fit_{key}')))
+            lim = d.get(f'{key}_limits', list(getattr(_gp0, f'{key}_limits')))
+            lo_edit.setText(_fmt(lim[0]))
+            hi_edit.setText(_fmt(lim[1]))
+        for key, (lbl, val_edit, fit_cb, lo_edit, hi_edit) in self._gp_corr_rows.items():
+            val_edit.setText(_fmt(d.get(key, getattr(_gp0, key))))
+            fit_cb.setChecked(d.get(f'fit_{key}', getattr(_gp0, f'fit_{key}')))
+            lim = d.get(f'{key}_limits', list(getattr(_gp0, f'{key}_limits')))
+            lo_edit.setText(_fmt(lim[0]))
+            hi_edit.setText(_fmt(lim[1]))
+
+    def _read_mf_state_dict(self) -> dict:
+        _mf0 = MassFractalPopulation()
+        d = {}
+        for key, (lbl, val_edit, fit_cb, lo_edit, hi_edit) in self._mf_rows.items():
+            d[key] = _parse(val_edit.text(), getattr(_mf0, key))
+            d[f'fit_{key}'] = fit_cb.isChecked()
+            d[f'{key}_limits'] = [_parse(lo_edit.text(), 0.0), _parse(hi_edit.text(), 1e10)]
+        return d
+
+    def _load_mf_state(self, d: dict):
+        _mf0 = MassFractalPopulation()
+        for key, (lbl, val_edit, fit_cb, lo_edit, hi_edit) in self._mf_rows.items():
+            val_edit.setText(_fmt(d.get(key, getattr(_mf0, key))))
+            fit_cb.setChecked(d.get(f'fit_{key}', getattr(_mf0, f'fit_{key}')))
+            lim = d.get(f'{key}_limits', list(getattr(_mf0, f'{key}_limits')))
+            lo_edit.setText(_fmt(lim[0]))
+            hi_edit.setText(_fmt(lim[1]))
+
+    def _read_sf2_state_dict(self) -> dict:
+        _sf0 = SurfaceFractalPopulation()
+        d = {'use_porod_transition': self.sf2_porod_cb.isChecked()}
+        for key, (lbl, val_edit, fit_cb, lo_edit, hi_edit) in self._sf2_rows.items():
+            d[key] = _parse(val_edit.text(), getattr(_sf0, key))
+            d[f'fit_{key}'] = fit_cb.isChecked()
+            d[f'{key}_limits'] = [_parse(lo_edit.text(), 0.0), _parse(hi_edit.text(), 1e10)]
+        for key, (lbl, val_edit, fit_cb, lo_edit, hi_edit) in self._sf2_porod_rows.items():
+            d[key] = _parse(val_edit.text(), getattr(_sf0, key))
+            d[f'fit_{key}'] = fit_cb.isChecked()
+            d[f'{key}_limits'] = [_parse(lo_edit.text(), 0.0), _parse(hi_edit.text(), 1e10)]
+        return d
+
+    def _load_sf2_state(self, d: dict):
+        _sf0 = SurfaceFractalPopulation()
+        porod = d.get('use_porod_transition', False)
+        self.sf2_porod_cb.setChecked(porod)
+        self._sf2_porod_group.setVisible(porod)
+        for key, (lbl, val_edit, fit_cb, lo_edit, hi_edit) in self._sf2_rows.items():
+            val_edit.setText(_fmt(d.get(key, getattr(_sf0, key))))
+            fit_cb.setChecked(d.get(f'fit_{key}', getattr(_sf0, f'fit_{key}')))
+            lim = d.get(f'{key}_limits', list(getattr(_sf0, f'{key}_limits')))
+            lo_edit.setText(_fmt(lim[0]))
+            hi_edit.setText(_fmt(lim[1]))
+        for key, (lbl, val_edit, fit_cb, lo_edit, hi_edit) in self._sf2_porod_rows.items():
+            val_edit.setText(_fmt(d.get(key, getattr(_sf0, key))))
+            fit_cb.setChecked(d.get(f'fit_{key}', getattr(_sf0, f'fit_{key}')))
+            lim = d.get(f'{key}_limits', list(getattr(_sf0, f'{key}_limits')))
+            lo_edit.setText(_fmt(lim[0]))
+            hi_edit.setText(_fmt(lim[1]))
+
+    # ── Full state (all panels) for state persistence ─────────────────────────
 
     def to_full_dict(self) -> dict:
         """Serialize all three panels for state persistence (used by _save_state)."""
@@ -1119,6 +1509,9 @@ class PopulationTab(QWidget):
             'n_bins': sd.n_bins,
             'uf': self._read_uf_state_dict(),
             'peak': self._read_peak_state_dict(),
+            'gp': self._read_gp_state_dict(),
+            'mf': self._read_mf_state_dict(),
+            'sf2': self._read_sf2_state_dict(),
             'label': self.label_edit.text().strip(),
         }
         return d
@@ -1140,16 +1533,25 @@ class PopulationTab(QWidget):
             self._size_dist_panel.setVisible(pt == 'size_dist')
             self._uf_panel.setVisible(pt == 'unified_level')
             self._peak_panel.setVisible(pt == 'diffraction_peak')
+            self._gp_panel.setVisible(pt == 'guinier_porod')
+            self._mf_panel.setVisible(pt == 'mass_fractal')
+            self._sf2_panel.setVisible(pt == 'surface_fractal')
 
             # Always load size-dist state (for state preservation when switching types)
             sd_pop = _pop_from_dict_size_dist(d)
             self._load_size_dist_population(sd_pop)
 
-            # Load UF and peak states too
+            # Load all panel states (graceful no-op if key absent = old state file)
             if 'uf' in d:
                 self._load_uf_state(d['uf'])
             if 'peak' in d:
                 self._load_peak_state(d['peak'])
+            if 'gp' in d:
+                self._load_gp_state(d['gp'])
+            if 'mf' in d:
+                self._load_mf_state(d['mf'])
+            if 'sf2' in d:
+                self._load_sf2_state(d['sf2'])
             self.label_edit.setText(d.get('label', ''))
         finally:
             self._building = False

--- a/pyirena/gui/sas_plot.py
+++ b/pyirena/gui/sas_plot.py
@@ -731,6 +731,8 @@ def make_sas_plot(
     if parent_widget is not None:
         _add_jpeg_export(plot, parent_widget, jpeg_default_name,
                          x_label=x_label, y_label=y_label, title=title or '')
+    if log_x and log_y:
+        add_slope_line_menu(plot)
     return plot
 
 

--- a/pyirena/gui/sas_plot.py
+++ b/pyirena/gui/sas_plot.py
@@ -456,12 +456,32 @@ class SlopeLine(pg.GraphicsObject):
         self.update()
 
     def _reposition_label(self) -> None:
-        """Place the TextItem label at 75 % of the way along the visible x range."""
+        """Place the TextItem label at the midpoint of the visible line segment.
+
+        The line may enter/exit the view through the top or bottom edges.
+        Computing the visible segment prevents the label from being placed
+        outside the ViewBox clip region (where it would be invisible).
+        """
         vb = self.getViewBox()
         if vb is None or not hasattr(vb, 'viewRange'):
             return
-        [[x0, x1], _] = vb.viewRange()
-        xp = x0 + 0.75 * (x1 - x0)
+        [[x0, x1], [y0, y1]] = vb.viewRange()
+        y_lo, y_hi = min(y0, y1), max(y0, y1)
+
+        # Find the x range over which the line is within the visible y band.
+        # y = slope*x + offset  →  x = (y - offset) / slope
+        if abs(self.slope) > 1e-10:
+            x_at_ylo = (y_lo - self.log10_offset) / self.slope
+            x_at_yhi = (y_hi - self.log10_offset) / self.slope
+            x_lo_clip = max(x0, min(x_at_ylo, x_at_yhi))
+            x_hi_clip = min(x1, max(x_at_ylo, x_at_yhi))
+        else:
+            x_lo_clip, x_hi_clip = x0, x1
+
+        if x_lo_clip >= x_hi_clip:
+            return  # line is entirely outside the visible area
+
+        xp = (x_lo_clip + x_hi_clip) / 2.0
         yp = self.slope * xp + self.log10_offset
         self._label.setPos(xp, yp)
 
@@ -548,7 +568,8 @@ class SlopeLine(pg.GraphicsObject):
         change_act = menu.addAction('Change slope…')
         remove_act = menu.addAction('Remove this slope line')
 
-        chosen = menu.exec(ev.screenPos().toPoint())
+        # screenPos() returns QPoint in PySide6 (already integer coords)
+        chosen = menu.exec(ev.screenPos())
         if chosen == remove_act:
             vb = self.getViewBox()
             if vb is not None:

--- a/pyirena/gui/sas_plot.py
+++ b/pyirena/gui/sas_plot.py
@@ -443,7 +443,7 @@ class SlopeLine(pg.GraphicsObject):
         calls prepareGeometryChange() so Qt re-queries this when zoom changes.
         """
         vb = self.getViewBox()
-        if vb is None:
+        if vb is None or not hasattr(vb, 'viewRange'):
             return QRectF(-1e9, -1e9, 2e9, 2e9)
         [[x0, x1], [y0, y1]] = vb.viewRange()
         return QRectF(QPointF(x0, min(y0, y1)),
@@ -458,7 +458,7 @@ class SlopeLine(pg.GraphicsObject):
     def _reposition_label(self) -> None:
         """Place the TextItem label at 75 % of the way along the visible x range."""
         vb = self.getViewBox()
-        if vb is None:
+        if vb is None or not hasattr(vb, 'viewRange'):
             return
         [[x0, x1], _] = vb.viewRange()
         xp = x0 + 0.75 * (x1 - x0)
@@ -472,12 +472,12 @@ class SlopeLine(pg.GraphicsObject):
         so this restricts interactivity to a narrow strip around the line.
         """
         vb = self.getViewBox()
-        if vb is None:
+        if vb is None or not hasattr(vb, 'viewRange'):
             return QPainterPath()
         [[x0, x1], _] = vb.viewRange()
         ya = self.slope * x0 + self.log10_offset
         yb = self.slope * x1 + self.log10_offset
-        _, py = vb.viewPixelSize()
+        _, py = vb.viewPixelSize() if hasattr(vb, 'viewPixelSize') else (0, 0)
         band = 8.0 * abs(py) if py else 0.05
         path = QPainterPath()
         path.moveTo(QPointF(x0, ya - band))
@@ -489,7 +489,7 @@ class SlopeLine(pg.GraphicsObject):
 
     def paint(self, p, *args) -> None:
         vb = self.getViewBox()
-        if vb is None:
+        if vb is None or not hasattr(vb, 'viewRange'):
             return
         [[x0, x1], _] = vb.viewRange()
         ya = self.slope * x0 + self.log10_offset

--- a/pyirena/gui/sas_plot.py
+++ b/pyirena/gui/sas_plot.py
@@ -384,10 +384,10 @@ class SlopeLine(pg.GraphicsObject):
     In log-log ViewBox coordinates the power law I ∝ Q^n appears as a
     straight line  log10(I) = n · log10(Q) + b.  This item works entirely
     in ViewBox space (log10 on both axes), so it stays geometrically correct
-    at every zoom level without any range-change callbacks.
+    at every zoom level.
 
     Drag vertically to shift the line up/down (changes *b*).
-    Right-click the line to remove it.
+    Right-click the line to change slope or remove it.
     """
 
     # Palette of distinguishable colours so multiple lines are easy to tell apart
@@ -411,24 +411,31 @@ class SlopeLine(pg.GraphicsObject):
         self._hover_pen = pg.mkPen(color, width=3.0, style=Qt.PenStyle.DashLine)
         self._active_pen = self._pen
         self._font = QFont('Arial', 9)
-
-        # Drag state
-        self._dragging = False
-        self._drag_view_y0 = None       # ViewBox y coord at drag start
-        self._drag_offset0 = None       # log10_offset at drag start
+        self._drag_offset0 = None   # log10_offset at start of current drag
 
         self.setAcceptHoverEvents(True)
-        self.setCursor(Qt.CursorShape.SizeVerCursor)
-        self.setZValue(10)              # draw above data
+        # Do NOT call setCursor() here — it would apply to the full
+        # boundingRect() and permanently hijack the cursor over the entire
+        # viewport.  Set/unset it only in the hover callbacks instead.
+        self.setZValue(10)          # draw above data
 
     # ------------------------------------------------------------------
     # GraphicsObject protocol
     # ------------------------------------------------------------------
 
     def boundingRect(self) -> QRectF:
-        # Must fully encompass the painted region; use an enormous rect so
-        # pyqtgraph never culls it, regardless of the current view range.
-        return QRectF(-1e9, -1e9, 2e9, 2e9)
+        """Return a rect covering the current ViewBox range.
+
+        Returning the view rect (rather than an enormous fixed rect) keeps
+        the cursor scope limited to the actual plot area.  viewRangeChanged()
+        calls prepareGeometryChange() so Qt re-queries this when zoom changes.
+        """
+        vb = self.getViewBox()
+        if vb is None:
+            return QRectF(-1e9, -1e9, 2e9, 2e9)
+        [[x0, x1], [y0, y1]] = vb.viewRange()
+        return QRectF(QPointF(x0, min(y0, y1)),
+                      QPointF(x1, max(y0, y1))).normalized()
 
     def viewRangeChanged(self) -> None:
         """Called by pyqtgraph when the ViewBox is panned or zoomed."""
@@ -436,17 +443,19 @@ class SlopeLine(pg.GraphicsObject):
         self.update()
 
     def shape(self) -> QPainterPath:
-        """Hit-test path: a band of ~8 pixels around the line."""
+        """Hit-test path: a band of ~8 pixels around the line.
+
+        Qt uses shape() (via contains()) for hover and cursor dispatch,
+        so this restricts interactivity to a narrow strip around the line.
+        """
         vb = self.getViewBox()
         if vb is None:
             return QPainterPath()
         [[x0, x1], _] = vb.viewRange()
         ya = self.slope * x0 + self.log10_offset
         yb = self.slope * x1 + self.log10_offset
-        # Width of 8 pixels expressed in y ViewBox units
         _, py = vb.viewPixelSize()
-        band = 8.0 * abs(py)
-        # Build a thin parallelogram around the line
+        band = 8.0 * abs(py) if py else 0.05
         path = QPainterPath()
         path.moveTo(QPointF(x0, ya - band))
         path.lineTo(QPointF(x1, yb - band))
@@ -463,75 +472,69 @@ class SlopeLine(pg.GraphicsObject):
         ya = self.slope * x0 + self.log10_offset
         yb = self.slope * x1 + self.log10_offset
 
-        p1 = QPointF(x0, ya)   # already in ViewBox / item coords
-        p2 = QPointF(x1, yb)
-
         p.setPen(self._active_pen)
-        p.drawLine(p1, p2)
+        p.drawLine(QPointF(x0, ya), QPointF(x1, yb))
 
         # ── Label at the right-hand end, drawn in screen pixels ──────────
-        # p.transform() maps item coords → device (screen) pixels
-        screen_p2 = p.transform().map(p2)
+        # p.transform() maps item (= ViewBox) coords → device pixels.
+        # After resetTransform() the painter is in screen-pixel space.
+        screen_p2 = p.transform().map(QPointF(x1, yb))
         label = f'n = {self.slope:g}'
         p.save()
-        p.resetTransform()      # switch painter to screen-pixel coordinates
+        p.resetTransform()
         p.setFont(self._font)
         p.setPen(pg.mkPen(self._color))
         p.drawText(QPointF(screen_p2.x() + 4, screen_p2.y() - 4), label)
         p.restore()
 
     # ------------------------------------------------------------------
-    # Mouse interaction — drag vertically to shift offset
+    # Hover — set / restore cursor only when near the line
     # ------------------------------------------------------------------
 
     def hoverEnterEvent(self, ev) -> None:
         self._active_pen = self._hover_pen
+        self.setCursor(Qt.CursorShape.SizeVerCursor)
         self.update()
         ev.accept()
 
     def hoverLeaveEvent(self, ev) -> None:
         self._active_pen = self._pen
+        self.unsetCursor()
         self.update()
         ev.accept()
 
-    def mousePressEvent(self, ev) -> None:
-        if ev.button() == Qt.MouseButton.LeftButton:
-            self._dragging = True
-            vb = self.getViewBox()
-            # ev.pos() is in item (= ViewBox) coords
-            self._drag_view_y0 = ev.pos().y()
+    # ------------------------------------------------------------------
+    # Drag — use pyqtgraph's mouseDragEvent, NOT Qt's mouseMoveEvent.
+    # pyqtgraph intercepts press+move and routes them through mouseDragEvent;
+    # mouseMoveEvent is only called when no button is held.
+    # ------------------------------------------------------------------
+
+    def mouseDragEvent(self, ev) -> None:
+        if ev.button() != Qt.MouseButton.LeftButton:
+            ev.ignore()
+            return
+        ev.accept()
+        if ev.isStart():
             self._drag_offset0 = self.log10_offset
-            ev.accept()
-        else:
-            ev.ignore()
+        # ev.pos() and ev.buttonDownPos() are in item (= ViewBox) coordinates
+        dy = ev.pos().y() - ev.buttonDownPos().y()
+        self.log10_offset = self._drag_offset0 + dy
+        self.prepareGeometryChange()
+        self.update()
 
-    def mouseMoveEvent(self, ev) -> None:
-        if self._dragging:
-            dy = ev.pos().y() - self._drag_view_y0
-            self.log10_offset = self._drag_offset0 + dy
-            self.update()
-            ev.accept()
-        else:
-            ev.ignore()
-
-    def mouseReleaseEvent(self, ev) -> None:
-        if ev.button() == Qt.MouseButton.LeftButton:
-            self._dragging = False
-            ev.accept()
-        else:
-            ev.ignore()
+    # ------------------------------------------------------------------
+    # Right-click context menu on the line itself
+    # ------------------------------------------------------------------
 
     def contextMenuEvent(self, ev) -> None:
-        """Right-click on the line → change slope or remove."""
         try:
             from PySide6.QtWidgets import QMenu
         except ImportError:
             from PyQt6.QtWidgets import QMenu
         menu = QMenu()
-        lbl = menu.addAction(f'Slope line  n = {self.slope:g}  (drag to reposition)')
-        lbl.setEnabled(False)
+        hdr = menu.addAction(f'Slope line  n = {self.slope:g}  — drag to reposition')
+        hdr.setEnabled(False)
         menu.addSeparator()
-
         change_act = menu.addAction('Change slope…')
         remove_act = menu.addAction('Remove this slope line')
 
@@ -548,6 +551,7 @@ class SlopeLine(pg.GraphicsObject):
             )
             if ok:
                 self.slope = val
+                self.prepareGeometryChange()
                 self.update()
         ev.accept()
 
@@ -566,20 +570,22 @@ def add_slope_line_menu(plot: pg.PlotItem, default_slope: float = -4.0) -> None:
     plot : pg.PlotItem
         The target plot (must be in log-log mode for the lines to be meaningful).
     default_slope : float
-        Slope used when the user clicks "Add slope line (default)".
+        Slope inserted by the 'Custom slope…' dialog as the initial value.
     """
     vb = plot.getViewBox()
     menu = vb.menu
 
     def _add(slope: float) -> None:
-        # Position the line at the vertical centre of the current view
-        _, [y0, y1] = vb.viewRange()
-        offset = (y0 + y1) / 2.0
+        # Place the line so it passes through the visual centre of the
+        # current view: offset = yc - slope * xc
+        [[x0, x1], [y0, y1]] = vb.viewRange()
+        xc = (x0 + x1) / 2.0
+        yc = (y0 + y1) / 2.0
+        offset = yc - slope * xc
         line = SlopeLine(slope=slope, log10_offset=offset)
         vb.addItem(line)
 
     def _remove_all() -> None:
-        # Collect items to remove (can't mutate the list while iterating)
         to_remove = [it for it in vb.addedItems if isinstance(it, SlopeLine)]
         for it in to_remove:
             vb.removeItem(it)
@@ -595,19 +601,15 @@ def add_slope_line_menu(plot: pg.PlotItem, default_slope: float = -4.0) -> None:
 
     menu.addSeparator()
     slope_menu = menu.addMenu('Add slope guide line')
-
     presets = [(-2, 'n = −2'), (-3, 'n = −3'), (-4, 'n = −4  (Porod)'),
                (-5, 'n = −5'), (-6, 'n = −6')]
     for n, label in presets:
         act = slope_menu.addAction(label)
         act.triggered.connect(lambda checked=False, s=n: _add(s))
-
     slope_menu.addSeparator()
-    custom_act = slope_menu.addAction('Custom slope…')
-    custom_act.triggered.connect(_custom)
+    slope_menu.addAction('Custom slope…').triggered.connect(_custom)
 
-    remove_act = menu.addAction('Remove all slope lines')
-    remove_act.triggered.connect(_remove_all)
+    menu.addAction('Remove all slope lines').triggered.connect(_remove_all)
 
 
 # ===========================================================================

--- a/pyirena/gui/sas_plot.py
+++ b/pyirena/gui/sas_plot.py
@@ -151,6 +151,66 @@ class RadiusAxisItem(pg.AxisItem):
 
 
 # ===========================================================================
+# DSpacingAxisItem — top axis showing d = 2π/Q for WAXS lin-lin plots
+# ===========================================================================
+
+class DSpacingAxisItem(pg.AxisItem):
+    """Top axis for WAXS I(Q) lin-lin plots showing d-spacing d = 2π/Q [Å].
+
+    The ViewBox x-coordinates are physical Q [Å⁻¹] (linear scale).
+    This axis picks nice round d values (1, 2, 5, 10, 20, 50, … Å),
+    converts them to Q = 2π/d positions, and labels them.  Labels
+    decrease from left to right because d ∝ 1/Q.
+    """
+
+    _NICE_MULTIPLIERS = (1, 2, 5)
+    _MAX_TICKS = 8
+
+    def tickValues(self, minVal, maxVal, size):
+        import math
+        TWO_PI = 2.0 * math.pi
+        if minVal <= 0:
+            minVal = 1e-9
+        d_min = TWO_PI / maxVal   # smallest d visible (at largest Q)
+        d_max = TWO_PI / minVal   # largest d visible (at smallest Q)
+        if d_min <= 0 or d_max <= 0 or d_min >= d_max:
+            return []
+        decade_lo = math.floor(math.log10(d_min)) - 1
+        decade_hi = math.ceil(math.log10(d_max)) + 1
+        positions = []
+        for exp in range(int(decade_lo), int(decade_hi) + 1):
+            for mult in self._NICE_MULTIPLIERS:
+                d = mult * (10.0 ** exp)
+                if d_min <= d <= d_max:
+                    q_pos = TWO_PI / d
+                    if minVal <= q_pos <= maxVal:
+                        positions.append(q_pos)
+        if not positions:
+            return []
+        if len(positions) > self._MAX_TICKS:
+            step = max(1, len(positions) // self._MAX_TICKS)
+            positions = positions[::step]
+        return [(1.0, positions)]
+
+    def tickStrings(self, values, scale, spacing):
+        import math
+        TWO_PI = 2.0 * math.pi
+        strings = []
+        for v in values:
+            if v > 0:
+                d = TWO_PI / v
+                if d >= 10:
+                    strings.append(f'{d:.0f}')
+                elif d >= 1:
+                    strings.append(f'{d:.1f}')
+                else:
+                    strings.append(f'{d:.2f}')
+            else:
+                strings.append('')
+        return strings
+
+
+# ===========================================================================
 # _LimitedAxisItem — caps tick-label density on log/linear axes
 # ===========================================================================
 
@@ -326,6 +386,7 @@ def make_sas_plot(
     x_link=None,
     log_x: bool = True,
     log_y: bool = True,
+    d_spacing_axis: bool = False,
     parent_widget=None,
     jpeg_default_name: str = 'pyirena_graph',
 ) -> pg.PlotItem:
@@ -362,12 +423,16 @@ def make_sas_plot(
     axis_items = {}
     if log_x:
         axis_items['top'] = RadiusAxisItem(orientation='top')
+    elif d_spacing_axis:
+        axis_items['top'] = DSpacingAxisItem(orientation='top')
     plot = graphics_layout.addPlot(row=row, col=col, axisItems=axis_items)
     plot.setLogMode(x=log_x, y=log_y)
     plot.setLabel('left',   y_label)
     plot.setLabel('bottom', x_label)
     if log_x and 'top' in axis_items:
         plot.getAxis('top').setLabel('R = π/Q  (Å)', **{'color': '#888', 'font-size': '9pt'})
+    elif d_spacing_axis and 'top' in axis_items:
+        plot.getAxis('top').setLabel('d = 2π/Q  (Å)', **{'color': '#888', 'font-size': '9pt'})
     plot.showGrid(x=True, y=True, alpha=SASPlotStyle.GRID_ALPHA)
     plot.getAxis('left').enableAutoSIPrefix(False)
     plot.getAxis('bottom').enableAutoSIPrefix(False)

--- a/pyirena/gui/sas_plot.py
+++ b/pyirena/gui/sas_plot.py
@@ -47,11 +47,13 @@ from pathlib import Path
 import pyqtgraph as pg
 
 try:
-    from PySide6.QtWidgets import QFileDialog, QMessageBox
-    from PySide6.QtCore import Qt
+    from PySide6.QtWidgets import QFileDialog, QMessageBox, QInputDialog
+    from PySide6.QtCore import Qt, QPointF, QRectF
+    from PySide6.QtGui import QPainterPath, QPainterPathStroker, QFont, QPen
 except ImportError:
-    from PyQt6.QtWidgets import QFileDialog, QMessageBox
-    from PyQt6.QtCore import Qt
+    from PyQt6.QtWidgets import QFileDialog, QMessageBox, QInputDialog
+    from PyQt6.QtCore import Qt, QPointF, QRectF
+    from PyQt6.QtGui import QPainterPath, QPainterPathStroker, QFont, QPen
 
 
 # ===========================================================================
@@ -370,6 +372,242 @@ try:
     _install_sendDragEvent_safeguard()
 except Exception:
     pass
+
+
+# ===========================================================================
+# SlopeLine — draggable power-law slope guide line for log-log I(Q) plots
+# ===========================================================================
+
+class SlopeLine(pg.GraphicsObject):
+    """Draggable power-law slope guide line for log-log I(Q) vs Q plots.
+
+    In log-log ViewBox coordinates the power law I ∝ Q^n appears as a
+    straight line  log10(I) = n · log10(Q) + b.  This item works entirely
+    in ViewBox space (log10 on both axes), so it stays geometrically correct
+    at every zoom level without any range-change callbacks.
+
+    Drag vertically to shift the line up/down (changes *b*).
+    Right-click the line to remove it.
+    """
+
+    # Palette of distinguishable colours so multiple lines are easy to tell apart
+    _COLORS = ['#e67e22', '#8e44ad', '#2980b9', '#27ae60', '#c0392b',
+               '#16a085', '#f39c12', '#7f8c8d']
+    _color_index = 0  # class-level counter; cycles through _COLORS
+
+    def __init__(self, slope: float = -4.0, log10_offset: float = 0.0,
+                 color: str | None = None):
+        super().__init__()
+
+        self.slope = float(slope)
+        self.log10_offset = float(log10_offset)
+
+        if color is None:
+            color = SlopeLine._COLORS[SlopeLine._color_index % len(SlopeLine._COLORS)]
+            SlopeLine._color_index += 1
+
+        self._color = color
+        self._pen = pg.mkPen(color, width=1.8, style=Qt.PenStyle.DashLine)
+        self._hover_pen = pg.mkPen(color, width=3.0, style=Qt.PenStyle.DashLine)
+        self._active_pen = self._pen
+        self._font = QFont('Arial', 9)
+
+        # Drag state
+        self._dragging = False
+        self._drag_view_y0 = None       # ViewBox y coord at drag start
+        self._drag_offset0 = None       # log10_offset at drag start
+
+        self.setAcceptHoverEvents(True)
+        self.setCursor(Qt.CursorShape.SizeVerCursor)
+        self.setZValue(10)              # draw above data
+
+    # ------------------------------------------------------------------
+    # GraphicsObject protocol
+    # ------------------------------------------------------------------
+
+    def boundingRect(self) -> QRectF:
+        # Must fully encompass the painted region; use an enormous rect so
+        # pyqtgraph never culls it, regardless of the current view range.
+        return QRectF(-1e9, -1e9, 2e9, 2e9)
+
+    def viewRangeChanged(self) -> None:
+        """Called by pyqtgraph when the ViewBox is panned or zoomed."""
+        self.prepareGeometryChange()
+        self.update()
+
+    def shape(self) -> QPainterPath:
+        """Hit-test path: a band of ~8 pixels around the line."""
+        vb = self.getViewBox()
+        if vb is None:
+            return QPainterPath()
+        [[x0, x1], _] = vb.viewRange()
+        ya = self.slope * x0 + self.log10_offset
+        yb = self.slope * x1 + self.log10_offset
+        # Width of 8 pixels expressed in y ViewBox units
+        _, py = vb.viewPixelSize()
+        band = 8.0 * abs(py)
+        # Build a thin parallelogram around the line
+        path = QPainterPath()
+        path.moveTo(QPointF(x0, ya - band))
+        path.lineTo(QPointF(x1, yb - band))
+        path.lineTo(QPointF(x1, yb + band))
+        path.lineTo(QPointF(x0, ya + band))
+        path.closeSubpath()
+        return path
+
+    def paint(self, p, *args) -> None:
+        vb = self.getViewBox()
+        if vb is None:
+            return
+        [[x0, x1], _] = vb.viewRange()
+        ya = self.slope * x0 + self.log10_offset
+        yb = self.slope * x1 + self.log10_offset
+
+        p1 = QPointF(x0, ya)   # already in ViewBox / item coords
+        p2 = QPointF(x1, yb)
+
+        p.setPen(self._active_pen)
+        p.drawLine(p1, p2)
+
+        # ── Label at the right-hand end, drawn in screen pixels ──────────
+        # p.transform() maps item coords → device (screen) pixels
+        screen_p2 = p.transform().map(p2)
+        label = f'n = {self.slope:g}'
+        p.save()
+        p.resetTransform()      # switch painter to screen-pixel coordinates
+        p.setFont(self._font)
+        p.setPen(pg.mkPen(self._color))
+        p.drawText(QPointF(screen_p2.x() + 4, screen_p2.y() - 4), label)
+        p.restore()
+
+    # ------------------------------------------------------------------
+    # Mouse interaction — drag vertically to shift offset
+    # ------------------------------------------------------------------
+
+    def hoverEnterEvent(self, ev) -> None:
+        self._active_pen = self._hover_pen
+        self.update()
+        ev.accept()
+
+    def hoverLeaveEvent(self, ev) -> None:
+        self._active_pen = self._pen
+        self.update()
+        ev.accept()
+
+    def mousePressEvent(self, ev) -> None:
+        if ev.button() == Qt.MouseButton.LeftButton:
+            self._dragging = True
+            vb = self.getViewBox()
+            # ev.pos() is in item (= ViewBox) coords
+            self._drag_view_y0 = ev.pos().y()
+            self._drag_offset0 = self.log10_offset
+            ev.accept()
+        else:
+            ev.ignore()
+
+    def mouseMoveEvent(self, ev) -> None:
+        if self._dragging:
+            dy = ev.pos().y() - self._drag_view_y0
+            self.log10_offset = self._drag_offset0 + dy
+            self.update()
+            ev.accept()
+        else:
+            ev.ignore()
+
+    def mouseReleaseEvent(self, ev) -> None:
+        if ev.button() == Qt.MouseButton.LeftButton:
+            self._dragging = False
+            ev.accept()
+        else:
+            ev.ignore()
+
+    def contextMenuEvent(self, ev) -> None:
+        """Right-click on the line → change slope or remove."""
+        try:
+            from PySide6.QtWidgets import QMenu
+        except ImportError:
+            from PyQt6.QtWidgets import QMenu
+        menu = QMenu()
+        lbl = menu.addAction(f'Slope line  n = {self.slope:g}  (drag to reposition)')
+        lbl.setEnabled(False)
+        menu.addSeparator()
+
+        change_act = menu.addAction('Change slope…')
+        remove_act = menu.addAction('Remove this slope line')
+
+        chosen = menu.exec(ev.screenPos().toPoint())
+        if chosen == remove_act:
+            vb = self.getViewBox()
+            if vb is not None:
+                vb.removeItem(self)
+        elif chosen == change_act:
+            val, ok = QInputDialog.getDouble(
+                None, 'Change slope',
+                'Power-law exponent  n  (e.g. −4 for Porod):',
+                self.slope, -8.0, -0.5, 2,
+            )
+            if ok:
+                self.slope = val
+                self.update()
+        ev.accept()
+
+
+# ---------------------------------------------------------------------------
+
+def add_slope_line_menu(plot: pg.PlotItem, default_slope: float = -4.0) -> None:
+    """Attach a 'Slope guide line' submenu to a PlotItem's ViewBox right-click menu.
+
+    Slope lines are guide lines with a fixed power-law slope drawn in log-log
+    ViewBox space.  They are geometrically correct at any zoom level and can be
+    dragged vertically to align with the data.
+
+    Parameters
+    ----------
+    plot : pg.PlotItem
+        The target plot (must be in log-log mode for the lines to be meaningful).
+    default_slope : float
+        Slope used when the user clicks "Add slope line (default)".
+    """
+    vb = plot.getViewBox()
+    menu = vb.menu
+
+    def _add(slope: float) -> None:
+        # Position the line at the vertical centre of the current view
+        _, [y0, y1] = vb.viewRange()
+        offset = (y0 + y1) / 2.0
+        line = SlopeLine(slope=slope, log10_offset=offset)
+        vb.addItem(line)
+
+    def _remove_all() -> None:
+        # Collect items to remove (can't mutate the list while iterating)
+        to_remove = [it for it in vb.addedItems if isinstance(it, SlopeLine)]
+        for it in to_remove:
+            vb.removeItem(it)
+
+    def _custom() -> None:
+        val, ok = QInputDialog.getDouble(
+            None, 'Add slope line',
+            'Power-law exponent  n  (e.g. −4 for Porod):',
+            default_slope, -8.0, -0.5, 2,
+        )
+        if ok:
+            _add(val)
+
+    menu.addSeparator()
+    slope_menu = menu.addMenu('Add slope guide line')
+
+    presets = [(-2, 'n = −2'), (-3, 'n = −3'), (-4, 'n = −4  (Porod)'),
+               (-5, 'n = −5'), (-6, 'n = −6')]
+    for n, label in presets:
+        act = slope_menu.addAction(label)
+        act.triggered.connect(lambda checked=False, s=n: _add(s))
+
+    slope_menu.addSeparator()
+    custom_act = slope_menu.addAction('Custom slope…')
+    custom_act.triggered.connect(_custom)
+
+    remove_act = menu.addAction('Remove all slope lines')
+    remove_act.triggered.connect(_remove_all)
 
 
 # ===========================================================================

--- a/pyirena/gui/sas_plot.py
+++ b/pyirena/gui/sas_plot.py
@@ -410,13 +410,25 @@ class SlopeLine(pg.GraphicsObject):
         self._pen = pg.mkPen(color, width=1.8, style=Qt.PenStyle.DashLine)
         self._hover_pen = pg.mkPen(color, width=3.0, style=Qt.PenStyle.DashLine)
         self._active_pen = self._pen
-        self._font = QFont('Arial', 9)
         self._drag_offset0 = None   # log10_offset at start of current drag
 
+        # Label — a TextItem child so it always renders at screen pixel size
+        # and follows the line during pan/zoom/drag automatically.
+        self._label = pg.TextItem(
+            text=f'n = {slope:g}',
+            color=color,
+            anchor=(0.5, 1),            # centre-bottom of text box at the set position
+            fill=pg.mkBrush(255, 255, 255, 180),   # semi-transparent white backing
+        )
+        self._label.setFont(QFont('Arial', 9, QFont.Weight.Bold))
+        self._label.setParentItem(self)
+        # Temporary initial position; updated by viewRangeChanged() once added to a ViewBox.
+        self._label.setPos(0.0, log10_offset)
+
         self.setAcceptHoverEvents(True)
-        # Do NOT call setCursor() here — it would apply to the full
-        # boundingRect() and permanently hijack the cursor over the entire
-        # viewport.  Set/unset it only in the hover callbacks instead.
+        # Do NOT call setCursor() here — applying it in __init__ would affect
+        # the full boundingRect() and permanently hijack the cursor everywhere.
+        # We set/unset it inside hoverEvent() instead.
         self.setZValue(10)          # draw above data
 
     # ------------------------------------------------------------------
@@ -440,7 +452,18 @@ class SlopeLine(pg.GraphicsObject):
     def viewRangeChanged(self) -> None:
         """Called by pyqtgraph when the ViewBox is panned or zoomed."""
         self.prepareGeometryChange()
+        self._reposition_label()
         self.update()
+
+    def _reposition_label(self) -> None:
+        """Place the TextItem label at 75 % of the way along the visible x range."""
+        vb = self.getViewBox()
+        if vb is None:
+            return
+        [[x0, x1], _] = vb.viewRange()
+        xp = x0 + 0.75 * (x1 - x0)
+        yp = self.slope * xp + self.log10_offset
+        self._label.setPos(xp, yp)
 
     def shape(self) -> QPainterPath:
         """Hit-test path: a band of ~8 pixels around the line.
@@ -471,37 +494,23 @@ class SlopeLine(pg.GraphicsObject):
         [[x0, x1], _] = vb.viewRange()
         ya = self.slope * x0 + self.log10_offset
         yb = self.slope * x1 + self.log10_offset
-
         p.setPen(self._active_pen)
         p.drawLine(QPointF(x0, ya), QPointF(x1, yb))
-
-        # ── Label at the right-hand end, drawn in screen pixels ──────────
-        # p.transform() maps item (= ViewBox) coords → device pixels.
-        # After resetTransform() the painter is in screen-pixel space.
-        screen_p2 = p.transform().map(QPointF(x1, yb))
-        label = f'n = {self.slope:g}'
-        p.save()
-        p.resetTransform()
-        p.setFont(self._font)
-        p.setPen(pg.mkPen(self._color))
-        p.drawText(QPointF(screen_p2.x() + 4, screen_p2.y() - 4), label)
-        p.restore()
+        # Label is drawn by the TextItem child — no label code here.
 
     # ------------------------------------------------------------------
-    # Hover — set / restore cursor only when near the line
+    # Hover — use pyqtgraph's hoverEvent (has reliable isExit()) rather
+    # than Qt's hoverEnterEvent / hoverLeaveEvent which can stay "stuck".
     # ------------------------------------------------------------------
 
-    def hoverEnterEvent(self, ev) -> None:
-        self._active_pen = self._hover_pen
-        self.setCursor(Qt.CursorShape.SizeVerCursor)
+    def hoverEvent(self, ev) -> None:
+        if ev.isExit():
+            self._active_pen = self._pen
+            self.unsetCursor()
+        else:
+            self._active_pen = self._hover_pen
+            self.setCursor(Qt.CursorShape.SizeVerCursor)
         self.update()
-        ev.accept()
-
-    def hoverLeaveEvent(self, ev) -> None:
-        self._active_pen = self._pen
-        self.unsetCursor()
-        self.update()
-        ev.accept()
 
     # ------------------------------------------------------------------
     # Drag — use pyqtgraph's mouseDragEvent, NOT Qt's mouseMoveEvent.
@@ -519,6 +528,7 @@ class SlopeLine(pg.GraphicsObject):
         # ev.pos() and ev.buttonDownPos() are in item (= ViewBox) coordinates
         dy = ev.pos().y() - ev.buttonDownPos().y()
         self.log10_offset = self._drag_offset0 + dy
+        self._reposition_label()
         self.prepareGeometryChange()
         self.update()
 
@@ -551,6 +561,8 @@ class SlopeLine(pg.GraphicsObject):
             )
             if ok:
                 self.slope = val
+                self._label.setText(f'n = {val:g}')
+                self._reposition_label()
                 self.prepareGeometryChange()
                 self.update()
         ev.accept()

--- a/pyirena/gui/sas_plot.py
+++ b/pyirena/gui/sas_plot.py
@@ -553,14 +553,27 @@ class SlopeLine(pg.GraphicsObject):
         self.update()
 
     # ------------------------------------------------------------------
-    # Right-click context menu on the line itself
+    # Right-click — use pyqtgraph's getContextMenus() hook rather than
+    # Qt's contextMenuEvent().  GraphicsScene calls getContextMenus() on
+    # items found near the click and combines results; returning [] lets
+    # the normal ViewBox menu show through unmodified.
     # ------------------------------------------------------------------
 
-    def contextMenuEvent(self, ev) -> None:
+    def getContextMenus(self, ev):
+        """Return slope-line actions when right-clicking near the line.
+
+        Called by pyqtgraph's GraphicsScene.contextMenuEvent.  Returning []
+        when the click is away from the line passes control to the ViewBox
+        so the standard graph menu is unaffected.
+        """
+        if not self.shape().contains(ev.pos()):
+            return []
+
         try:
             from PySide6.QtWidgets import QMenu
         except ImportError:
             from PyQt6.QtWidgets import QMenu
+
         menu = QMenu()
         hdr = menu.addAction(f'Slope line  n = {self.slope:g}  — drag to reposition')
         hdr.setEnabled(False)
@@ -568,13 +581,7 @@ class SlopeLine(pg.GraphicsObject):
         change_act = menu.addAction('Change slope…')
         remove_act = menu.addAction('Remove this slope line')
 
-        # screenPos() returns QPoint in PySide6 (already integer coords)
-        chosen = menu.exec(ev.screenPos())
-        if chosen == remove_act:
-            vb = self.getViewBox()
-            if vb is not None:
-                vb.removeItem(self)
-        elif chosen == change_act:
+        def _change():
             val, ok = QInputDialog.getDouble(
                 None, 'Change slope',
                 'Power-law exponent  n  (e.g. −4 for Porod):',
@@ -586,7 +593,15 @@ class SlopeLine(pg.GraphicsObject):
                 self._reposition_label()
                 self.prepareGeometryChange()
                 self.update()
-        ev.accept()
+
+        def _remove():
+            vb = self.getViewBox()
+            if vb is not None:
+                vb.removeItem(self)
+
+        change_act.triggered.connect(_change)
+        remove_act.triggered.connect(_remove)
+        return [menu]
 
 
 # ---------------------------------------------------------------------------

--- a/pyirena/gui/simple_fits_panel.py
+++ b/pyirena/gui/simple_fits_panel.py
@@ -548,6 +548,10 @@ class SimpleFitsPanel(QWidget):
             QPushButton { background-color: #27ae60; color: white; font-weight: bold; font-size: 13px; }
             QPushButton:hover { background-color: #1e8449; }
         """)
+        self.fit_btn.setToolTip(
+            "Fit the selected model to the loaded data using the current Q range.\n"
+            "Checked parameters are varied; unchecked parameters are held fixed."
+        )
         self.fit_btn.clicked.connect(self._run_fit)
         btn_row1.addWidget(self.fit_btn)
         layout.addLayout(btn_row1)
@@ -568,6 +572,10 @@ class SimpleFitsPanel(QWidget):
             QPushButton { background-color: #16a085; color: white; font-weight: bold; }
             QPushButton:hover { background-color: #1abc9c; }
         """)
+        self.unc_btn.setToolTip(
+            "Estimate parameter uncertainties by repeating the fit on noise-perturbed data.\n"
+            "Set 'Passes' to control how many Monte Carlo replicates are used."
+        )
         self.unc_btn.clicked.connect(self._calculate_uncertainty)
         btn_row_unc.addWidget(self.unc_btn)
         layout.addLayout(btn_row_unc)
@@ -638,20 +646,22 @@ class SimpleFitsPanel(QWidget):
 
         # Row 3: Export | Import parameters
         row_out3 = QHBoxLayout()
-        self.export_btn = QPushButton('Export parameters')
+        self.export_btn = QPushButton('Save params to JSON')
         self.export_btn.setMinimumHeight(26)
         self.export_btn.setStyleSheet('background-color: lightgreen;')
         self.export_btn.setToolTip(
-            'Export current parameters to a pyIrena JSON configuration file.'
+            'Save current fit parameters to a pyIrena JSON file.\n'
+            'Use "Load params from JSON" to restore them later.'
         )
         self.export_btn.clicked.connect(self._export_parameters)
         row_out3.addWidget(self.export_btn)
 
-        self.import_btn = QPushButton('Import parameters')
+        self.import_btn = QPushButton('Load params from JSON')
         self.import_btn.setMinimumHeight(26)
         self.import_btn.setStyleSheet('background-color: lightgreen;')
         self.import_btn.setToolTip(
-            'Import parameters from a pyIrena JSON configuration file.'
+            'Load fit parameters from a previously saved pyIrena JSON file.\n'
+            'Use "Save params to JSON" to create a compatible file.'
         )
         self.import_btn.clicked.connect(self._import_parameters)
         row_out3.addWidget(self.import_btn)

--- a/pyirena/gui/sizes_panel.py
+++ b/pyirena/gui/sizes_panel.py
@@ -34,7 +34,7 @@ from pathlib import Path
 import pyqtgraph as pg
 
 from pyirena.core.sizes import SizesDistribution
-from pyirena.gui.sas_plot import RadiusAxisItem, save_itx_from_plot
+from pyirena.gui.sas_plot import RadiusAxisItem, save_itx_from_plot, add_slope_line_menu
 from pyirena.state.state_manager import StateManager
 
 
@@ -205,6 +205,7 @@ class SizesFitGraphWindow(QWidget):
 
         # ── Main I(Q) plot  (log-log) ────────────────────────────────────────
         self.main_plot.setLogMode(x=True, y=True)
+        add_slope_line_menu(self.main_plot)
         # Use units IN the label string — avoids pyqtgraph's SI-prefix auto-scaling
         self.main_plot.setLabel('left',   'I  (cm⁻¹)')
         self.main_plot.setLabel('bottom', 'Q  (Å⁻¹)')

--- a/pyirena/gui/sizes_panel.py
+++ b/pyirena/gui/sizes_panel.py
@@ -1078,6 +1078,8 @@ class SizesFitPanel(QWidget):
                 btn.setMaximumWidth(36)
                 btn.setMaximumHeight(22)
                 btn.setStyleSheet("font-size:10px; padding:1px 3px;")
+            btn_div.setToolTip("Divide this parameter value by 10.")
+            btn_mul.setToolTip("Multiply this parameter value by 10.")
             btn_div.clicked.connect(lambda _=False, e=edit: self._scale_edit(e, 0.1))
             btn_mul.clicked.connect(lambda _=False, e=edit: self._scale_edit(e, 10.0))
             row.addWidget(btn_div)
@@ -1321,6 +1323,7 @@ class SizesFitPanel(QWidget):
         pl_cursor_btn = QPushButton("Set Q from cursors")
         pl_cursor_btn.setMaximumHeight(22)
         pl_cursor_btn.setStyleSheet("font-size:10px; padding:1px 4px;")
+        pl_cursor_btn.setToolTip("Set the power-law Q range from the current cursor positions.")
         pl_cursor_btn.clicked.connect(self._set_pl_q_from_cursors)
         pl_cursor_row.addWidget(pl_cursor_btn)
         pl_cursor_row.addStretch()
@@ -1332,6 +1335,10 @@ class SizesFitPanel(QWidget):
             QPushButton { background-color: #8e44ad; color: white; font-weight: bold; }
             QPushButton:hover { background-color: #7d3c98; }
         """)
+        self.fit_pl_button.setToolTip(
+            "Fit a power-law B·Q⁻ᴾ to the data within the Q range above.\n"
+            "Result sets P and B starting values for the size distribution fit."
+        )
         self.fit_pl_button.clicked.connect(self.fit_power_law_action)
         pl_layout.addWidget(self.fit_pl_button)
 
@@ -1383,6 +1390,7 @@ class SizesFitPanel(QWidget):
         bg_cursor_btn = QPushButton("Set Q from cursors")
         bg_cursor_btn.setMaximumHeight(22)
         bg_cursor_btn.setStyleSheet("font-size:10px; padding:1px 4px;")
+        bg_cursor_btn.setToolTip("Set the background Q range from the current cursor positions.")
         bg_cursor_btn.clicked.connect(self._set_bg_q_from_cursors)
         bg_cursor_row.addWidget(bg_cursor_btn)
         bg_cursor_row.addStretch()
@@ -1394,6 +1402,10 @@ class SizesFitPanel(QWidget):
             QPushButton { background-color: #8e44ad; color: white; font-weight: bold; }
             QPushButton:hover { background-color: #7d3c98; }
         """)
+        self.fit_bg_button.setToolTip(
+            "Fit a flat background constant to data within the Q range above.\n"
+            "Result sets the Background starting value for the size distribution fit."
+        )
         self.fit_bg_button.clicked.connect(self.fit_background_action)
         flat_layout.addWidget(self.fit_bg_button)
 
@@ -1413,6 +1425,10 @@ class SizesFitPanel(QWidget):
             QPushButton { background-color: #52c77a; color: white; font-weight: bold; }
             QPushButton:hover { background-color: #3eb56a; }
         """)
+        self.graph_button.setToolTip(
+            "Compute and display the current size distribution model without fitting.\n"
+            "Use this to preview the model before running a fit."
+        )
         self.graph_button.clicked.connect(self.compute_model)
         btn_row1.addWidget(self.graph_button)
 
@@ -1422,6 +1438,10 @@ class SizesFitPanel(QWidget):
             QPushButton { background-color: #27ae60; color: white; font-weight: bold; font-size: 12px; }
             QPushButton:hover { background-color: #1e8449; }
         """)
+        self.fit_button.setToolTip(
+            "Fit the size distribution model to the loaded data.\n"
+            "Uses the Q range defined by the cursors."
+        )
         self.fit_button.clicked.connect(self.run_fit)
         btn_row1.addWidget(self.fit_button)
 
@@ -1431,6 +1451,10 @@ class SizesFitPanel(QWidget):
             QPushButton { background-color: #2980b9; color: white; font-weight: bold; font-size: 12px; }
             QPushButton:hover { background-color: #1f618d; }
         """)
+        self.fit_all_button.setToolTip(
+            "Fit all selected files sequentially using the current parameters.\n"
+            "Results are stored to each file automatically."
+        )
         self.fit_all_button.clicked.connect(self.fit_all_action)
         btn_row1.addWidget(self.fit_all_button)
 
@@ -1451,6 +1475,10 @@ class SizesFitPanel(QWidget):
             QPushButton { background-color: #16a085; color: white; font-weight: bold; }
             QPushButton:hover { background-color: #1abc9c; }
         """)
+        self.uncertainty_button.setToolTip(
+            "Estimate parameter uncertainties by repeating the fit on noise-perturbed data.\n"
+            "Set 'Passes' to control how many Monte Carlo replicates are used."
+        )
         self.uncertainty_button.clicked.connect(self.calculate_uncertainty)
         btn_row_unc.addWidget(self.uncertainty_button)
         layout.addLayout(btn_row_unc)
@@ -1463,6 +1491,10 @@ class SizesFitPanel(QWidget):
             QPushButton { background-color: #e67e22; color: white; font-weight: bold; }
             QPushButton:hover { background-color: #f39c12; }
         """)
+        self.revert_button.setToolTip(
+            "Restore all parameters to the values they had before the last fit.\n"
+            "Useful if a fit diverged or gave unreasonable results."
+        )
         self.revert_button.clicked.connect(self._revert)
         btn_row2.addWidget(self.revert_button)
 
@@ -1472,6 +1504,10 @@ class SizesFitPanel(QWidget):
             QPushButton { background-color: #e67e22; color: white; font-weight: bold; }
             QPushButton:hover { background-color: #d35400; }
         """)
+        self.reset_button.setToolTip(
+            "Reset all parameters to their factory default values.\n"
+            "This cannot be undone — use 'Revert' to undo only the last fit."
+        )
         self.reset_button.clicked.connect(self.reset_to_defaults)
         btn_row2.addWidget(self.reset_button)
 
@@ -1538,12 +1574,20 @@ class SizesFitPanel(QWidget):
             QPushButton { background-color: #3498db; color: white; font-weight: bold; }
             QPushButton:hover { background-color: #2980b9; }
         """)
+        self.save_state_button.setToolTip(
+            "Save current parameters and settings to the pyIrena state file.\n"
+            "State is restored automatically when the file is reopened."
+        )
         self.save_state_button.clicked.connect(self.save_state)
         store_row.addWidget(self.save_state_button)
 
         self.store_file_button = QPushButton("Store in File")
         self.store_file_button.setMinimumHeight(26)
         self.store_file_button.setStyleSheet("background-color: lightgreen;")
+        self.store_file_button.setToolTip(
+            "Save fit results (parameters and model curves) into the source HDF5/NXcanSAS file.\n"
+            "Results are appended as a pyirena NXprocess group."
+        )
         self.store_file_button.clicked.connect(self.store_results_to_file)
         store_row.addWidget(self.store_file_button)
 
@@ -1552,20 +1596,22 @@ class SizesFitPanel(QWidget):
         # ── Export / Import Parameters buttons ───────────────────────────────
         params_row = QHBoxLayout()
 
-        self.export_params_button = QPushButton("Export Parameters")
+        self.export_params_button = QPushButton("Save params to JSON")
         self.export_params_button.setMinimumHeight(26)
         self.export_params_button.setStyleSheet("background-color: lightgreen;")
         self.export_params_button.setToolTip(
-            "Export current Sizes parameters to a pyIrena JSON config file."
+            "Save current Sizes parameters to a pyIrena JSON file.\n"
+            "Use 'Load params from JSON' to restore them later."
         )
         self.export_params_button.clicked.connect(self.export_parameters)
         params_row.addWidget(self.export_params_button)
 
-        self.import_params_button = QPushButton("Import Parameters")
+        self.import_params_button = QPushButton("Load params from JSON")
         self.import_params_button.setMinimumHeight(26)
         self.import_params_button.setStyleSheet("background-color: lightgreen;")
         self.import_params_button.setToolTip(
-            "Load Sizes parameters from a pyIrena JSON config file."
+            "Load Sizes parameters from a previously saved pyIrena JSON file.\n"
+            "Use 'Save params to JSON' to create a compatible file."
         )
         self.import_params_button.clicked.connect(self.import_parameters)
         params_row.addWidget(self.import_params_button)

--- a/pyirena/gui/unified_fit.py
+++ b/pyirena/gui/unified_fit.py
@@ -565,12 +565,12 @@ class UnifiedFitGraphWindow(QWidget):
             ax.setTextPen('k')
             ax.enableAutoSIPrefix(False)
 
-        # Show top and right axes (without labels) to create a box
+        # Show top axis (RadiusAxisItem) with values and right axis as a box border
         self.main_plot.showAxis('top')
         self.main_plot.showAxis('right')
         self.main_plot.getAxis('top').setPen('k')
+        self.main_plot.getAxis('top').setTextPen('#888')
         self.main_plot.getAxis('right').setPen('k')
-        self.main_plot.getAxis('top').setStyle(showValues=False)
         self.main_plot.getAxis('right').setStyle(showValues=False)
 
         # Enable auto-range
@@ -1141,6 +1141,7 @@ class LevelParametersWidget(QWidget):
     def __init__(self, level_number: int, parent=None):
         super().__init__(parent)
         self.level_number = level_number
+        self._limits_visible = True  # tracks current state of "No limits?" (True = limits shown)
         self.init_ui()
 
     def init_ui(self):
@@ -1253,6 +1254,10 @@ class LevelParametersWidget(QWidget):
         # Calculate width to align with high limit field (roughly 35% of total width)
         button_width = 140  # Approximate width for 35%
         self.fit_rg_g_button.setMaximumWidth(button_width)
+        self.fit_rg_g_button.setToolTip(
+            "Fit Rg and G for this level using data between the two cursors.\n"
+            "Results are applied as starting values for the full Unified Fit."
+        )
         fit_rg_g_layout.addWidget(self.fit_rg_g_button)
         layout.addLayout(fit_rg_g_layout)
 
@@ -1332,6 +1337,10 @@ class LevelParametersWidget(QWidget):
         self.fit_p_b_button = QPushButton("Fit P/B btwn cursors")
         self.fit_p_b_button.setMinimumHeight(24)
         self.fit_p_b_button.setMaximumWidth(button_width)
+        self.fit_p_b_button.setToolTip(
+            "Fit power-law exponent P and prefactor B using data between the two cursors.\n"
+            "Results are applied as starting values for the full Unified Fit."
+        )
         fit_p_b_layout.addWidget(self.fit_p_b_button)
         layout.addLayout(fit_p_b_layout)
 
@@ -1422,6 +1431,10 @@ class LevelParametersWidget(QWidget):
         # Copy/Swap button
         self.copy_move_button = QPushButton("Copy/Swap level")
         self.copy_move_button.setMinimumHeight(24)
+        self.copy_move_button.setToolTip(
+            "Copy or swap parameters between this level and another level.\n"
+            "Useful for reorganizing levels or duplicating a good starting guess."
+        )
         layout.addWidget(self.copy_move_button)
 
         # Calculated values display - Sv and Invariant
@@ -1480,6 +1493,7 @@ class LevelParametersWidget(QWidget):
 
     def toggle_limits_visibility(self, show: bool):
         """Show or hide all limit fields and headers."""
+        self._limits_visible = show
         for field in self.limit_fields:
             # Don't show B limits if estimate_B is checked
             if field in [self.b_low, self.b_high] and self.estimate_b_check.isChecked():
@@ -1619,10 +1633,9 @@ class LevelParametersWidget(QWidget):
             # Re-enable B fit checkbox
             self.b_fit.setEnabled(True)
 
-            # Show B limit fields (unless "No limits?" is checked globally)
-            # This will be handled by the parent's toggle_limits_visibility if needed
-            self.b_low.setVisible(True)
-            self.b_high.setVisible(True)
+            # Show B limit fields only if limits are currently visible ("No limits?" unchecked)
+            self.b_low.setVisible(self._limits_visible)
+            self.b_high.setVisible(self._limits_visible)
 
         self.parameter_changed.emit()
 
@@ -2209,6 +2222,10 @@ class UnifiedFitPanel(QWidget):
                 background-color: #3eb56a;
             }
         """)
+        self.graph_unified_button.setToolTip(
+            "Compute and display the current Unified Fit model without fitting.\n"
+            "Use this to preview the model before running a fit."
+        )
         self.graph_unified_button.clicked.connect(self.graph_unified)
         fit_buttons.addWidget(self.graph_unified_button)
         fit_buttons.addStretch()
@@ -2227,6 +2244,10 @@ class UnifiedFitPanel(QWidget):
                 background-color: #1e8449;
             }
         """)
+        self.fit_button.setToolTip(
+            "Fit the Unified Fit model to the loaded data using the current parameters.\n"
+            "Results are displayed in the graph and the Results section below."
+        )
         self.fit_button.clicked.connect(self.run_fit)
         fit_buttons.addWidget(self.fit_button)
 
@@ -2243,6 +2264,10 @@ class UnifiedFitPanel(QWidget):
                 background-color: #f39c12;
             }
         """)
+        self.revert_button.setToolTip(
+            "Restore all parameters to the values they had before the last fit.\n"
+            "Useful if a fit diverged or gave unreasonable results."
+        )
         self.revert_button.clicked.connect(self.revert_to_backup)
         fit_buttons.addWidget(self.revert_button)
 
@@ -2259,6 +2284,10 @@ class UnifiedFitPanel(QWidget):
                 background-color: #2ecc71;
             }
         """)
+        self.fix_limits_button.setToolTip(
+            "Set all fit limits to ±5× the current parameter values.\n"
+            "Convenient starting point before running a constrained fit."
+        )
         self.fix_limits_button.clicked.connect(self.fix_all_limits)
         fit_buttons.addWidget(self.fix_limits_button)
 
@@ -2279,6 +2308,10 @@ class UnifiedFitPanel(QWidget):
                 background-color: #d35400;
             }
         """)
+        self.reset_button.setToolTip(
+            "Reset all parameters to their factory default values.\n"
+            "This cannot be undone — use 'Revert back' to undo only the last fit."
+        )
         self.reset_button.clicked.connect(self.reset_to_defaults)
         additional_buttons.addWidget(self.reset_button)
 
@@ -2311,12 +2344,20 @@ class UnifiedFitPanel(QWidget):
                 background-color: #2980b9;
             }
         """)
+        self.save_state_button.setToolTip(
+            "Save current parameters and settings to the pyIrena state file.\n"
+            "State is restored automatically when the file is reopened."
+        )
         self.save_state_button.clicked.connect(self.save_state)
         results_buttons1.addWidget(self.save_state_button)
 
         self.store_data_button = QPushButton("Store in File")
         self.store_data_button.setMinimumHeight(26)
         self.store_data_button.setStyleSheet("background-color: lightgreen;")
+        self.store_data_button.setToolTip(
+            "Save fit results (parameters and model curve) into the source HDF5/NXcanSAS file.\n"
+            "Results are appended as a pyirena NXprocess group."
+        )
         self.store_data_button.clicked.connect(self.store_results_to_file)
         results_buttons1.addWidget(self.store_data_button)
 
@@ -2332,6 +2373,10 @@ class UnifiedFitPanel(QWidget):
                 background-color: #66bb6a;
             }
         """)
+        self.results_graphs_button.setToolTip(
+            "Plot fit results for all selected files in the data selector.\n"
+            "Useful for comparing parameters across a dataset."
+        )
         self.results_graphs_button.clicked.connect(self.display_results_on_graph)
         results_buttons1.addWidget(self.results_graphs_button)
 
@@ -2340,15 +2385,23 @@ class UnifiedFitPanel(QWidget):
         # Results buttons row 2
         results_buttons2 = QHBoxLayout()
 
-        self.export_params_button = QPushButton("Export Parameters")
+        self.export_params_button = QPushButton("Save params to JSON")
         self.export_params_button.setMinimumHeight(26)
         self.export_params_button.setStyleSheet("background-color: lightgreen;")
+        self.export_params_button.setToolTip(
+            "Save current Unified Fit parameters to a pyIrena JSON file.\n"
+            "Use 'Load params from JSON' to restore them later."
+        )
         self.export_params_button.clicked.connect(self.export_parameters)
         results_buttons2.addWidget(self.export_params_button)
 
-        self.import_params_button = QPushButton("Import Parameters")
+        self.import_params_button = QPushButton("Load params from JSON")
         self.import_params_button.setMinimumHeight(26)
         self.import_params_button.setStyleSheet("background-color: lightgreen;")
+        self.import_params_button.setToolTip(
+            "Load Unified Fit parameters from a previously saved pyIrena JSON file.\n"
+            "Use 'Save params to JSON' to create a compatible file."
+        )
         self.import_params_button.clicked.connect(self.import_parameters)
         results_buttons2.addWidget(self.import_params_button)
 
@@ -2370,6 +2423,10 @@ class UnifiedFitPanel(QWidget):
             QPushButton { background-color: #16a085; color: white; font-weight: bold; }
             QPushButton:hover { background-color: #1abc9c; }
         """)
+        self.analyze_results_button.setToolTip(
+            "Estimate parameter uncertainties by repeating the fit on noise-perturbed data.\n"
+            "Set 'Passes' to control how many Monte Carlo replicates are used."
+        )
         self.analyze_results_button.clicked.connect(self.analyze_results)
         results_buttons3.addWidget(self.analyze_results_button)
 

--- a/pyirena/gui/unified_fit.py
+++ b/pyirena/gui/unified_fit.py
@@ -42,7 +42,9 @@ except ImportError:
 import pyqtgraph as pg
 
 from pyirena.core.unified import UnifiedFitModel, UnifiedLevel
-from pyirena.gui.sas_plot import RadiusAxisItem, _LimitedAxisItem, save_itx_from_plot
+from pyirena.gui.sas_plot import (
+    RadiusAxisItem, _LimitedAxisItem, save_itx_from_plot, add_slope_line_menu,
+)
 from pyirena.state import StateManager
 
 
@@ -572,6 +574,9 @@ class UnifiedFitGraphWindow(QWidget):
         self.main_plot.getAxis('top').setTextPen('#888')
         self.main_plot.getAxis('right').setPen('k')
         self.main_plot.getAxis('right').setStyle(showValues=False)
+
+        # Slope guide lines (right-click submenu)
+        add_slope_line_menu(self.main_plot)
 
         # Enable auto-range
         self.main_plot.enableAutoRange()

--- a/pyirena/gui/waxs_peakfit_panel.py
+++ b/pyirena/gui/waxs_peakfit_panel.py
@@ -47,7 +47,7 @@ from pyirena.core.waxs_peakfit import (
     compute_adaptive_background,
     find_peaks_in_data, WAXSPeakFitModel,
 )
-from pyirena.gui.sas_plot import save_itx_from_plot
+from pyirena.gui.sas_plot import save_itx_from_plot, DSpacingAxisItem
 
 
 # ── colour palette for peaks ──────────────────────────────────────────────
@@ -513,10 +513,15 @@ class WAXSPeakFitGraphWindow(QWidget):
         self.gl.setBackground('w')
 
         # ── Top plot: data + model ────────────────────────────────────────
-        self.main_plot = self.gl.addPlot(row=0, col=0)
+        self.main_plot = self.gl.addPlot(
+            row=0, col=0,
+            axisItems={'top': DSpacingAxisItem(orientation='top')},
+        )
         self.main_plot.setLogMode(False, False)
         self.main_plot.setLabel('left',   'Intensity')
         self.main_plot.setLabel('bottom', 'Q  (Å⁻¹)')
+        self.main_plot.getAxis('top').setLabel('d = 2π/Q  (Å)', **{'color': '#888', 'font-size': '9pt'})
+        self.main_plot.getAxis('top').setTextPen('#888')
         self.main_plot.showGrid(x=True, y=True, alpha=0.3)
         self._legend = self.main_plot.addLegend(offset=(-10, 10), labelTextSize='13pt', labelTextColor='k')
         self._style_axes(self.main_plot)
@@ -1300,6 +1305,10 @@ class WAXSPeakFitPanel(QWidget):
         self._find_btn = QPushButton("Find Peaks")
         self._find_btn.setStyleSheet(_BTN_FIND)
         self._find_btn.setMinimumHeight(28)
+        self._find_btn.setToolTip(
+            "Automatically locate peaks in the data using the threshold and width settings above.\n"
+            "Found peaks are added to the peak list and shown on the graph."
+        )
         self._find_btn.clicked.connect(self._find_peaks)
         pf_layout.addWidget(self._find_btn, len(rows), 0, 1, 2)
         ll.addWidget(pf_box)
@@ -1324,12 +1333,17 @@ class WAXSPeakFitPanel(QWidget):
         add_btn = QPushButton("Add Peak Manually")
         add_btn.setStyleSheet(_BTN_ADD)
         add_btn.setMinimumHeight(26)
+        add_btn.setToolTip(
+            "Add a new peak entry at a default Q position.\n"
+            "Edit the Q₀ and FWHM values, then click Fit."
+        )
         add_btn.clicked.connect(lambda: self._add_peak_at_q(None, None))
         peak_btn_row.addWidget(add_btn)
 
         sort_btn = QPushButton("Sort by Q")
         sort_btn.setStyleSheet(_BTN_SAVE)
         sort_btn.setMinimumHeight(26)
+        sort_btn.setToolTip("Sort all peaks in the list by ascending Q₀ position.")
         sort_btn.clicked.connect(self._sort_peaks_by_q)
         peak_btn_row.addWidget(sort_btn)
         peaks_outer_layout.addLayout(peak_btn_row)
@@ -1341,6 +1355,10 @@ class WAXSPeakFitPanel(QWidget):
         self._graph_btn.setStyleSheet(_BTN_GRAPH)
         self._graph_btn.setMinimumHeight(28)
         self._graph_btn.setMaximumWidth(120)
+        self._graph_btn.setToolTip(
+            "Compute and display the current peak model without fitting.\n"
+            "Use this to preview the model before running a fit."
+        )
         self._graph_btn.clicked.connect(self._graph_model)
         fit_row.addWidget(self._graph_btn)
         fit_row.addStretch()
@@ -1349,6 +1367,10 @@ class WAXSPeakFitPanel(QWidget):
         self._fit_btn.setStyleSheet(_BTN_FIT)
         self._fit_btn.setMinimumHeight(28)
         self._fit_btn.setMaximumWidth(90)
+        self._fit_btn.setToolTip(
+            "Fit all active peaks to the data within the Q range.\n"
+            "Checked parameters per peak are varied; unchecked are held fixed."
+        )
         self._fit_btn.clicked.connect(self._run_fit)
         fit_row.addWidget(self._fit_btn)
 
@@ -1357,6 +1379,10 @@ class WAXSPeakFitPanel(QWidget):
         self._revert_btn.setMinimumHeight(28)
         self._revert_btn.setMaximumWidth(90)
         self._revert_btn.setEnabled(False)
+        self._revert_btn.setToolTip(
+            "Restore all peak parameters to their values before the last fit.\n"
+            "Useful if a fit diverged or gave unreasonable results."
+        )
         self._revert_btn.clicked.connect(self._revert)
         fit_row.addWidget(self._revert_btn)
         ll.addLayout(fit_row)
@@ -1454,12 +1480,20 @@ class WAXSPeakFitPanel(QWidget):
         fix_limits_btn = QPushButton("Fix Limits")
         fix_limits_btn.setStyleSheet(_BTN_FIXLIM)
         fix_limits_btn.setMinimumHeight(28)
+        fix_limits_btn.setToolTip(
+            "Set all fit limits to ±5× the current peak parameter values.\n"
+            "Convenient starting point before running a constrained fit."
+        )
         fix_limits_btn.clicked.connect(self._fix_limits)
         extra_row.addWidget(fix_limits_btn)
 
         reset_btn = QPushButton("Reset to Defaults")
         reset_btn.setStyleSheet(_BTN_RESET)
         reset_btn.setMinimumHeight(28)
+        reset_btn.setToolTip(
+            "Reset all peak parameters to their factory default values.\n"
+            "This cannot be undone — use 'Revert' to undo only the last fit."
+        )
         reset_btn.clicked.connect(self._reset_defaults)
         extra_row.addWidget(reset_btn)
         ll.addLayout(extra_row)
@@ -1483,13 +1517,18 @@ class WAXSPeakFitPanel(QWidget):
         ll.addLayout(row1)
 
         row2 = QHBoxLayout()
-        for txt, style, slot in [
-            ("Export Parameters", _BTN_EXPORT, self._export_params),
-            ("Import Parameters", _BTN_EXPORT, self._import_params),
+        for txt, style, slot, tip in [
+            ("Save params to JSON", _BTN_EXPORT, self._export_params,
+             "Save current peak fit parameters to a pyIrena JSON file.\n"
+             "Use 'Load params from JSON' to restore them later."),
+            ("Load params from JSON", _BTN_EXPORT, self._import_params,
+             "Load peak fit parameters from a previously saved pyIrena JSON file.\n"
+             "Use 'Save params to JSON' to create a compatible file."),
         ]:
             b = QPushButton(txt)
             b.setStyleSheet(style)
             b.setMinimumHeight(26)
+            b.setToolTip(tip)
             b.clicked.connect(slot)
             row2.addWidget(b)
         ll.addLayout(row2)

--- a/pyirena/io/ascii_export.py
+++ b/pyirena/io/ascii_export.py
@@ -606,7 +606,9 @@ def _hdr_waxs(wp: dict) -> list:
                 bg_strs.append(f"{name}={_format_scalar_for_header(val)}")
         lines.append("# Background: " + " ".join(bg_strs))
 
-    # Per-peak parameters (one line each)
+    # Per-peak parameters (one line each).  Trailing Area=… is the closed-form
+    # integral under the peak profile; +/- value is the linearised 1-σ
+    # uncertainty propagated from the fitted A/FWHM[/eta/Q0] uncertainties.
     peaks = wp.get("peaks", []) or []
     peaks_std = wp.get("peaks_std", []) or [{} for _ in peaks]
     for i, peak in enumerate(peaks, start=1):
@@ -623,6 +625,20 @@ def _hdr_waxs(wp: dict) -> list:
                                        f"{_format_scalar_for_header(err)}")
                 else:
                     params_strs.append(f"{pn}={_format_scalar_for_header(val)}")
+        # Area (derived).  Prefer stored scalar; recompute for older HDF5 files
+        # that predate the area dataset so the ASCII output always includes it.
+        area_v = peak.get("area")
+        area_s = peak.get("area_std")
+        if area_v is None:
+            from pyirena.core.waxs_peakfit import peak_area, peak_area_std
+            area_v = peak_area(peak.get("shape", "Gauss"), peak)
+            area_s = peak_area_std(peak.get("shape", "Gauss"), peak, pstd)
+        if area_v is not None and np.isfinite(area_v):
+            if area_s is not None and np.isfinite(area_s) and area_s > 0:
+                params_strs.append(f"Area={_format_scalar_for_header(area_v)}+/-"
+                                   f"{_format_scalar_for_header(area_s)}")
+            else:
+                params_strs.append(f"Area={_format_scalar_for_header(area_v)}")
         lines.append(f"# Peak {i} [{shape}]: " + " ".join(params_strs))
     return lines
 

--- a/pyirena/io/h5xp_extractor.py
+++ b/pyirena/io/h5xp_extractor.py
@@ -385,6 +385,38 @@ def _extract_size_distribution(grp: h5py.Group, h5xp: h5py.File,
     return wrote_any
 
 
+def _waxs_recompute_peak_area(pk_grp, with_std: bool):
+    """Fallback peak-area computation for HDF5 files written before the
+    ``area`` / ``area_std`` datasets were added to ``peak_NN/``.
+
+    Mirrors the same logic in ``pyirena.gui.hdf5viewer.pyirena_readers`` so
+    the Igor Results table and the HDF5 Viewer's Collect Values stay in
+    lock-step on old files.  Returns float or None.
+    """
+    try:
+        from pyirena.core.waxs_peakfit import peak_area, peak_area_std
+        shape = str(pk_grp.attrs.get("shape", "Gauss"))
+        if isinstance(shape, bytes):
+            shape = shape.decode("utf-8", errors="ignore")
+        params: dict = {}
+        if "params" in pk_grp:
+            for pn in ("A", "Q0", "FWHM", "eta"):
+                if pn in pk_grp["params"]:
+                    params[pn] = float(pk_grp["params"][pn][()])
+        params_std: dict = {}
+        if "params_std" in pk_grp:
+            for pn, ds in pk_grp["params_std"].items():
+                try:
+                    params_std[pn] = float(ds[()])
+                except Exception:
+                    pass
+        if with_std:
+            return float(peak_area_std(shape, params, params_std))
+        return float(peak_area(shape, params))
+    except Exception:
+        return None
+
+
 def _extract_waxs_peakfit(grp: h5py.Group, h5xp: h5py.File,
                            folder: str, category: str) -> bool:
     """Write SADModelIntensity and per-peak SADModelIntPeak{n} waves."""
@@ -417,6 +449,19 @@ def _extract_waxs_peakfit(grp: h5py.Group, h5xp: h5py.File,
                     v = _scalar(pk["params"], pname)
                     if not np.isnan(v):
                         pk_params[pname] = v
+            # Derived: integral under the peak profile.  Stored directly on
+            # the peak group (not inside params/).  Falls back to recompute
+            # from params for older HDF5 files that predate the dataset.
+            area_v = _scalar(pk, "area")
+            if np.isnan(area_v):
+                area_v = _waxs_recompute_peak_area(pk, with_std=False)
+            if area_v is not None and np.isfinite(area_v):
+                pk_params["Area"] = float(area_v)
+            area_s = _scalar(pk, "area_std")
+            if np.isnan(area_s):
+                area_s = _waxs_recompute_peak_area(pk, with_std=True)
+            if area_s is not None and np.isfinite(area_s):
+                pk_params["Area_err"] = float(area_s)
             write_result_wave(h5xp, folder, f"SADModelIntPeak{n}",
                               q_pk, I_pk, pk_params, category)
             wrote_any = True

--- a/pyirena/io/nxcansas_modeling.py
+++ b/pyirena/io/nxcansas_modeling.py
@@ -148,7 +148,7 @@ def save_modeling_results(
 
             elif pop_type == 'mass_fractal':
                 # Mass Fractal parameters
-                for pn in ['Phi', 'Radius', 'Dv', 'Ksi', 'Eta', 'Contrast']:
+                for pn in ['Phi', 'Radius', 'Beta', 'Dv', 'Ksi', 'Eta', 'Contrast']:
                     pg.create_dataset(pn, data=float(getattr(pop, pn)))
                     pg[pn].attrs['fit'] = bool(getattr(pop, f'fit_{pn}'))
                     lim = getattr(pop, f'{pn}_limits')
@@ -328,7 +328,7 @@ def load_modeling_results(
                 pop_dict['correlations'] = bool(pg['correlations'][()]) if 'correlations' in pg else False
 
             elif pop_type == 'mass_fractal':
-                for pn in ['Phi', 'Radius', 'Dv', 'Ksi', 'Eta', 'Contrast']:
+                for pn in ['Phi', 'Radius', 'Beta', 'Dv', 'Ksi', 'Eta', 'Contrast']:
                     pop_dict[pn] = float(pg[pn][()]) if pn in pg else None
 
             elif pop_type == 'surface_fractal':

--- a/pyirena/io/nxcansas_modeling.py
+++ b/pyirena/io/nxcansas_modeling.py
@@ -130,6 +130,47 @@ def save_modeling_results(
                     pg[pn].attrs['limit_lo'] = float(lim[0])
                     pg[pn].attrs['limit_hi'] = float(lim[1])
 
+            elif pop_type == 'guinier_porod':
+                # Guinier-Porod Level parameters
+                for pn in ['G', 'Rg1', 's1', 'P', 'Rg2', 's2', 'RgCO']:
+                    pg.create_dataset(pn, data=float(getattr(pop, pn)))
+                    pg[pn].attrs['fit'] = bool(getattr(pop, f'fit_{pn}'))
+                    lim = getattr(pop, f'{pn}_limits')
+                    pg[pn].attrs['limit_lo'] = float(lim[0])
+                    pg[pn].attrs['limit_hi'] = float(lim[1])
+                pg.create_dataset('correlations', data=bool(pop.correlations))
+                for pn in ['ETA', 'PACK']:
+                    pg.create_dataset(pn, data=float(getattr(pop, pn)))
+                    pg[pn].attrs['fit'] = bool(getattr(pop, f'fit_{pn}'))
+                    lim = getattr(pop, f'{pn}_limits')
+                    pg[pn].attrs['limit_lo'] = float(lim[0])
+                    pg[pn].attrs['limit_hi'] = float(lim[1])
+
+            elif pop_type == 'mass_fractal':
+                # Mass Fractal parameters
+                for pn in ['Phi', 'Radius', 'Dv', 'Ksi', 'Eta', 'Contrast']:
+                    pg.create_dataset(pn, data=float(getattr(pop, pn)))
+                    pg[pn].attrs['fit'] = bool(getattr(pop, f'fit_{pn}'))
+                    lim = getattr(pop, f'{pn}_limits')
+                    pg[pn].attrs['limit_lo'] = float(lim[0])
+                    pg[pn].attrs['limit_hi'] = float(lim[1])
+
+            elif pop_type == 'surface_fractal':
+                # Surface Fractal parameters
+                for pn in ['Surface', 'Ds', 'Ksi', 'Contrast']:
+                    pg.create_dataset(pn, data=float(getattr(pop, pn)))
+                    pg[pn].attrs['fit'] = bool(getattr(pop, f'fit_{pn}'))
+                    lim = getattr(pop, f'{pn}_limits')
+                    pg[pn].attrs['limit_lo'] = float(lim[0])
+                    pg[pn].attrs['limit_hi'] = float(lim[1])
+                pg.create_dataset('use_porod_transition', data=bool(pop.use_porod_transition))
+                for pn in ['Qc', 'QcWidth']:
+                    pg.create_dataset(pn, data=float(getattr(pop, pn)))
+                    pg[pn].attrs['fit'] = bool(getattr(pop, f'fit_{pn}'))
+                    lim = getattr(pop, f'{pn}_limits')
+                    pg[pn].attrs['limit_lo'] = float(lim[0])
+                    pg[pn].attrs['limit_hi'] = float(lim[1])
+
             else:
                 # Size Distribution parameters
                 pg.attrs['dist_type'] = pop.dist_type
@@ -280,6 +321,20 @@ def load_modeling_results(
                 pop_dict['peak_type'] = pg.attrs.get('peak_type', 'gaussian')
                 for pn in ['position', 'amplitude', 'width', 'eta_voigt']:
                     pop_dict[pn] = float(pg[pn][()]) if pn in pg else None
+
+            elif pop_type == 'guinier_porod':
+                for pn in ['G', 'Rg1', 's1', 'P', 'Rg2', 's2', 'RgCO', 'ETA', 'PACK']:
+                    pop_dict[pn] = float(pg[pn][()]) if pn in pg else None
+                pop_dict['correlations'] = bool(pg['correlations'][()]) if 'correlations' in pg else False
+
+            elif pop_type == 'mass_fractal':
+                for pn in ['Phi', 'Radius', 'Dv', 'Ksi', 'Eta', 'Contrast']:
+                    pop_dict[pn] = float(pg[pn][()]) if pn in pg else None
+
+            elif pop_type == 'surface_fractal':
+                for pn in ['Surface', 'Ds', 'Ksi', 'Contrast', 'Qc', 'QcWidth']:
+                    pop_dict[pn] = float(pg[pn][()]) if pn in pg else None
+                pop_dict['use_porod_transition'] = bool(pg['use_porod_transition'][()]) if 'use_porod_transition' in pg else False
 
             else:
                 # size_dist

--- a/pyirena/io/nxcansas_waxs_peakfit.py
+++ b/pyirena/io/nxcansas_waxs_peakfit.py
@@ -24,6 +24,9 @@ waxs_peakfit_results/
         (attrs)     shape
         Q_peak      — 1-D float64, Q range ±5×FWHM around Q0
         I_peak      — 1-D float64, individual peak curve on Q_peak
+        area        — float64 scalar, ∫peak(q)dq (integral under the curve,
+                       derived from fitted A/FWHM[/eta/Q0], not fitted)
+        area_std    — float64 scalar, 1-σ uncertainty on area
         params/
             A, Q0, FWHM[, eta]  — float64 scalar each
             (attrs on each) limit_low, limit_high
@@ -48,6 +51,8 @@ from pyirena.core.waxs_peakfit import (
     _PEAK_PARAM_NAMES,
     bg_param_names,
     eval_peak,
+    peak_area,
+    peak_area_std,
 )
 
 _GROUP = "entry/waxs_peakfit_results"
@@ -186,6 +191,15 @@ def save_waxs_peakfit_results(
             pk_grp.create_dataset("I_peak", data=I_peak, dtype="float64")
             pk_grp["I_peak"].attrs["units"] = "arb"
 
+            # Derived: integral under the peak curve (closed-form analytic)
+            area_val = peak_area(shape, peak)
+            area_err = peak_area_std(shape, peak, p_std)
+            ds_area = pk_grp.create_dataset("area", data=float(area_val), dtype="float64")
+            ds_area.attrs["units"]       = "arb/angstrom"
+            ds_area.attrs["description"] = "Integral of peak profile, ∫I_peak(q)dq"
+            pk_grp.create_dataset("area_std", data=float(area_err), dtype="float64")
+            pk_grp["area_std"].attrs["units"] = "arb/angstrom"
+
             # Fitted parameters
             p_grp   = pk_grp.create_group("params")
             ps_grp  = pk_grp.create_group("params_std")
@@ -322,6 +336,20 @@ def load_waxs_peakfit_results(filepath: Path) -> Dict:
 
             q_pk  = np.array(pk_grp["Q_peak"], float) if "Q_peak" in pk_grp else None
             I_pk  = np.array(pk_grp["I_peak"], float) if "I_peak" in pk_grp else None
+
+            # Derived: peak area + uncertainty.  Older files predate these
+            # datasets — recompute on the fly from the loaded params so callers
+            # can rely on the value being present.
+            if "area" in pk_grp and isinstance(pk_grp["area"], h5py.Dataset):
+                area_v = float(pk_grp["area"][()])
+            else:
+                area_v = float(peak_area(shape, peak_d))
+            if "area_std" in pk_grp and isinstance(pk_grp["area_std"], h5py.Dataset):
+                area_s = float(pk_grp["area_std"][()])
+            else:
+                area_s = float(peak_area_std(shape, peak_d, p_std_d))
+            peak_d["area"]     = area_v
+            peak_d["area_std"] = area_s
 
             peaks_list.append(peak_d)
             peaks_std.append(p_std_d)

--- a/pyirena/io/schema.py
+++ b/pyirena/io/schema.py
@@ -275,6 +275,9 @@ TOOL_REGISTRY: dict[str, dict] = {
             _per_subgroup("peak_A",    "peak_{n}/params/A",    "arb",        "Peak amplitude",  "peak_"),
             _per_subgroup("peak_FWHM", "peak_{n}/params/FWHM", "1/angstrom", "Peak FWHM (Å⁻¹)", "peak_"),
             _per_subgroup("peak_eta",  "peak_{n}/params/eta",  "",           "Peak η (Voigt)",  "peak_"),
+            # Derived: integral under the peak profile, ∫I_peak(q)dq.
+            # NaN for HDF5 files written before this dataset was added.
+            _per_subgroup("peak_Area", "peak_{n}/area",        "arb/angstrom", "Peak area (∫I dq)", "peak_"),
         ],
         "sub_groups": _PEAK_SUBGROUP,
         # Note: peak sub-group names are zero-padded, e.g. "peak_01", "peak_02".

--- a/pyirena/state/state_manager.py
+++ b/pyirena/state/state_manager.py
@@ -308,6 +308,7 @@ class StateManager:
             "similarity_method": "cormap",
             "similarity_reference": "first",   # 'first' | 'majority'
             "similarity_p_min": 0.01,
+            "similarity_normalize_scale": True,
         },
         "modeling": {
             "schema_version": 2,

--- a/pyirena/state/state_manager.py
+++ b/pyirena/state/state_manager.py
@@ -373,6 +373,35 @@ class StateManager:
                         "amplitude": 1.0, "fit_amplitude": True,  "amplitude_limits": [0.0, 1e10],
                         "width": 0.01,    "fit_width": True,      "width_limits": [1e-6, 10.0],
                         "eta_voigt": 0.5, "fit_eta_voigt": False, "eta_voigt_limits": [0.0, 1.0]
+                    },
+                    "gp": {
+                        "G": 1.0,    "fit_G": True,    "G_limits": [1e-10, 1e10],
+                        "Rg1": 10.0, "fit_Rg1": True,  "Rg1_limits": [0.1, 1e6],
+                        "s1": 0.0,   "fit_s1": False,  "s1_limits": [0.0, 3.0],
+                        "P": 4.0,    "fit_P": False,   "P_limits": [0.0, 6.0],
+                        "Rg2": 1e10, "fit_Rg2": False, "Rg2_limits": [0.1, 1e12],
+                        "s2": 0.0,   "fit_s2": False,  "s2_limits": [0.0, 3.0],
+                        "RgCO": 0.0, "fit_RgCO": False,"RgCO_limits": [0.0, 1e6],
+                        "correlations": False,
+                        "ETA": 10.0, "fit_ETA": False,  "ETA_limits": [0.1, 1e6],
+                        "PACK": 0.0, "fit_PACK": False, "PACK_limits": [0.0, 16.0]
+                    },
+                    "mf": {
+                        "Phi": 0.001,    "fit_Phi": True,     "Phi_limits": [1e-8, 1.0],
+                        "Radius": 50.0,  "fit_Radius": True,  "Radius_limits": [0.1, 1e6],
+                        "Dv": 2.5,       "fit_Dv": True,      "Dv_limits": [1.0, 3.0],
+                        "Ksi": 500.0,    "fit_Ksi": True,     "Ksi_limits": [1.0, 1e7],
+                        "Eta": 0.5,      "fit_Eta": False,    "Eta_limits": [0.3, 0.8],
+                        "Contrast": 1.0, "fit_Contrast": False,"Contrast_limits": [0.0, 1e10]
+                    },
+                    "sf2": {
+                        "Surface": 1e4,  "fit_Surface": True, "Surface_limits": [1.0, 1e12],
+                        "Ds": 2.5,       "fit_Ds": True,      "Ds_limits": [2.0, 3.0],
+                        "Ksi": 500.0,    "fit_Ksi": True,     "Ksi_limits": [1.0, 1e7],
+                        "Contrast": 1.0, "fit_Contrast": False,"Contrast_limits": [0.0, 1e10],
+                        "use_porod_transition": False,
+                        "Qc": 0.1,       "fit_Qc": False,     "Qc_limits": [0.001, 10.0],
+                        "QcWidth": 0.1,  "fit_QcWidth": False,"QcWidth_limits": [0.01, 1.0]
                     }
                 },
                 # Populations 1-9 — disabled by default (same structure, enabled=False)
@@ -430,6 +459,35 @@ class StateManager:
                             "amplitude": 1.0, "fit_amplitude": True,  "amplitude_limits": [0.0, 1e10],
                             "width": 0.01,    "fit_width": True,      "width_limits": [1e-6, 10.0],
                             "eta_voigt": 0.5, "fit_eta_voigt": False, "eta_voigt_limits": [0.0, 1.0]
+                        },
+                        "gp": {
+                            "G": 1.0,    "fit_G": True,    "G_limits": [1e-10, 1e10],
+                            "Rg1": 10.0, "fit_Rg1": True,  "Rg1_limits": [0.1, 1e6],
+                            "s1": 0.0,   "fit_s1": False,  "s1_limits": [0.0, 3.0],
+                            "P": 4.0,    "fit_P": False,   "P_limits": [0.0, 6.0],
+                            "Rg2": 1e10, "fit_Rg2": False, "Rg2_limits": [0.1, 1e12],
+                            "s2": 0.0,   "fit_s2": False,  "s2_limits": [0.0, 3.0],
+                            "RgCO": 0.0, "fit_RgCO": False,"RgCO_limits": [0.0, 1e6],
+                            "correlations": False,
+                            "ETA": 10.0, "fit_ETA": False,  "ETA_limits": [0.1, 1e6],
+                            "PACK": 0.0, "fit_PACK": False, "PACK_limits": [0.0, 16.0]
+                        },
+                        "mf": {
+                            "Phi": 0.001,    "fit_Phi": True,     "Phi_limits": [1e-8, 1.0],
+                            "Radius": 50.0,  "fit_Radius": True,  "Radius_limits": [0.1, 1e6],
+                            "Dv": 2.5,       "fit_Dv": True,      "Dv_limits": [1.0, 3.0],
+                            "Ksi": 500.0,    "fit_Ksi": True,     "Ksi_limits": [1.0, 1e7],
+                            "Eta": 0.5,      "fit_Eta": False,    "Eta_limits": [0.3, 0.8],
+                            "Contrast": 1.0, "fit_Contrast": False,"Contrast_limits": [0.0, 1e10]
+                        },
+                        "sf2": {
+                            "Surface": 1e4,  "fit_Surface": True, "Surface_limits": [1.0, 1e12],
+                            "Ds": 2.5,       "fit_Ds": True,      "Ds_limits": [2.0, 3.0],
+                            "Ksi": 500.0,    "fit_Ksi": True,     "Ksi_limits": [1.0, 1e7],
+                            "Contrast": 1.0, "fit_Contrast": False,"Contrast_limits": [0.0, 1e10],
+                            "use_porod_transition": False,
+                            "Qc": 0.1,       "fit_Qc": False,     "Qc_limits": [0.001, 10.0],
+                            "QcWidth": 0.1,  "fit_QcWidth": False,"QcWidth_limits": [0.01, 1.0]
                         }
                     }
                     for _ in range(9)

--- a/pyirena/state/state_manager.py
+++ b/pyirena/state/state_manager.py
@@ -389,6 +389,7 @@ class StateManager:
                     "mf": {
                         "Phi": 0.001,    "fit_Phi": True,     "Phi_limits": [1e-8, 1.0],
                         "Radius": 50.0,  "fit_Radius": True,  "Radius_limits": [0.1, 1e6],
+                        "Beta": 1.0,     "fit_Beta": False,   "Beta_limits": [0.01, 100.0],
                         "Dv": 2.5,       "fit_Dv": True,      "Dv_limits": [1.0, 3.0],
                         "Ksi": 500.0,    "fit_Ksi": True,     "Ksi_limits": [1.0, 1e7],
                         "Eta": 0.5,      "fit_Eta": False,    "Eta_limits": [0.3, 0.8],

--- a/pyirena/state/state_manager.py
+++ b/pyirena/state/state_manager.py
@@ -282,7 +282,7 @@ class StateManager:
             "match_files": False,
         },
         "data_manipulation": {
-            "schema_version": 1,
+            "schema_version": 2,
             "folder": None,
             "file_type": "HDF5 Nexus",
             "filter": "",
@@ -304,6 +304,10 @@ class StateManager:
             # Divide tab
             "divide_denominator_scale": 1.0,
             "divide_denominator_background": 0.0,
+            # Average tab — similarity analysis
+            "similarity_method": "cormap",
+            "similarity_reference": "first",   # 'first' | 'majority'
+            "similarity_p_min": 0.01,
         },
         "modeling": {
             "schema_version": 2,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pyirena"
-version = "0.6.4"
+version = "0.6.5"
 description = "Python tools for small-angle scattering data analysis."
 readme = {file = "README.md", content-type = "text/markdown"}
 requires-python = ">=3.9"


### PR DESCRIPTION
## Summary

This release adds three new Modeling population types, CorMap-based radiation-damage detection, WAXS Peak Fit area reporting, and several GUI improvements across all tools.

### New features

**Modeling tool — three new population types (6 total, up from 3)**
- **Guinier-Porod Level** (`guinier_porod`): piecewise model for non-spherical/non-dilute systems (Hammouda 2010). Parameters G, Rg1, s1, P, Rg2, s2, RgCO; optional Born-Green correlations.
- **Mass Fractal** (`mass_fractal`): fractal aggregate scattering (Teixeira 1988). Primary particles are spheroids with aspect ratio β — orientation-averaged form factor via 50-pt Gauss-Legendre quadrature eliminates unphysical Bessel oscillations. Parameters Phi, Radius, Beta, Dv, Ksi, Eta, Contrast.
- **Surface Fractal** (`surface_fractal`): surface roughness scattering (Teixeira 1988). Parameters Surface, Ds, Ksi, Contrast; optional Porod transition at Qc.
- All three: full fitting, MC uncertainty, HDF5 save/load, JSON state, batch API.

**Data Manipulation — CorMap similarity filtering (Average tab)**
- Detects radiation-damaged frames before averaging using the CorMap test (Franke et al. 2015, *Nature Methods*).
- Two reference modes: First frame / Majority vote. Adjustable p-value threshold.
- Color-coded results table + Auto-reject button.
- `average_data()` headless API gains `similarity_check`, `similarity_p_min`, `similarity_method`, `similarity_reference` arguments.

**WAXS Peak Fit — per-peak Area**
- Closed-form integral ∫I_peak(q)dq for all four peak shapes; linearised uncertainty.
- Saved in HDF5; propagated to Data Selector report, CSV tabulation, ASCII export, Data Explorer Collect Values, and Export to Igor.

**WAXS / Data Merge — d-spacing top axis**
- `d = 2π/Q [Å]` axis on all linear-scale plots via new `DSpacingAxisItem`.

**Unified Fit — draggable slope guide lines**
- Right-click → *Add slope guide line*; presets n = −2..−6, custom range [−8, −0.5].
- Lines drag vertically, carry a label, and can be removed individually or in bulk.

**GUI polish**
- Clearer button labels ("Save params to JSON" / "Load params from JSON") across all tools.
- Tooltips on all action buttons across all panels.

### Bug fixes

- Modeling: "No limits?" checkbox now hides Min/Max columns for all six population types (was missing the three new types — GUI-only gap, fitting was already correct).
- Unified Fit: top axis R = π/Q now shows numerical labels.
- Unified Fit: B limit fields stay hidden when "No limits?" is active and "Estimate B" is toggled.

## Test plan

- [ ] Launch Modeling tool; switch each of the six population types; graph model; run a fit with and without "No limits?"
- [ ] Average tab: load multi-frame data; run Check Similarity; Auto-reject; verify filtered average
- [ ] WAXS Peak Fit: fit peaks; verify Area column in tabulate results and HDF5
- [ ] Data Merge: switch to WAXS mode; verify d-spacing axis appears
- [ ] Unified Fit: right-click graph → add slope guide lines; drag; remove
- [ ] Batch: `fit_modeling()` with a config that uses `mass_fractal` with `Beta=2.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)