### PR TITLE
feat: MCP tool prefix, Igor PXP/H5XP importer, mixed plot content, engineering notation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,5 +102,6 @@ dmypy.json
 # Local developer fixtures (e.g. legacy .pxp test files too large for git)
 /temp/
 
+
 # Claude memory
 .claude/

--- a/.gitignore
+++ b/.gitignore
@@ -99,5 +99,8 @@ dmypy.json
 *.bak
 *~
 
+# Local developer fixtures (e.g. legacy .pxp test files too large for git)
+/temp/
+
 # Claude memory
 .claude/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,59 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.2] — 2026-05-25
+
+### Fixed
+
+- **`.pxp` importer: many small fixes from end-to-end testing on real
+  legacy USAXS experiments**. Aggregating one release because each
+  fix on its own was small and they were diagnosed in a single session:
+
+  1. **macOS native-alignment bug** (`fix 61333a3`). The igor2 packed
+     record-header struct was being built with native alignment on
+     macOS Python builds, inflating the 8-byte logical header to 16
+     bytes and immediately misreading `numDataBytes` as a giant
+     garbage int. Force explicit `<`/`>` byte order to disable
+     alignment padding — header is now reliably 8 bytes everywhere.
+  2. **OOM-safety on malformed records** (`fix 3cfd756`). Added a
+     256 MB sanity ceiling on `numDataBytes` plus a file-size check,
+     so a corrupt or unhandled record type can't make us preallocate
+     gigabytes of garbage.
+  3. **Igor 8/10 v7 wave format** (`fix 63a38a5`). `igor2 0.5.x`
+     rejects binary-wave version 7 (Igor 8's long-name format) even
+     though its numeric data layout is identical to v5. The loader
+     now patches the leading version field from 7→5 and retries —
+     recovering hundreds of waves per file in real experiments.
+  4. **Per-sample (root-level) folder layout** (`fix 35eec97`). Some
+     experiments organise data by sample rather than by technique —
+     one folder per sample at root level, with USAXS/SAXS/WAXS waves
+     all inside the same folder. The walker now recognises this and
+     yields up to three output files per such folder, one per
+     technique whose wave triple is present. Infrastructure folders
+     (`Packages/`, `SavedSampleSets/`) are skipped explicitly so
+     they don't pollute the summary.
+  5. **Igor 8 long-name records that we can't decode are now
+     surfaced explicitly**. Igor Pro 8 introduced new packed-record
+     types (26 and 33) used when folder or wave names exceed 31
+     characters. `igor2 0.5.x` skips these as unknown, so any
+     sample whose folder name is > 31 chars is silently invisible
+     to the importer. The loader now counts these markers and
+     reports `n_igor8_longname_markers` on `ExtractionResult`; the
+     CLI prints a `*** WARNING ***` block, the batch API surfaces
+     it via the result dict, and the GUI shows a Warning-icon
+     dialog with the recommendation to re-save the experiment as
+     `.h5xp` (which has no such limit and which pyirena reads
+     perfectly). See `docs/igor_pxp_import.md` for details.
+
+  Net effect: a real 22 MB legacy experiment went from "crashes with
+  MemoryError" to "imports cleanly, with a clear warning if any
+  samples are missing due to Igor 8 long names". A 125 MB
+  time-series experiment with ~700 samples went from "imports 22
+  samples" to "imports every sample whose folder name fits, with
+  warning that the rest need .h5xp re-save".
+
+  +4 new unit tests (23 total).
+
 ## [0.8.1] — 2026-05-25
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,48 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.1] — 2026-05-25
+
+### Added
+
+- **Import Igor Pro `.h5xp` packed experiments** (Wavemetrics' HDF5
+  packed-experiment format), completing the Igor import story. The
+  GUI button, batch API, and CLI now all accept `.h5xp` alongside
+  the existing `.pxp`. Format is auto-detected from the file extension.
+
+  New entry points:
+  - `pyirena.batch.igor_to_nexus("file.pxp"|"file.h5xp", …)` — single
+    function for both formats; the old `pxp_to_nexus` is kept as a
+    deprecated alias for back-compat.
+  - `pyirena.io.pxp_to_nexus.extract_igor_experiment(...)` — dispatcher
+    used by the GUI and CLI; also exposes the format-specific
+    `extract_h5xp_to_nexus()` for explicit calls.
+  - GUI file dialog filter now includes `*.h5xp`.
+
+  Implementation notes:
+  - h5xp tree is walked with `h5py.File(...).visit()` over the
+    `/Packed Data/` subtree; no special parser needed (HDF5 is
+    well-defined). The `/Packed Data/Results/` group is intentionally
+    skipped — its per-parameter collected-value waves don't match the
+    per-sample-folder shape this importer expects.
+  - h5xp wave notes use `key:value;` (colon) while pxp uses
+    `key=value;` (equals); the parser auto-detects the separator
+    per-note so the same metadata extraction code handles both.
+  - h5xp wave names use either the literal triple `Q`/`R`/`S`/`dQ` or
+    the suffixed `q_<folder>`/`r_<folder>`/`s_<folder>`/`dq_<folder>`
+    convention emitted by `pyirena.io.h5xp_writer.write_iq_data`. Both
+    patterns are recognised via the new `<folder>` substitution token in
+    `WAVE_PICKERS_H5XP`.
+  - 9 new tests use `h5xp_writer` to synthesise fixtures, so they
+    don't depend on any external data files and run on every CI build.
+
+  Files: `pyirena/io/pxp_to_nexus.py` (added `_load_h5xp_filesystem`,
+  `_H5Wave` adapter, `extract_h5xp_to_nexus`, `extract_igor_experiment`
+  dispatcher, `WAVE_PICKERS_H5XP`); `pyirena/batch.py`
+  (added `igor_to_nexus`, kept `pxp_to_nexus` as alias);
+  `pyirena/gui/data_selector.py` (extended file dialog filter);
+  `pyirena/tests/test_pxp_to_nexus.py` (+9 tests).
+
 ## [0.8.0] — 2026-05-25
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,53 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.0] — 2026-05-25
+
+### Added
+
+- **Import Igor Pro packed experiments (`.pxp`) → per-sample NeXus files.**
+  Users with legacy Igor data can now bring it into pyIrena for analysis
+  without re-reducing from raw detector files. The importer walks the
+  experiment's USAXS / SAXS / WAXS folder hierarchy, picks the
+  standard wave triples (`DSM_Qvec`/`DSM_Int`/`DSM_Error`(+`DSM_dQ`)
+  for USAXS, `R_Qvec`/`R_Int`/`R_Error` for SAXS and WAXS), and
+  writes one NXcanSAS `.h5` per sample into a sibling `<pxp>_data/`
+  folder organised as `USAXS/`, `SAXS/`, `WAXS/`.
+
+  Rich wave-note metadata produced by the APS USAXS pipeline (sample
+  name, thickness, temperature, wavelength, plus the full instrument
+  state) is parsed from the `NXSampleStart`/`End`, `NXInstrumentStart`/
+  `End`, `NXMetadataStart`/`End` sentinel blocks and lands in the
+  canonical NXcanSAS locations (`entry/sample/`, `entry/instrument/`,
+  `entry/notes/`). The Q resolution column `Qdev` is written when
+  the source wave has `DSM_dQ` (per the NXcanSAS optional-array spec).
+
+  Entry points:
+  - GUI: **Data Processing & Reference → Import Igor Experiment…**
+    (purple button in the Data Selector). A modal dialog lets users
+    pick output folder, technique subset, and overwrite policy; on
+    success the output folder loads automatically as the current
+    data folder.
+  - Headless: `pyirena.batch.pxp_to_nexus("legacy.pxp", techniques=["USAXS"])`
+  - CLI: `python -m pyirena.io.pxp_to_nexus legacy.pxp -v`
+
+  New dependency: `igor2 >= 0.5.13` (pure Python, numpy-only).
+
+  Implementation notes:
+  - Files: `pyirena/io/pxp_to_nexus.py` (reader + writer engine),
+    `pyirena/io/nxcansas_unified.py` (extended `create_nxcansas_file`
+    with `dq=` and `metadata=` parameters), `pyirena/batch.py`
+    (`pxp_to_nexus` entry point), `pyirena/gui/data_selector.py`
+    (button + `_IgorImportDialog`), `pyirena/tests/test_pxp_to_nexus.py`
+    (11 tests).
+  - The wave-name picker (`WAVE_PICKERS`) and folder-name classifier
+    (`TECHNIQUE_FOLDERS`) are data-driven dicts at the top of
+    `pxp_to_nexus.py`; users with non-standard pipelines can extend
+    them without touching extractor logic.
+  - The reader is defensive: a single corrupt wave record (real Igor
+    files occasionally have them) is skipped and reported in the
+    summary rather than aborting the whole import.
+
 ## [0.7.2] — 2026-05-20
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -126,6 +126,14 @@ datasets, and export to Igor Pro h5xp format. Supports all pyIrena result types
 
 - [Data Explorer guide](docs/hdf5_viewer_gui.md)
 
+### Import Igor Experiment
+Open a legacy Igor Pro packed experiment (`.pxp`) and export each
+reduced USAXS/SAXS/WAXS sample as a stand-alone NXcanSAS `.h5` file.
+Brings older Igor-only data into pyIrena's analysis tools without
+re-reducing from raw detector files.
+
+- [Import Igor Experiment guide](docs/igor_pxp_import.md)
+
 ### Scattering Contrast Calculator
 Look up X-ray and neutron scattering length densities for materials by chemical
 formula. Computes contrast (Delta-rho-squared) between two materials.
@@ -223,6 +231,7 @@ and **AnythingLLM**:
 | WAXS Peak Fit GUI guide | [docs/waxs_peakfit_gui.md](docs/waxs_peakfit_gui.md) |
 | Data Merge GUI guide | [docs/data_merge_gui.md](docs/data_merge_gui.md) |
 | Data Explorer guide | [docs/hdf5_viewer_gui.md](docs/hdf5_viewer_gui.md) |
+| Import Igor Experiment (.pxp → NeXus) | [docs/igor_pxp_import.md](docs/igor_pxp_import.md) |
 | Contrast Calculator guide | [docs/scattering_contrast_gui.md](docs/scattering_contrast_gui.md) |
 | NXcanSAS file format | [docs/NXcanSAS_UnifiedFit_Format.md](docs/NXcanSAS_UnifiedFit_Format.md) |
 | Batch fitting API | [docs/batch_api.md](docs/batch_api.md) |

--- a/README.md
+++ b/README.md
@@ -195,10 +195,11 @@ Add to `claude_desktop_config.json` (or your client's MCP server config):
 }
 ```
 
-The agent can then call tools like `summarize_folder`, `tabulate_parameter`,
-`plot_iq`, `read_modeling` etc. to answer questions about analysis results in
-plain language. The underlying `pyirena.api` module is also usable as a regular
-Python library (no MCP needed).
+The agent can then call tools like `pyirena_summarize_folder`,
+`pyirena_tabulate_parameter`, `pyirena_plot_iq`, `pyirena_read_modeling` etc.
+to answer questions about analysis results in plain language. The underlying
+`pyirena.api` module is also usable as a regular Python library, with unprefixed
+names (`api.summarize_folder`, `api.plot_iq`, …) — no MCP needed.
 
 Full instructions, including configs for **Claude Desktop**, **Claude Code**,
 and **AnythingLLM**:

--- a/README.md
+++ b/README.md
@@ -127,10 +127,10 @@ datasets, and export to Igor Pro h5xp format. Supports all pyIrena result types
 - [Data Explorer guide](docs/hdf5_viewer_gui.md)
 
 ### Import Igor Experiment
-Open a legacy Igor Pro packed experiment (`.pxp`) and export each
+Open an Igor Pro packed experiment (`.pxp` or `.h5xp`) and export each
 reduced USAXS/SAXS/WAXS sample as a stand-alone NXcanSAS `.h5` file.
-Brings older Igor-only data into pyIrena's analysis tools without
-re-reducing from raw detector files.
+Brings legacy and modern Igor data into pyIrena's analysis tools
+without re-reducing from raw detector files.
 
 - [Import Igor Experiment guide](docs/igor_pxp_import.md)
 
@@ -231,7 +231,7 @@ and **AnythingLLM**:
 | WAXS Peak Fit GUI guide | [docs/waxs_peakfit_gui.md](docs/waxs_peakfit_gui.md) |
 | Data Merge GUI guide | [docs/data_merge_gui.md](docs/data_merge_gui.md) |
 | Data Explorer guide | [docs/hdf5_viewer_gui.md](docs/hdf5_viewer_gui.md) |
-| Import Igor Experiment (.pxp → NeXus) | [docs/igor_pxp_import.md](docs/igor_pxp_import.md) |
+| Import Igor Experiment (.pxp / .h5xp → NeXus) | [docs/igor_pxp_import.md](docs/igor_pxp_import.md) |
 | Contrast Calculator guide | [docs/scattering_contrast_gui.md](docs/scattering_contrast_gui.md) |
 | NXcanSAS file format | [docs/NXcanSAS_UnifiedFit_Format.md](docs/NXcanSAS_UnifiedFit_Format.md) |
 | Batch fitting API | [docs/batch_api.md](docs/batch_api.md) |

--- a/docs/ai_integration.md
+++ b/docs/ai_integration.md
@@ -43,7 +43,8 @@ AI summarises in plain language.
 
 The MCP server is a small process that the AI client spawns on demand. It
 exposes 18 tools (discovery, per-tool result reading, parameter
-aggregation across files, headless plotting) — see
+aggregation across files, headless plotting), all prefixed `pyirena_`
+(e.g. `pyirena_summarize_folder`, `pyirena_list_files`) — see
 [ai_tools_reference.md](ai_tools_reference.md).
 
 ---

--- a/docs/ai_integration.md
+++ b/docs/ai_integration.md
@@ -239,7 +239,8 @@ fetched on the fly.
 | `command not found` in client logs | macOS GUI apps don't inherit shell `PATH` | Same — absolute path |
 | Tool calls fail with `PathSecurityError` | File is outside `PYIRENA_DATA_ROOT` | Either widen the root or remove the env var while debugging |
 | File-read tools return `{"found": false, ...}` | Group not present in the file, or wrong path | Use `inspect_file()` first to see which analyses are present |
-| Plots don't render inline in the AI client | Client doesn't support inline image content from this tool | The PNG is still on disk under `PYIRENA_PLOT_CACHE` — ask the agent to give you the path |
+| Plots don't render inline in the AI client | Client doesn't support MCP `ImageContent` blocks | The PNG is on disk under `PYIRENA_PLOT_CACHE` — ask the agent for the path from the text item (content[0]) |
+| Agent prints a wall of garbled characters when a plot is requested | Agent/pipeline iterated over tool content items without checking `type`, stringifying the raw base64 PNG data | Instruct the agent: plot tools return **two content items** — `text` (file path) and `image` (base64 PNG). It must branch on `item.type`; never print or forward an `image` item as text. See [ai_tools_reference.md § Plotting](ai_tools_reference.md#plotting-returns-mixed-text--image-content) |
 | Wrong python is used | `pyirena-mcp` resolves to a different env | `head -1 $(which pyirena-mcp)` should show the python interpreter; if wrong, prepend the conda env's `bin/` to `PATH` or use a different absolute path |
 | AI calls succeed but answers are wrong | Model is the bottleneck (limited tool-use training) | Try a model trained for tool use: Claude, GPT-4, Llama 3.1+ Instruct, Qwen 2.5+, Gemma 2 Instruct |
 

--- a/docs/ai_tools_reference.md
+++ b/docs/ai_tools_reference.md
@@ -211,11 +211,40 @@ when the user asks "tell me everything about sample_X".
 
 ---
 
-### Plotting (returns inline images)
+### Plotting (returns mixed text + image content)
+
+Both plotting tools return a **two-item content list**, not a single
+value. You must handle both items by content type:
+
+| Index | `type` | What it contains |
+|-------|--------|-----------------|
+| 0 | `text` | `"Plot saved to: /abs/path/to/file.png"` — the on-disk location |
+| 1 | `image` | The PNG encoded as base64; `mimeType` is `"image/png"` |
+
+**Critical: never print or forward item 1 as a string.** It is raw
+base64 binary data. If your client or agent loop iterates over content
+items without checking `type`, it will dump thousands of characters of
+garbled text to the user. Always branch on `content[i].type`:
+
+```python
+for item in tool_result.content:
+    if item.type == "text":
+        print(item.text)          # file path — safe to show
+    elif item.type == "image":
+        display_image(item.data)  # base64 PNG — render, don't print
+```
+
+If the AI client renders content items by type natively (Claude Desktop,
+Claude Code, MCP Inspector), the image appears inline automatically and
+you do not need to handle it manually.
+
+If the client does not render images (AnythingLLM in some modes, custom
+pipelines), skip the image item entirely and tell the user the file path
+from item 0 so they can open the PNG manually.
 
 #### `pyirena_plot_iq(paths, overlay=True, log_x=True, log_y=True, output_path=None)`
-Plots I(Q) for one or more files. Returns the PNG inline (the AI client
-displays it) AND saves to disk under `PYIRENA_PLOT_CACHE`.
+Plots I(Q) for one or more files. Saves PNG to `PYIRENA_PLOT_CACHE`
+(or `output_path`) and returns both items described above.
 
 - `overlay=True` (default): one axes, all curves overlaid (colour-coded
   by file).
@@ -226,8 +255,8 @@ displays it) AND saves to disk under `PYIRENA_PLOT_CACHE`.
 
 #### `pyirena_plot_parameter_trend(folder, tool, parameter, x_axis="scan_number", subgroup_index=None, sample_filter=None, output_path=None)`
 Internally calls `pyirena_tabulate_parameter` then renders the result as
-a line+marker plot with error bars (when `stddev` is available). Returns
-the PNG inline.
+a line+marker plot with error bars (when `stddev` is available). Saves
+PNG and returns both items described above.
 
 Use for the very common request: "plot how Rg evolved across all my
 scans for sample X."
@@ -250,7 +279,9 @@ scans for sample X."
 1. pyirena_list_files("/data/run42", sort="mtime_desc", limit=3)
    → filter rows where sample == "catalyst_A"
 2. pyirena_plot_iq([row["path"] for row in rows], overlay=True)
-3. The image appears inline.
+   → content[0]: text — "Plot saved to: /tmp/.../iq_xxxxx.png"
+     content[1]: image — base64 PNG (render inline; do NOT print as text)
+3. Display the image; mention the saved path.
 ```
 
 ### "Is Rg trending across this batch?"
@@ -258,6 +289,8 @@ scans for sample X."
 1. pyirena_summarize_folder(...) — confirm unified_fit results are present.
 2. pyirena_plot_parameter_trend(folder, tool="unified_fit",
                                  parameter="Rg", subgroup_index=1)
+   → content[0]: text — file path
+     content[1]: image — base64 PNG (render inline; do NOT print as text)
 3. Describe the trend in words (slope direction, scatter, any plateau).
 ```
 

--- a/docs/ai_tools_reference.md
+++ b/docs/ai_tools_reference.md
@@ -8,6 +8,14 @@ If you are an AI assistant with access to pyirena tools, read this
 document — or have it inlined into your system prompt — before asking
 questions about a user's analysis data.
 
+> **All MCP tool names are prefixed `pyirena_`** (e.g.
+> `pyirena_summarize_folder`, `pyirena_list_files`). The prefix makes
+> tools globally unambiguous when a client connects to multiple MCP
+> servers, and avoids confusing small models with the `server-tool`
+> dash convention some clients render. The underlying Python library
+> functions in `pyirena.api` are unprefixed (`api.summarize_folder`,
+> `api.list_files`) — only the MCP wrappers carry the prefix.
+
 ---
 
 ## What pyirena gives you
@@ -40,17 +48,18 @@ means physically.
 
 Almost every interaction should start with cheap orientation calls:
 
-1. **`summarize_folder(folder)`** — get a one-shot snapshot: how many
-   files, which samples, which analyses are present per file. Use this
-   first whenever the user mentions a folder.
-2. **`list_files(folder, sort="mtime_desc", limit=20)`** — when you need
-   to identify specific files. The newest are usually most relevant.
-3. **`inspect_file(path)`** — drill into one file: sample name, exact
-   list of analyses present, Q range, number of points.
-4. **`read_<tool>(path)`** — only now load the actual results.
+1. **`pyirena_summarize_folder(folder)`** — get a one-shot snapshot:
+   how many files, which samples, which analyses are present per file.
+   Use this first whenever the user mentions a folder.
+2. **`pyirena_list_files(folder, sort="mtime_desc", limit=20)`** — when
+   you need to identify specific files. The newest are usually most
+   relevant.
+3. **`pyirena_inspect_file(path)`** — drill into one file: sample name,
+   exact list of analyses present, Q range, number of points.
+4. **`pyirena_read_<tool>(path)`** — only now load the actual results.
 
-Do not call `read_*` functions until you know which analyses exist —
-otherwise you'll get `{"found": false}` and waste a turn.
+Do not call `pyirena_read_*` functions until you know which analyses
+exist — otherwise you'll get `{"found": false}` and waste a turn.
 
 ---
 
@@ -62,8 +71,8 @@ otherwise you'll get `{"found": false}` and waste a turn.
   can defensively check `result["found"]` before using fields.
 - **Arrays are decimated by default** to about 500 points so responses
   stay small. To get the full curve, pass `include_arrays=True` on
-  per-tool readers or `include_full=True` on `read_reduced_data`. Only
-  do this when you specifically need the high-resolution shape.
+  per-tool readers or `include_full=True` on `pyirena_read_reduced_data`.
+  Only do this when you specifically need the high-resolution shape.
 - **File paths must be absolute** (or relative to `PYIRENA_DATA_ROOT` if
   that env var is set by the operator).
 - **`PYIRENA_DATA_ROOT` may restrict access.** If a file path is rejected
@@ -76,14 +85,14 @@ otherwise you'll get `{"found": false}` and waste a turn.
 
 ### Discovery — call these first
 
-#### `summarize_folder(folder, sample_filter=None)`
+#### `pyirena_summarize_folder(folder, sample_filter=None)`
 Aggregate snapshot. Returns total file count, distinct sample names, per-
 analysis file counts (e.g. `{"unified_fit": 30, "modeling": 12}`), and
 mtime range. Optional `sample_filter` is a case-insensitive substring.
 
 When to use: first call when the user mentions a folder or "all my data".
 
-#### `list_files(folder, pattern="*.h5,...", sort="mtime_desc", limit=100, deep=True)`
+#### `pyirena_list_files(folder, pattern="*.h5,...", sort="mtime_desc", limit=100, deep=True)`
 One row per file. Sort keys: `name_asc/desc`, `mtime_asc/desc`,
 `size_asc/desc`. Use `deep=False` for a faster shallow listing if you
 only need paths/sizes/mtime.
@@ -91,22 +100,23 @@ only need paths/sizes/mtime.
 When to use: you need to identify specific files (latest 3, oldest,
 matching a name pattern).
 
-#### `inspect_file(path)`
+#### `pyirena_inspect_file(path)`
 Single-file deep look. Returns sample, scan number, mtime, list of
 `analyses_present`, Q range, number of points.
 
-When to use: before any `read_*` call, to confirm what's in the file.
+When to use: before any `pyirena_read_*` call, to confirm what's in the
+file.
 
 ---
 
 ### Reading reduced data
 
-#### `read_reduced_data(path, decimate=500, include_full=False)`
+#### `pyirena_read_reduced_data(path, decimate=500, include_full=False)`
 The raw measured I(Q). Default decimation keeps response small. Set
 `include_full=True` only if you need the actual point density (rare for
 question-answering).
 
-#### `read_metadata(path)`
+#### `pyirena_read_metadata(path)`
 Sample name, label, thickness, blank file, instrument, timestamp.
 
 ---
@@ -117,23 +127,23 @@ All take `(path, include_arrays=False, max_points=500)` unless noted.
 Arrays are **omitted by default** to keep responses compact — pass
 `include_arrays=True` only when you specifically need the curves.
 
-#### `read_simple_fit(path)`
+#### `pyirena_read_simple_fit(path)`
 Returns `{model, success, chi_squared, reduced_chi_squared, dof, q_min,
 q_max, params{}, params_std{}, derived{}, ...}`. Single model per file.
 
-#### `read_unified_fit(path)`
+#### `pyirena_read_unified_fit(path)`
 Returns `{num_levels, background, chi_squared, levels: [...]}` where each
 level has `{G, Rg, B, P, RgCutoff, ETA, PACK, correlations,
 G_err, Rg_err, ...}`. Use this for the most common question:
 hierarchical structure with multiple Rg's.
 
-#### `read_size_distribution(path)`
+#### `pyirena_read_size_distribution(path)`
 Returns `{method, shape, volume_fraction, rg, chi_squared, n_iterations,
 q_power, r_min, r_max, n_bins, ...}`. With `include_arrays=True`:
 `r_grid`, `distribution` (volume-weighted P(r)), `number_dist`,
 `cumul_vol_dist`.
 
-#### `read_modeling(path)`
+#### `pyirena_read_modeling(path)`
 Returns `{chi_squared, background, populations: [...]}` where each
 population has `{pop_type, label, parameters{}, derived{}}`. `pop_type`
 is one of: `size_dist`, `unified_level`, `diffraction_peak`,
@@ -141,30 +151,30 @@ is one of: `size_dist`, `unified_level`, `diffraction_peak`,
 parameters vary by type — refer to the `parameters` dict for what's
 present.
 
-#### `read_saxs_morph(path)`
+#### `pyirena_read_saxs_morph(path)`
 Returns `{chi_squared, volume_fraction, contrast, rg_A, phi_actual,
 voxel_size, box_size_A, morphology_metrics: {...}, ...}`. The 3-D
 voxelgram itself is intentionally not exposed (too large). Morphology
 metrics include pore-size statistics, Euler number, open/closed
 porosity.
 
-#### `read_waxs_peakfit(path)`
+#### `pyirena_read_waxs_peakfit(path)`
 Returns `{n_peaks, bg_shape, chi_squared, bg_params{}, peaks: [...]}`
 where each peak has `{shape, params{Q0, A, FWHM, eta, ...},
 params_std{}, area, area_std}`.
 
-#### `read_fractals(path)`
+#### `pyirena_read_fractals(path)`
 Returns metadata for each grown fractal aggregate in the file:
 `{aggregates: [{Z, df, dmin, c, RgPrimary, RgAggregate, ...}]}`. Full
 intensity arrays per aggregate are not exposed via this tool — they
 require direct HDF5 access.
 
-#### `read_merge_provenance(path)`
+#### `pyirena_read_merge_provenance(path)`
 Returns `{scale, q_shift, background, chi_squared, q_overlap_min,
 q_overlap_max, ds1_file, ds2_file}`. Tells you how a merged file was
 constructed.
 
-#### `read_manipulation_provenance(path)`
+#### `pyirena_read_manipulation_provenance(path)`
 Returns `{operation, source_file, parameters{...}}`. Tells you whether a
 file was scaled, trimmed, rebinned, subtracted, divided, or averaged.
 
@@ -172,7 +182,7 @@ file was scaled, trimmed, rebinned, subtracted, divided, or averaged.
 
 ### Cross-file aggregation
 
-#### `tabulate_parameter(folder, tool, parameter, x_axis="scan_number", subgroup_index=None, sample_filter=None)`
+#### `pyirena_tabulate_parameter(folder, tool, parameter, x_axis="scan_number", subgroup_index=None, sample_filter=None)`
 The workhorse for trend questions. Extracts ONE scalar across every file
 in `folder` that contains the requested tool's results.
 
@@ -194,7 +204,7 @@ Returns `{n_rows, rows: [{path, name, sample, scan_number, mtime, value,
 stddev}], units, label}`. Use `value` for the plot and `stddev` for
 error bars when available.
 
-#### `summarize_sample(folder, sample)`
+#### `pyirena_summarize_sample(folder, sample)`
 Condenses one sample's history across the folder: how many files,
 analyses run, and min/max/n of every top-level scalar parameter. Use
 when the user asks "tell me everything about sample_X".
@@ -203,7 +213,7 @@ when the user asks "tell me everything about sample_X".
 
 ### Plotting (returns inline images)
 
-#### `plot_iq(paths, overlay=True, log_x=True, log_y=True, output_path=None)`
+#### `pyirena_plot_iq(paths, overlay=True, log_x=True, log_y=True, output_path=None)`
 Plots I(Q) for one or more files. Returns the PNG inline (the AI client
 displays it) AND saves to disk under `PYIRENA_PLOT_CACHE`.
 
@@ -214,9 +224,9 @@ displays it) AND saves to disk under `PYIRENA_PLOT_CACHE`.
 - WAXS data: pass `log_x=False, log_y=False` for the standard
   linear-linear WAXS view.
 
-#### `plot_parameter_trend(folder, tool, parameter, x_axis="scan_number", subgroup_index=None, sample_filter=None, output_path=None)`
-Internally calls `tabulate_parameter` then renders the result as a
-line+marker plot with error bars (when `stddev` is available). Returns
+#### `pyirena_plot_parameter_trend(folder, tool, parameter, x_axis="scan_number", subgroup_index=None, sample_filter=None, output_path=None)`
+Internally calls `pyirena_tabulate_parameter` then renders the result as
+a line+marker plot with error bars (when `stddev` is available). Returns
 the PNG inline.
 
 Use for the very common request: "plot how Rg evolved across all my
@@ -228,7 +238,7 @@ scans for sample X."
 
 ### "What's in this folder?"
 ```
-1. summarize_folder("/data/run42")
+1. pyirena_summarize_folder("/data/run42")
    → {"n_files": 47, "samples": ["catalyst_A", "catalyst_B"],
        "analyses_count": {"unified_fit": 47, "size_distribution": 47,
                           "modeling": 12}}
@@ -237,39 +247,39 @@ scans for sample X."
 
 ### "Show me the last three I(Q) curves for catalyst_A."
 ```
-1. list_files("/data/run42", sort="mtime_desc", limit=3)
+1. pyirena_list_files("/data/run42", sort="mtime_desc", limit=3)
    → filter rows where sample == "catalyst_A"
-2. plot_iq([row["path"] for row in rows], overlay=True)
+2. pyirena_plot_iq([row["path"] for row in rows], overlay=True)
 3. The image appears inline.
 ```
 
 ### "Is Rg trending across this batch?"
 ```
-1. summarize_folder(...) — confirm unified_fit results are present.
-2. plot_parameter_trend(folder, tool="unified_fit", parameter="Rg",
-                         subgroup_index=1)
+1. pyirena_summarize_folder(...) — confirm unified_fit results are present.
+2. pyirena_plot_parameter_trend(folder, tool="unified_fit",
+                                 parameter="Rg", subgroup_index=1)
 3. Describe the trend in words (slope direction, scatter, any plateau).
 ```
 
 ### "Compare the two most recent fits in detail."
 ```
-1. list_files(..., limit=2)
+1. pyirena_list_files(..., limit=2)
 2. For each of the two paths:
-   - inspect_file(path) to see which analyses are present
-   - read_unified_fit(path) — get parameters
+   - pyirena_inspect_file(path) to see which analyses are present
+   - pyirena_read_unified_fit(path) — get parameters
 3. Present the parameters side by side and comment on differences.
 ```
 
 ### "Why might Rg jump at scan 17?"
 ```
-1. tabulate_parameter(..., tool="unified_fit", parameter="Rg",
-                       subgroup_index=1)
+1. pyirena_tabulate_parameter(..., tool="unified_fit", parameter="Rg",
+                                subgroup_index=1)
 2. Identify the jump in the rows.
 3. For scan 17 specifically:
-   - inspect_file → confirm what data is there
-   - read_metadata → sample notes, thickness, blank
-   - read_reduced_data(include_full=True) — get the actual curve to
-     comment on changes in slope / Guinier region
+   - pyirena_inspect_file → confirm what data is there
+   - pyirena_read_metadata → sample notes, thickness, blank
+   - pyirena_read_reduced_data(include_full=True) — get the actual curve
+     to comment on changes in slope / Guinier region
 4. Hypothesise (changed sample? exposure? beam intensity?
    contamination?). Always frame as hypotheses, not certainties.
 ```
@@ -278,9 +288,9 @@ scans for sample X."
 
 ## Things to avoid
 
-- **Don't call `read_*` blindly.** Use `inspect_file` first to confirm
-  the analysis is there. Otherwise you'll get `{"found": false}` and
-  burn a turn.
+- **Don't call `pyirena_read_*` blindly.** Use `pyirena_inspect_file`
+  first to confirm the analysis is there. Otherwise you'll get
+  `{"found": false}` and burn a turn.
 - **Don't request full arrays unless necessary.** `include_arrays=True`
   / `include_full=True` make responses much larger and consume your
   context budget. For most questions, the scalar summary is enough.
@@ -290,7 +300,7 @@ scans for sample X."
   "this Rg means …") should be framed as "consistent with…" and tied to
   what the user has told you about their sample.
 - **Don't try to write or modify files.** v0.7 is read-only. There are
-  no `save_*`, `update_*`, or `run_*` tools.
+  no `pyirena_save_*`, `pyirena_update_*`, or `pyirena_run_*` tools.
 
 ---
 

--- a/docs/batch_api.md
+++ b/docs/batch_api.md
@@ -19,11 +19,12 @@ is no need to write configuration code by hand.
 8. [API reference — `fit_saxs_morph`](#fit_saxs_morph)
 9. [API reference — `merge_data`](#merge_data)
 10. [API reference — `average_data`](#average_data)
-11. [API reference — `fit_pyirena`](#fit_pyirena)
-12. [Return structures](#return-structures)
-13. [Error handling](#error-handling)
-14. [Batch processing patterns](#batch-processing-patterns)
-15. [Extending with new tools](#extending-with-new-tools)
+11. [API reference — `pxp_to_nexus`](#pxp_to_nexus)
+12. [API reference — `fit_pyirena`](#fit_pyirena)
+13. [Return structures](#return-structures)
+14. [Error handling](#error-handling)
+15. [Batch processing patterns](#batch-processing-patterns)
+16. [Extending with new tools](#extending-with-new-tools)
 
 ---
 
@@ -1119,6 +1120,85 @@ by random chance alone.  Low p → curves differ → likely damaged.
 2. Run on a sample known to contain damaged frames.  Raise the threshold
    until the damaged frames appear in `result['rejected']`.
 3. Fix the threshold in your pipeline configuration.
+
+---
+
+## `pxp_to_nexus`
+
+```python
+from pyirena.batch import pxp_to_nexus
+
+result = pxp_to_nexus(
+    pxp_file,                    # str or Path — input .pxp
+    output_folder=None,          # str/Path/None — default: <stem>_data
+    techniques=None,             # list[str]/None — e.g. ["USAXS", "SAXS"]
+    overwrite=False,             # bool — append _2,_3,… if False
+    verbose=False,               # bool — print per-file summary
+)
+```
+
+Import a legacy Igor Pro packed experiment (`.pxp`) and export each
+reduced USAXS / SAXS / WAXS sample as a stand-alone NXcanSAS HDF5 file.
+This is the headless counterpart of the GUI's
+**Import Igor Experiment…** button.
+
+### What it does
+
+1. Walks the experiment's folder tree (`root:USAXS:...`, `root:SAXS:...`,
+   `root:WAXS:...`).
+2. For each sample folder, picks the documented wave triple
+   (`DSM_*` for USAXS, `R_*` for SAXS/WAXS).
+3. Parses the wave note — including APS USAXS's `NXSampleStart`/`End`
+   and `NXInstrumentStart`/`End` sentinel blocks — into NXcanSAS
+   sample/instrument metadata.
+4. Writes one `.h5` per sample into
+   `<output_folder>/<technique>/<sample>.h5`.
+
+### Returns
+
+```python
+{
+    'success': True,
+    'output_folder': str,
+    'n_written': int,
+    'n_skipped': int,
+    'n_errors':  int,
+    'n_unparseable_records': int,
+    'files': [
+        {
+            'source':    str,   # Igor folder path, e.g. "root:SAXS:Sample01"
+            'output':    str,   # absolute path to the .h5 file (or None)
+            'technique': str,   # "USAXS" | "SAXS" | "WAXS"
+            'n_points':  int,
+            'status':    str,   # "ok" | "skipped" | "error"
+            'message':   str,   # explanation for skipped/error rows
+        },
+        ...
+    ],
+}
+```
+
+Returns `None` only if the input `.pxp` cannot be found.
+
+### Example
+
+```python
+from pyirena.batch import pxp_to_nexus, fit_pyirena
+from pathlib import Path
+
+# 1. Bring legacy Igor data into NeXus.
+imported = pxp_to_nexus("2020_beamtime.pxp", techniques=["USAXS"])
+print(f"Got {imported['n_written']} USAXS files")
+
+# 2. Fit each one with the standard pyirena config.
+out_dir = Path(imported['output_folder']) / "USAXS"
+for h5 in sorted(out_dir.glob("*.h5")):
+    fit_pyirena(str(h5), "pyirena_config.json")
+```
+
+See the [Import Igor Experiment guide](igor_pxp_import.md) for the
+wave-name and folder-name conventions, and how to extend them for
+non-standard reduction pipelines.
 
 ---
 

--- a/docs/batch_api.md
+++ b/docs/batch_api.md
@@ -19,7 +19,7 @@ is no need to write configuration code by hand.
 8. [API reference — `fit_saxs_morph`](#fit_saxs_morph)
 9. [API reference — `merge_data`](#merge_data)
 10. [API reference — `average_data`](#average_data)
-11. [API reference — `pxp_to_nexus`](#pxp_to_nexus)
+11. [API reference — `igor_to_nexus`](#igor_to_nexus)
 12. [API reference — `fit_pyirena`](#fit_pyirena)
 13. [Return structures](#return-structures)
 14. [Error handling](#error-handling)
@@ -1123,13 +1123,13 @@ by random chance alone.  Low p → curves differ → likely damaged.
 
 ---
 
-## `pxp_to_nexus`
+## `igor_to_nexus`  *(formerly `pxp_to_nexus`)*
 
 ```python
-from pyirena.batch import pxp_to_nexus
+from pyirena.batch import igor_to_nexus
 
-result = pxp_to_nexus(
-    pxp_file,                    # str or Path — input .pxp
+result = igor_to_nexus(
+    igor_file,                   # str or Path — input .pxp OR .h5xp
     output_folder=None,          # str/Path/None — default: <stem>_data
     techniques=None,             # list[str]/None — e.g. ["USAXS", "SAXS"]
     overwrite=False,             # bool — append _2,_3,… if False
@@ -1137,10 +1137,13 @@ result = pxp_to_nexus(
 )
 ```
 
-Import a legacy Igor Pro packed experiment (`.pxp`) and export each
-reduced USAXS / SAXS / WAXS sample as a stand-alone NXcanSAS HDF5 file.
-This is the headless counterpart of the GUI's
-**Import Igor Experiment…** button.
+Import an Igor Pro packed experiment and export each reduced USAXS /
+SAXS / WAXS sample as a stand-alone NXcanSAS HDF5 file. Accepts both
+`.pxp` (legacy binary) and `.h5xp` (modern HDF5) — the format is
+auto-detected from the file extension. This is the headless counterpart
+of the GUI's **Import Igor Experiment…** button.
+
+> `pxp_to_nexus(...)` remains as a deprecated alias for back-compat.
 
 ### What it does
 
@@ -1183,11 +1186,11 @@ Returns `None` only if the input `.pxp` cannot be found.
 ### Example
 
 ```python
-from pyirena.batch import pxp_to_nexus, fit_pyirena
+from pyirena.batch import igor_to_nexus, fit_pyirena
 from pathlib import Path
 
 # 1. Bring legacy Igor data into NeXus.
-imported = pxp_to_nexus("2020_beamtime.pxp", techniques=["USAXS"])
+imported = igor_to_nexus("2020_beamtime.pxp", techniques=["USAXS"])
 print(f"Got {imported['n_written']} USAXS files")
 
 # 2. Fit each one with the standard pyirena config.

--- a/docs/igor_pxp_import.md
+++ b/docs/igor_pxp_import.md
@@ -305,12 +305,50 @@ instrument.
   Distribution, etc.) are *not* parsed. Re-fit them in pyIrena using
   the imported NeXus files — that way the results are stored in the
   pyIrena schema and can be browsed by the HDF5 Viewer.
-- **One known igor2 quirk.** The upstream `igor2` package occasionally
-  fails to decode a single wave record in older Igor experiments
-  (typically a text or dependency-formula wave). The importer is
-  defensive — it skips that record and reports it in
-  `n_unparseable_records` rather than aborting, so the rest of the
-  experiment still extracts cleanly.
+
+### Long folder/wave names in `.pxp` (Igor 8+ format) — use `.h5xp` instead
+
+Igor Pro 8 introduced a new on-disk format for folders and waves whose
+names exceed **31 characters**. The format uses record types that
+`igor2` (the underlying parser) does not understand, so those folders
+are invisible to the `.pxp` importer. A typical symptom is that an
+experiment containing ~700 time-series samples imports only the
+samples whose folder names fit in 31 characters (e.g.
+`AMC_04_07_26_3min_0033` works; `AMC_25_crystalline_04_07_26_10min_0036`
+is silently skipped).
+
+**The fix is straightforward in Igor**: save the experiment as
+`.h5xp` instead of `.pxp`, then import the `.h5xp` into pyIrena.
+The HDF5-based `.h5xp` format has no name-length restriction, and
+pyIrena reads it directly:
+
+1. In Igor Pro, choose **Data → Save Data → Save Experiment As Packed HDF5
+   Experiment...** (or `SaveExperiment /P=path "Filename.h5xp"` from
+   the command line).
+2. Import the resulting `.h5xp` in pyIrena exactly as you would a
+   `.pxp` — same button, same API, same output.
+
+We deliberately do not attempt to reverse-engineer Igor 8's new `.pxp`
+encoding for long names: the format is undocumented, the `.h5xp` route
+is officially supported by Wavemetrics, and a future `igor2` release
+may add `.pxp` long-name support upstream. When that happens we'll
+pick it up automatically by bumping the `igor2` minimum version.
+
+### Other quirks
+
+- **One unparseable record per file is normal.** Wavemetrics' `igor2`
+  parser occasionally fails on a single text or dependency-formula
+  wave per experiment. These never carry I(Q) data, so the result is
+  cosmetic: a `Note: 1 wave record(s) could not be parsed` line in
+  the summary. Safe to ignore.
+- **Per-sample vs per-technique layouts both work.** If your samples
+  live under `root:USAXS:`, `root:SAXS:`, `root:WAXS:`, the importer
+  produces one file per sample under the matching technique folder.
+  If your samples instead live at root level (`root:Sample01/...`)
+  with USAXS/SAXS/WAXS waves all inside the same folder — common for
+  in-situ time series — the importer recognises this and emits up to
+  three files per sample, one per technique whose wave triple is
+  present.
 
 ## Troubleshooting
 

--- a/docs/igor_pxp_import.md
+++ b/docs/igor_pxp_import.md
@@ -1,18 +1,22 @@
-# Importing Igor Pro Packed Experiments (.pxp)
+# Importing Igor Pro Packed Experiments (.pxp / .h5xp)
 
-The **Import Igor Experiment** tool lets you bring data from a legacy Igor
-Pro packed experiment (`.pxp`) into pyIrena for analysis. Each USAXS, SAXS,
-or WAXS sample in the experiment becomes a stand-alone NXcanSAS `.h5`
-file that any pyIrena tool (Unified Fit, Size Distribution, Modeling,
-…) can open directly.
+The **Import Igor Experiment** tool lets you bring data from an Igor Pro
+packed experiment (`.pxp` — legacy binary, or `.h5xp` — modern HDF5
+packed-experiment) into pyIrena for analysis. Each USAXS, SAXS, or WAXS
+sample in the experiment becomes a stand-alone NXcanSAS `.h5` file that
+any pyIrena tool (Unified Fit, Size Distribution, Modeling, …) can open
+directly.
 
 The tool is available three ways:
 
 | Mode             | How to launch                                                          |
 |------------------|------------------------------------------------------------------------|
 | Interactive GUI  | **Data Processing & Reference → Import Igor Experiment…** in the Data Selector |
-| Python API       | `from pyirena.batch import pxp_to_nexus`                                |
+| Python API       | `from pyirena.batch import igor_to_nexus`                              |
 | CLI              | `python -m pyirena.io.pxp_to_nexus legacy.pxp -v`                       |
+
+The format is detected from the file extension; the same interface
+handles both `.pxp` and `.h5xp`.
 
 ---
 
@@ -125,13 +129,13 @@ the folder names encode experimental conditions you care about.
 ## Python API
 
 ```python
-from pyirena.batch import pxp_to_nexus
+from pyirena.batch import igor_to_nexus
 
-result = pxp_to_nexus(
-    pxp_file="legacy.pxp",
-    output_folder=None,         # default: <pxp_stem>_data next to input
-    techniques=["USAXS"],       # default: None = all present
-    overwrite=False,            # default: append _2, _3, …
+result = igor_to_nexus(
+    igor_file="legacy.pxp",       # or "modern.h5xp" — format auto-detected
+    output_folder=None,           # default: <stem>_data next to input
+    techniques=["USAXS"],         # default: None = all present
+    overwrite=False,              # default: append _2, _3, …
     verbose=True,
 )
 
@@ -140,6 +144,10 @@ for f in result['files']:
     if f['status'] != 'ok':
         print(f"  {f['status']}: {f['source']} — {f['message']}")
 ```
+
+> **Deprecated alias**: `pyirena.batch.pxp_to_nexus()` is kept as a
+> thin wrapper around `igor_to_nexus()` so existing scripts continue
+> to work. New code should prefer `igor_to_nexus`.
 
 Returned dict:
 
@@ -194,7 +202,7 @@ TECHNIQUE_FOLDERS = {
 Matching is case-insensitive. The folder name **inside** Igor (e.g.
 `root:Imported SAXS:...`) is what's checked.
 
-### Per-technique wave triples
+### Per-technique wave triples (.pxp)
 
 ```python
 WAVE_PICKERS = {
@@ -209,6 +217,29 @@ importer tries the entries in order; the first one whose Q, I, and
 Err waves all exist in a sample folder wins. dQ is optional — if the
 named wave isn't there, `Qdev` is simply omitted from the NeXus file.
 
+### Per-technique wave triples (.h5xp)
+
+```python
+WAVE_PICKERS_H5XP = {
+    "USAXS": [
+        ("q_<folder>", "r_<folder>", "s_<folder>", "dq_<folder>"),
+        ("Q",          "R",          "S",          "dQ"),
+    ],
+    "SAXS":  [ ... same shape ... ],
+    "WAXS":  [ ... same shape ... ],
+}
+```
+
+The literal token `<folder>` is replaced with the sample folder name at
+lookup time, matching the two conventions emitted by
+`pyirena.io.h5xp_writer.write_iq_data`:
+
+- lowercase suffixed: `q_<folder>`/`r_<folder>`/`s_<folder>`/`dq_<folder>`
+  — the per-sample-folder default
+- uppercase plain: `Q`/`R`/`S`/`dQ` — older Igor-side exports
+
+### Extending the pickers
+
 To add a new pattern (e.g. exporting slit-smeared USAXS as well), append
 a tuple:
 
@@ -220,8 +251,17 @@ WAVE_PICKERS["USAXS"].append(
 
 ## Wave-note metadata
 
-Igor wave notes use the convention `key=value;key=value;`. The APS USAXS
-pipeline wraps NeXus-style metadata in sentinel markers:
+Igor wave notes carry per-wave metadata as `key`/`value` pairs. The
+separator depends on format:
+
+- **.pxp** files use `key=value;` (equals sign)
+- **.h5xp** files use `key:value;` (colon)
+
+The parser auto-detects the separator on a per-note basis, so the same
+metadata extraction code handles both formats identically.
+
+The APS USAXS pipeline (.pxp) wraps NeXus-style metadata in sentinel
+markers:
 
 ```
 DATAFILE=03_31_run.dat;DATE=2026-03-31 12:22:05;COMMENT=Sample01;

--- a/docs/igor_pxp_import.md
+++ b/docs/igor_pxp_import.md
@@ -1,0 +1,298 @@
+# Importing Igor Pro Packed Experiments (.pxp)
+
+The **Import Igor Experiment** tool lets you bring data from a legacy Igor
+Pro packed experiment (`.pxp`) into pyIrena for analysis. Each USAXS, SAXS,
+or WAXS sample in the experiment becomes a stand-alone NXcanSAS `.h5`
+file that any pyIrena tool (Unified Fit, Size Distribution, Modeling,
+…) can open directly.
+
+The tool is available three ways:
+
+| Mode             | How to launch                                                          |
+|------------------|------------------------------------------------------------------------|
+| Interactive GUI  | **Data Processing & Reference → Import Igor Experiment…** in the Data Selector |
+| Python API       | `from pyirena.batch import pxp_to_nexus`                                |
+| CLI              | `python -m pyirena.io.pxp_to_nexus legacy.pxp -v`                       |
+
+---
+
+## Contents
+
+1. [When to use this tool](#when-to-use-this-tool)
+2. [What gets exported](#what-gets-exported)
+3. [GUI walkthrough](#gui-walkthrough)
+4. [Output folder layout](#output-folder-layout)
+5. [Python API](#python-api)
+6. [CLI reference](#cli-reference)
+7. [Wave-name and folder-name conventions](#wave-name-and-folder-name-conventions)
+8. [Wave-note metadata](#wave-note-metadata)
+9. [Limitations](#limitations)
+10. [Troubleshooting](#troubleshooting)
+
+---
+
+## When to use this tool
+
+Use it whenever your reduced 1-D scattering data lives in an Igor Pro
+experiment (`.pxp` or `.pxt`) and you want to analyse it in pyIrena
+without going back to raw detector files.
+
+Typical scenarios:
+
+- **Legacy archives** — years of USAXS/SAXS/WAXS data reduced with the
+  original Igor pipeline, stored as one `.pxp` per beamtime.
+- **Quick triage** — somebody hands you an Igor experiment with 30
+  samples; you want to fit Unified or size distributions to all of them
+  in one go without manual export.
+- **Round-tripping** — combine with the existing **Export to Igor**
+  (h5xp writer) for Python → Igor → Python workflows.
+
+The reverse direction — exporting pyIrena results *into* an Igor `.h5xp`
+packed experiment — is documented in
+[`hdf5_viewer_gui.md`](hdf5_viewer_gui.md#export-to-igor).
+
+## What gets exported
+
+For each sample folder the tool recognises (see [conventions](#wave-name-and-folder-name-conventions)),
+one NXcanSAS `.h5` file is written containing:
+
+| Dataset                        | Source wave                                   | Notes                                  |
+|--------------------------------|-----------------------------------------------|----------------------------------------|
+| `entry/<sample>/sasdata/Q`     | `DSM_Qvec` (USAXS) or `R_Qvec` (SAXS/WAXS)    | units = `1/angstrom`                  |
+| `entry/<sample>/sasdata/I`     | `DSM_Int`  or `R_Int`                          | units = `1/cm`                        |
+| `entry/<sample>/sasdata/Idev`  | `DSM_Error` or `R_Error`                       | always written                        |
+| `entry/<sample>/sasdata/Qdev`  | `DSM_dQ`                                       | written only when the source wave exists |
+| `entry/sample/*`               | parsed from `NXSampleStart…End` in the note    | when present                          |
+| `entry/instrument/*`           | parsed from `NXInstrumentStart…End`            | wavelength is hoisted to `entry/instrument/beam/incident_wavelength` |
+| `entry/notes/*`                | everything else from the wave note             | preserved verbatim                    |
+
+Samples whose folders **don't** contain the expected wave triple are
+skipped silently — typically these are "blank" / "raw" folders that
+were never desmeared or reduced.
+
+## GUI walkthrough
+
+1. Open the Data Selector (`pyirena-gui`).
+2. Click **Import Igor Experiment…** in the *Data Processing &
+   Reference* group (purple button).
+3. Pick the `.pxp` file in the file dialog.
+4. In the import dialog:
+   - **Output folder** — defaults to `<pxp_stem>_data` next to the input.
+   - **Techniques to export** — three checkboxes (USAXS / SAXS / WAXS),
+     all on by default.
+   - **Overwrite existing files** — off by default; an unused suffix
+     (`_2`, `_3`, …) is appended to keep both copies if the target
+     filename exists.
+5. Click **Import**. Extraction runs synchronously (a 16-MB legacy
+   experiment with 50+ samples finishes in 1–2 s on a typical laptop).
+6. A summary dialog reports the per-technique tally and offers to load
+   the output folder as the current data folder, so you can start
+   analysing immediately.
+
+## Output folder layout
+
+A 60-sample APS USAXS experiment with all three techniques produces:
+
+```
+legacy_2024_data/
+├── USAXS/
+│   ├── Sample01.h5
+│   ├── Sample02.h5
+│   └── ...
+├── SAXS/
+│   ├── Sample01.h5
+│   └── ...
+└── WAXS/
+    ├── Sample01.h5
+    └── ...
+```
+
+If your Igor experiment uses nested sub-folders for in-situ runs
+(e.g. `root:SAXS:heater_run_42:step_03:Sample01`), the importer
+**mirrors** that depth in the output:
+
+```
+legacy_2024_data/
+└── SAXS/
+    └── heater_run_42/
+        └── step_03/
+            └── Sample01.h5
+```
+
+This preserves the organisation you already chose in Igor — useful when
+the folder names encode experimental conditions you care about.
+
+## Python API
+
+```python
+from pyirena.batch import pxp_to_nexus
+
+result = pxp_to_nexus(
+    pxp_file="legacy.pxp",
+    output_folder=None,         # default: <pxp_stem>_data next to input
+    techniques=["USAXS"],       # default: None = all present
+    overwrite=False,            # default: append _2, _3, …
+    verbose=True,
+)
+
+print(f"Wrote {result['n_written']} files to {result['output_folder']}")
+for f in result['files']:
+    if f['status'] != 'ok':
+        print(f"  {f['status']}: {f['source']} — {f['message']}")
+```
+
+Returned dict:
+
+| Key                       | Type     | Meaning                                                                 |
+|---------------------------|----------|-------------------------------------------------------------------------|
+| `success`                 | bool     | always `True` if the function returns                                    |
+| `output_folder`           | str      | absolute path of the output folder                                       |
+| `n_written`               | int      | number of `.h5` files successfully written                               |
+| `n_skipped`               | int      | sample folders that didn't have a recognised wave triple                 |
+| `n_errors`                | int      | sample folders that failed during file write                             |
+| `n_unparseable_records`   | int      | wave records in the `.pxp` that igor2 couldn't decode (usually 0–1)      |
+| `files`                   | list     | per-folder dicts with `source`, `output`, `technique`, `n_points`, `status`, `message` |
+
+Returns `None` only if the input path does not exist.
+
+## CLI reference
+
+```
+python -m pyirena.io.pxp_to_nexus PXP [-o OUTPUT] [-t TECHNIQUE] [--overwrite] [-v]
+```
+
+Options:
+
+| Flag              | Meaning                                                                |
+|-------------------|------------------------------------------------------------------------|
+| `-o, --output`    | Output folder. Default: `<pxp_stem>_data` next to the input.           |
+| `-t, --technique` | Only export this technique. Repeat for multiple (e.g. `-t USAXS -t SAXS`). |
+| `--overwrite`     | Overwrite existing output files instead of appending `_2`, `_3`, …     |
+| `-v, --verbose`   | Print a per-file summary table.                                        |
+
+Exit status is 0 if all files wrote successfully, 1 otherwise.
+
+## Wave-name and folder-name conventions
+
+The recognition tables are **data-driven dicts at the top of
+`pyirena/io/pxp_to_nexus.py`** — you can extend them in-place if your
+group uses different conventions.
+
+### Top-level folder → technique
+
+```python
+TECHNIQUE_FOLDERS = {
+    "USAXS":         "USAXS",
+    "SAXS":          "SAXS",
+    "WAXS":          "WAXS",
+    "Imported SAXS": "SAXS",
+    "SAS":           "SAXS",
+    "Imported":      "SAXS",
+}
+```
+
+Matching is case-insensitive. The folder name **inside** Igor (e.g.
+`root:Imported SAXS:...`) is what's checked.
+
+### Per-technique wave triples
+
+```python
+WAVE_PICKERS = {
+    "USAXS": [("DSM_Qvec", "DSM_Int", "DSM_Error", "DSM_dQ")],
+    "SAXS":  [("R_Qvec",   "R_Int",   "R_Error",   None)],
+    "WAXS":  [("R_Qvec",   "R_Int",   "R_Error",   None)],
+}
+```
+
+Each entry is `(Q_name, I_name, Err_name, dQ_name_or_None)`. The
+importer tries the entries in order; the first one whose Q, I, and
+Err waves all exist in a sample folder wins. dQ is optional — if the
+named wave isn't there, `Qdev` is simply omitted from the NeXus file.
+
+To add a new pattern (e.g. exporting slit-smeared USAXS as well), append
+a tuple:
+
+```python
+WAVE_PICKERS["USAXS"].append(
+    ("SMR_Qvec", "SMR_Int", "SMR_Error", "SMR_dQ"),
+)
+```
+
+## Wave-note metadata
+
+Igor wave notes use the convention `key=value;key=value;`. The APS USAXS
+pipeline wraps NeXus-style metadata in sentinel markers:
+
+```
+DATAFILE=03_31_run.dat;DATE=2026-03-31 12:22:05;COMMENT=Sample01;
+Nexus_attributesStartHere;
+NXUserStart;...;NXUserEnd;
+NXSampleStart;name=Sample01;thickness=4;temperature=20;NXSampleEnd;
+NXInstrumentStart;name=APS USAXS;wavelength=0.5904;NXInstrumentEnd;
+NXMetadataStart;...;NXMetadataEnd;
+Nexus_attributesEndHere;
+SlitLength=0.024;NumberOfSteps=100;...
+```
+
+The parser maps these to NXcanSAS as follows:
+
+| Marker pair                                  | Lands in              |
+|----------------------------------------------|-----------------------|
+| `NXSampleStart` … `NXSampleEnd`              | `entry/sample/<key>`  |
+| `NXInstrumentStart` … `NXInstrumentEnd`     | `entry/instrument/<key>` |
+| `NXUserStart` … `NXUserEnd`                  | `entry/notes/user_<key>` |
+| `NXMetadataStart` … `NXMetadataEnd`         | `entry/notes/<key>`   |
+| `DATAFILE=...` (top-level)                   | `entry/title` + `entry/notes/DATAFILE` |
+| `DATE=...` (top-level)                       | `entry/start_time` + `entry/notes/DATE` |
+| `COMMENT=...` (top-level)                    | `entry/title` (only if no DATAFILE) |
+| Any other top-level `key=value`              | `entry/notes/<key>`   |
+
+The `instrument.wavelength` value is also hoisted into the canonical
+NXcanSAS location `entry/instrument/beam/incident_wavelength` so that
+downstream tools find it at the spec-mandated path.
+
+Bare wave-level annotations (`units=...`, `long_name=...`, `Wname=...`)
+are dropped — they describe the wave itself, not the sample or
+instrument.
+
+## Limitations
+
+- **Reduced 1-D data only.** 2-D detector frames, calibration tables,
+  and Igor procedure files are ignored. The goal is to bring
+  analysis-ready I(Q) into pyIrena, not to fully round-trip an entire
+  Igor experiment.
+- **No analysis-result import.** Fits stored in Igor (Unified, Size
+  Distribution, etc.) are *not* parsed. Re-fit them in pyIrena using
+  the imported NeXus files — that way the results are stored in the
+  pyIrena schema and can be browsed by the HDF5 Viewer.
+- **One known igor2 quirk.** The upstream `igor2` package occasionally
+  fails to decode a single wave record in older Igor experiments
+  (typically a text or dependency-formula wave). The importer is
+  defensive — it skips that record and reports it in
+  `n_unparseable_records` rather than aborting, so the rest of the
+  experiment still extracts cleanly.
+
+## Troubleshooting
+
+**"0 files written" but the experiment definitely has samples** —
+your folder layout probably doesn't match `TECHNIQUE_FOLDERS`. Open
+the `.pxp` in Igor and check the top-level folder names. If they're
+e.g. `MyData_USAXS`, `MyData_SAXS`, add them to the dict.
+
+**Sample folders show up as skipped** — they don't contain the
+expected wave triple. Likely causes:
+
+- It's a "blank" folder that holds raw detector counts only (intended
+  behaviour — these are correctly skipped).
+- The reduction pipeline used a different wave-name convention. Add
+  a tuple to `WAVE_PICKERS` for the relevant technique.
+
+**"igor2 is required" ImportError** — install it: `pip install igor2`
+(or `pip install -e ".[gui]"` to get the full pyIrena stack).
+`igor2` is a hard dependency now and is pulled in automatically by
+both `pip install pyirena` and `environment.yml`.
+
+**Imported files don't appear in the Data Selector** — the importer
+already calls the same NXcanSAS locator (`find_matching_groups`) that
+pyIrena's reader uses, so this shouldn't happen. If it does, file an
+issue with one of the offending `.h5` files attached.

--- a/pyirena/__init__.py
+++ b/pyirena/__init__.py
@@ -29,14 +29,17 @@ References:
     Beaucage, G. (1996). J. Appl. Cryst. 29, 134-146
 """
 
-__version__ = "0.7.2"
+__version__ = "0.8.0"
 __author__ = "Jan Ilavsky"
 __email__ = "ilavsky@aps.anl.gov"
 
 from pyirena.core.unified import UnifiedFitModel, UnifiedLevel, load_data_from_nxcansas
 from pyirena.core.sizes import SizesDistribution
 from pyirena.core.simple_fits import SimpleFitModel, MODEL_REGISTRY, MODEL_NAMES
-from pyirena.batch import fit_unified, fit_sizes, fit_simple, fit_pyirena, manipulate_data, average_data, fit_saxs_morph
+from pyirena.batch import (
+    fit_unified, fit_sizes, fit_simple, fit_pyirena,
+    manipulate_data, average_data, fit_saxs_morph, pxp_to_nexus,
+)
 from pyirena.io.results import load_result, SUPPORTED_ANALYSES
 
 try:
@@ -59,6 +62,7 @@ __all__ = [
     "fit_saxs_morph",
     "manipulate_data",
     "average_data",
+    "pxp_to_nexus",
     "load_result",
     "SUPPORTED_ANALYSES",
     "plot_saxs",

--- a/pyirena/__init__.py
+++ b/pyirena/__init__.py
@@ -29,7 +29,7 @@ References:
     Beaucage, G. (1996). J. Appl. Cryst. 29, 134-146
 """
 
-__version__ = "0.8.0"
+__version__ = "0.8.1"
 __author__ = "Jan Ilavsky"
 __email__ = "ilavsky@aps.anl.gov"
 
@@ -38,7 +38,8 @@ from pyirena.core.sizes import SizesDistribution
 from pyirena.core.simple_fits import SimpleFitModel, MODEL_REGISTRY, MODEL_NAMES
 from pyirena.batch import (
     fit_unified, fit_sizes, fit_simple, fit_pyirena,
-    manipulate_data, average_data, fit_saxs_morph, pxp_to_nexus,
+    manipulate_data, average_data, fit_saxs_morph,
+    igor_to_nexus, pxp_to_nexus,
 )
 from pyirena.io.results import load_result, SUPPORTED_ANALYSES
 
@@ -62,6 +63,7 @@ __all__ = [
     "fit_saxs_morph",
     "manipulate_data",
     "average_data",
+    "igor_to_nexus",
     "pxp_to_nexus",
     "load_result",
     "SUPPORTED_ANALYSES",

--- a/pyirena/__init__.py
+++ b/pyirena/__init__.py
@@ -29,7 +29,7 @@ References:
     Beaucage, G. (1996). J. Appl. Cryst. 29, 134-146
 """
 
-__version__ = "0.8.1"
+__version__ = "0.8.2"
 __author__ = "Jan Ilavsky"
 __email__ = "ilavsky@aps.anl.gov"
 

--- a/pyirena/api/aggregate.py
+++ b/pyirena/api/aggregate.py
@@ -103,10 +103,11 @@ def _extract_scalar(f: h5py.File, tool: str, parameter: str,
         return None, None, None
     grp = f[group_path]
 
-    # Find matching scalar spec
+    # Find matching scalar spec (case-insensitive so AI can pass 'Rg' or 'rg')
     spec = None
+    parameter_lc = parameter.lower()
     for sc in schema["scalars"]:
-        if sc["key"] == parameter:
+        if sc["key"].lower() == parameter_lc:
             spec = sc
             break
     if spec is None:

--- a/pyirena/batch.py
+++ b/pyirena/batch.py
@@ -2421,6 +2421,10 @@ def igor_to_nexus(
         print(f"  errors:   {res.n_errors}")
         if res.n_unparseable_records:
             print(f"  note:     {res.n_unparseable_records} wave record(s) could not be parsed")
+        if res.n_igor8_longname_markers:
+            print(f"  WARNING:  {res.n_igor8_longname_markers} Igor-8 long-name "
+                  f"record(s) seen — some samples likely missing. "
+                  f"Re-save as .h5xp from Igor.")
 
     return {
         'success':     True,
@@ -2429,6 +2433,7 @@ def igor_to_nexus(
         'n_skipped':   res.n_skipped,
         'n_errors':    res.n_errors,
         'n_unparseable_records': res.n_unparseable_records,
+        'n_igor8_longname_markers': res.n_igor8_longname_markers,
         'files':       files_list,
     }
 

--- a/pyirena/batch.py
+++ b/pyirena/batch.py
@@ -2333,23 +2333,27 @@ def average_data(
 # Igor packed experiment (.pxp) import
 # ---------------------------------------------------------------------------
 
-def pxp_to_nexus(
-    pxp_file: Union[str, Path],
+def igor_to_nexus(
+    igor_file: Union[str, Path],
     output_folder: Optional[Union[str, Path]] = None,
     techniques: Optional[List[str]] = None,
     overwrite: bool = False,
     verbose: bool = False,
 ) -> Optional[Dict]:
-    """Import an Igor Pro packed experiment (.pxp) and export reduced data as NeXus files.
+    """Import an Igor Pro packed experiment (.pxp **or** .h5xp) and export
+    its reduced data as per-sample NeXus files.
 
-    Walks the experiment's USAXS / SAXS / WAXS folder hierarchy and writes one
-    NXcanSAS ``.h5`` file per sample. See
-    :func:`pyirena.io.pxp_to_nexus.extract_pxp_to_nexus` for details of the
-    folder and wave-name conventions recognised.
+    Auto-detects the format from the file extension and dispatches to the
+    appropriate reader. Both formats produce the same output: one
+    NXcanSAS ``.h5`` per sample under
+    ``<output>/<technique>/<sample>.h5`` (see
+    :func:`pyirena.io.pxp_to_nexus.extract_igor_experiment` for the
+    folder and wave-name conventions recognised).
 
     Args:
-        pxp_file: Path to the input ``.pxp`` file.
-        output_folder: Destination directory. Defaults to ``<pxp_stem>_data``
+        igor_file: Path to the input ``.pxp`` (binary Igor packed) or
+            ``.h5xp`` (Wavemetrics HDF5 packed) experiment.
+        output_folder: Destination directory. Defaults to ``<stem>_data``
             next to the input file. Created if it does not exist.
         techniques: List of techniques to export, e.g. ``["USAXS", "SAXS"]``.
             ``None`` (default) exports every technique present in the file.
@@ -2362,30 +2366,39 @@ def pxp_to_nexus(
         ``output_folder``, ``n_written``, ``n_skipped``, ``n_errors``,
         ``files`` (list of per-file dicts: ``source``, ``output``,
         ``technique``, ``n_points``, ``status``, ``message``).
-        Returns ``None`` only if the input file cannot be located.
+        Returns ``None`` only if the input file cannot be located or its
+        extension is unrecognised.
 
     Example::
 
-        from pyirena.batch import pxp_to_nexus
-        result = pxp_to_nexus("legacy_experiment.pxp", techniques=["USAXS"])
+        from pyirena.batch import igor_to_nexus
+        result = igor_to_nexus("legacy_experiment.pxp", techniques=["USAXS"])
         print(f"Wrote {result['n_written']} files to {result['output_folder']}")
-    """
-    from pyirena.io.pxp_to_nexus import extract_pxp_to_nexus
 
-    pxp_path = Path(pxp_file)
-    if not pxp_path.is_file():
-        print(f"[pyirena.batch.pxp_to_nexus] File not found: {pxp_path}")
+        # h5xp works the same way
+        igor_to_nexus("modern_export.h5xp")
+    """
+    from pyirena.io.pxp_to_nexus import extract_igor_experiment
+
+    src_path = Path(igor_file)
+    if not src_path.is_file():
+        print(f"[pyirena.batch.igor_to_nexus] File not found: {src_path}")
         return None
 
     try:
-        res = extract_pxp_to_nexus(
-            pxp_path=pxp_path,
+        res = extract_igor_experiment(
+            path=src_path,
             output_root=output_folder,
             techniques=techniques,
             overwrite=overwrite,
         )
+    except ValueError as exc:
+        # Unsupported extension — translate to None-return per the
+        # batch-API convention (caller already prints the path).
+        print(f"[pyirena.batch.igor_to_nexus] {exc}")
+        return None
     except Exception:
-        print(f"[pyirena.batch.pxp_to_nexus] Error:\n{traceback.format_exc()}")
+        print(f"[pyirena.batch.igor_to_nexus] Error:\n{traceback.format_exc()}")
         return None
 
     files_list = [
@@ -2401,7 +2414,7 @@ def pxp_to_nexus(
     ]
 
     if verbose:
-        print(f"[pyirena.batch.pxp_to_nexus] {res.pxp_path}")
+        print(f"[pyirena.batch.igor_to_nexus] {res.pxp_path}")
         print(f"  output:   {res.output_root}")
         print(f"  written:  {res.n_written}")
         print(f"  skipped:  {res.n_skipped}")
@@ -2418,3 +2431,26 @@ def pxp_to_nexus(
         'n_unparseable_records': res.n_unparseable_records,
         'files':       files_list,
     }
+
+
+def pxp_to_nexus(
+    pxp_file: Union[str, Path],
+    output_folder: Optional[Union[str, Path]] = None,
+    techniques: Optional[List[str]] = None,
+    overwrite: bool = False,
+    verbose: bool = False,
+) -> Optional[Dict]:
+    """Backwards-compatible alias for :func:`igor_to_nexus`.
+
+    .. deprecated:: 0.8.1
+       Renamed to :func:`igor_to_nexus` now that .h5xp is also supported.
+       The old name is kept so existing scripts continue to work; new
+       code should prefer ``igor_to_nexus``.
+    """
+    return igor_to_nexus(
+        igor_file=pxp_file,
+        output_folder=output_folder,
+        techniques=techniques,
+        overwrite=overwrite,
+        verbose=verbose,
+    )

--- a/pyirena/batch.py
+++ b/pyirena/batch.py
@@ -2327,3 +2327,94 @@ def average_data(
         'n_datasets': len(datasets),
         'rejected': rejected_pairs,
     }
+
+
+# ---------------------------------------------------------------------------
+# Igor packed experiment (.pxp) import
+# ---------------------------------------------------------------------------
+
+def pxp_to_nexus(
+    pxp_file: Union[str, Path],
+    output_folder: Optional[Union[str, Path]] = None,
+    techniques: Optional[List[str]] = None,
+    overwrite: bool = False,
+    verbose: bool = False,
+) -> Optional[Dict]:
+    """Import an Igor Pro packed experiment (.pxp) and export reduced data as NeXus files.
+
+    Walks the experiment's USAXS / SAXS / WAXS folder hierarchy and writes one
+    NXcanSAS ``.h5`` file per sample. See
+    :func:`pyirena.io.pxp_to_nexus.extract_pxp_to_nexus` for details of the
+    folder and wave-name conventions recognised.
+
+    Args:
+        pxp_file: Path to the input ``.pxp`` file.
+        output_folder: Destination directory. Defaults to ``<pxp_stem>_data``
+            next to the input file. Created if it does not exist.
+        techniques: List of techniques to export, e.g. ``["USAXS", "SAXS"]``.
+            ``None`` (default) exports every technique present in the file.
+        overwrite: If True, existing files in the destination are overwritten.
+            If False (default), an unused suffix is appended.
+        verbose: Print per-file summary to stdout.
+
+    Returns:
+        Dict with keys ``success`` (always True if the function returns),
+        ``output_folder``, ``n_written``, ``n_skipped``, ``n_errors``,
+        ``files`` (list of per-file dicts: ``source``, ``output``,
+        ``technique``, ``n_points``, ``status``, ``message``).
+        Returns ``None`` only if the input file cannot be located.
+
+    Example::
+
+        from pyirena.batch import pxp_to_nexus
+        result = pxp_to_nexus("legacy_experiment.pxp", techniques=["USAXS"])
+        print(f"Wrote {result['n_written']} files to {result['output_folder']}")
+    """
+    from pyirena.io.pxp_to_nexus import extract_pxp_to_nexus
+
+    pxp_path = Path(pxp_file)
+    if not pxp_path.is_file():
+        print(f"[pyirena.batch.pxp_to_nexus] File not found: {pxp_path}")
+        return None
+
+    try:
+        res = extract_pxp_to_nexus(
+            pxp_path=pxp_path,
+            output_root=output_folder,
+            techniques=techniques,
+            overwrite=overwrite,
+        )
+    except Exception:
+        print(f"[pyirena.batch.pxp_to_nexus] Error:\n{traceback.format_exc()}")
+        return None
+
+    files_list = [
+        {
+            'source':    f.source_path,
+            'output':    str(f.output_path) if f.output_path else None,
+            'technique': f.technique,
+            'n_points':  f.n_points,
+            'status':    f.status,
+            'message':   f.message,
+        }
+        for f in res.files
+    ]
+
+    if verbose:
+        print(f"[pyirena.batch.pxp_to_nexus] {res.pxp_path}")
+        print(f"  output:   {res.output_root}")
+        print(f"  written:  {res.n_written}")
+        print(f"  skipped:  {res.n_skipped}")
+        print(f"  errors:   {res.n_errors}")
+        if res.n_unparseable_records:
+            print(f"  note:     {res.n_unparseable_records} wave record(s) could not be parsed")
+
+    return {
+        'success':     True,
+        'output_folder': str(res.output_root),
+        'n_written':   res.n_written,
+        'n_skipped':   res.n_skipped,
+        'n_errors':    res.n_errors,
+        'n_unparseable_records': res.n_unparseable_records,
+        'files':       files_list,
+    }

--- a/pyirena/gui/contrast_panel.py
+++ b/pyirena/gui/contrast_panel.py
@@ -160,10 +160,8 @@ def _fmt(val: Any, sig: int = 4) -> str:
             return str(v)
         if v == 0:
             return "0"
-        mag = abs(v)
-        if 0.001 <= mag < 1e5:
-            return f"{v:.{sig}g}"
-        return f"{v:.{sig - 1}e}"
+        from pyirena.gui.fmt_utils import eng_fmt
+        return eng_fmt(v, sig=sig)
     except Exception:
         return str(val)
 

--- a/pyirena/gui/data_selector.py
+++ b/pyirena/gui/data_selector.py
@@ -287,6 +287,7 @@ def _build_report(file_path: str,
     L.append("")
 
     # ── Data summary ─────────────────────────────────────────────────────────
+    from pyirena.gui.fmt_utils import eng_fmt as _ef
     if data_info is not None:
         Q = data_info['Q']
         I = data_info['I']
@@ -296,13 +297,13 @@ def _build_report(file_path: str,
             "",
             "| Parameter | Value |",
             "|-----------|-------|",
-            f"| Q range | {Q.min():.4g} – {Q.max():.4g} Å⁻¹ |",
-            f"| Intensity range | {I.min():.4e} – {I.max():.4e} cm⁻¹ |",
+            f"| Q range | {_ef(Q.min())} – {_ef(Q.max())} Å⁻¹ |",
+            f"| Intensity range | {_ef(I.min())} – {_ef(I.max())} cm⁻¹ |",
             f"| Data points | {len(Q)} |",
         ]
         if I_error is not None:
             L.append(
-                f"| Uncertainty range | {I_error.min():.4e} – {I_error.max():.4e} cm⁻¹ |"
+                f"| Uncertainty range | {_ef(I_error.min())} – {_ef(I_error.max())} cm⁻¹ |"
             )
         L.append("")
 
@@ -322,8 +323,8 @@ def _build_report(file_path: str,
             "|-----------|-------|",
             f"| Chi-squared (χ²) | {chi2:.4f} |",
             f"| Number of levels | {n_levels} |",
-            f"| Background | {bg:.4e} cm⁻¹ |",
-            f"| Q range (fit) | {Q_fit.min():.4g} – {Q_fit.max():.4g} Å⁻¹ |",
+            f"| Background | {_ef(bg)} cm⁻¹ |",
+            f"| Q range (fit) | {_ef(Q_fit.min())} – {_ef(Q_fit.max())} Å⁻¹ |",
             f"| Data points (fit) | {len(Q_fit)} |",
             f"| Residuals mean | {np.mean(residuals):.4f} |",
             f"| Residuals std dev | {np.std(residuals):.4f} |",
@@ -349,10 +350,16 @@ def _build_report(file_path: str,
                 val = level.get(key)
                 if val is None:
                     return
-                val_str = f"{val:{fmt}}{unit}"
+                if fmt.endswith('f'):
+                    val_str = f"{val:{fmt}}{unit}"
+                else:
+                    val_str = f"{_ef(float(val))}{unit}"
                 if has_mc:
                     err = level.get(f'{key}_err', 0.0)
-                    err_str = f"± {err:{fmt}}{unit}" if err > 0 else "—"
+                    if fmt.endswith('f'):
+                        err_str = f"± {err:{fmt}}{unit}" if err > 0 else "—"
+                    else:
+                        err_str = f"± {_ef(float(err))}{unit}" if err > 0 else "—"
                     L.append(f"| {label} | {val_str} | {err_str} |")
                 else:
                     L.append(f"| {label} | {val_str} |")
@@ -416,12 +423,16 @@ def _build_report(file_path: str,
             if v is None:
                 return 'N/A'
             try:
-                if np.isnan(float(v)):
+                fv = float(v)
+                if np.isnan(fv):
                     return 'N/A'
             except (TypeError, ValueError):
-                pass
+                return str(v)
             try:
-                return f"{v:{spec}}{suffix}"
+                if spec.endswith('f'):
+                    return f"{fv:{spec}}{suffix}"
+                sig = int(spec[1:-1]) if len(spec) > 2 else 4
+                return _ef(fv, sig=sig) + suffix
             except (TypeError, ValueError):
                 return str(v)
 
@@ -548,12 +559,16 @@ def _build_report(file_path: str,
             if v is None:
                 return 'N/A'
             try:
-                if np.isnan(float(v)):
+                fv = float(v)
+                if np.isnan(fv):
                     return 'N/A'
             except (TypeError, ValueError):
-                pass
+                return str(v)
             try:
-                return f"{v:{spec}}{suffix}"
+                if spec.endswith('f'):
+                    return f"{fv:{spec}}{suffix}"
+                sig = int(spec[1:-1]) if len(spec) > 2 else 4
+                return _ef(fv, sig=sig) + suffix
             except (TypeError, ValueError):
                 return str(v)
 
@@ -607,12 +622,16 @@ def _build_report(file_path: str,
             if v is None:
                 return 'N/A'
             try:
-                if np.isnan(float(v)):
+                fv = float(v)
+                if np.isnan(fv):
                     return 'N/A'
             except (TypeError, ValueError):
-                pass
+                return str(v)
             try:
-                return f"{v:{spec}}"
+                if spec.endswith('f'):
+                    return f"{fv:{spec}}"
+                sig = int(spec[1:-1]) if len(spec) > 2 else 4
+                return _ef(fv, sig=sig)
             except (TypeError, ValueError):
                 return str(v)
 
@@ -670,12 +689,16 @@ def _build_report(file_path: str,
             if v is None:
                 return 'N/A'
             try:
-                if np.isnan(float(v)):
+                fv = float(v)
+                if np.isnan(fv):
                     return 'N/A'
             except (TypeError, ValueError):
-                pass
+                return str(v)
             try:
-                return f"{v:{spec}}"
+                if spec.endswith('f'):
+                    return f"{fv:{spec}}"
+                sig = int(spec[1:-1]) if len(spec) > 2 else 4
+                return _ef(fv, sig=sig)
             except (TypeError, ValueError):
                 return str(v)
 
@@ -754,12 +777,16 @@ def _build_report(file_path: str,
             if v is None:
                 return 'N/A'
             try:
-                if np.isnan(float(v)):
+                fv = float(v)
+                if np.isnan(fv):
                     return 'N/A'
             except (TypeError, ValueError):
-                pass
+                return str(v)
             try:
-                return f"{v:{spec}}"
+                if spec.endswith('f'):
+                    return f"{fv:{spec}}"
+                sig = int(spec[1:-1]) if len(spec) > 2 else 4
+                return _ef(fv, sig=sig)
             except (TypeError, ValueError):
                 return str(v)
 

--- a/pyirena/gui/data_selector.py
+++ b/pyirena/gui/data_selector.py
@@ -2268,11 +2268,12 @@ class BatchWorker(QThread):
 
 class _IgorImportDialog(QDialog):
     """Modal dialog asking the user where to send extracted NeXus files and
-    which techniques to keep, before the actual pxp → NeXus import runs.
+    which techniques to keep, before the actual Igor → NeXus import runs.
 
     Used only by :meth:`DataSelectorPanel.launch_igor_import`. The dialog is
     short and purely a settings prompt; the real work happens in
-    :func:`pyirena.batch.pxp_to_nexus`.
+    :func:`pyirena.batch.igor_to_nexus`, which dispatches to either the
+    .pxp or .h5xp reader based on the input extension.
     """
 
     def __init__(self, pxp_path, parent=None):
@@ -2310,9 +2311,9 @@ class _IgorImportDialog(QDialog):
         # Techniques group
         grp = QGroupBox("Techniques to export")
         gv = QVBoxLayout(grp)
-        self._cb_usaxs = QCheckBox("USAXS  (desmeared DSM_* waves)")
-        self._cb_saxs  = QCheckBox("SAXS   (R_Qvec / R_Int / R_Error)")
-        self._cb_waxs  = QCheckBox("WAXS   (R_Qvec / R_Int / R_Error)")
+        self._cb_usaxs = QCheckBox("USAXS")
+        self._cb_saxs  = QCheckBox("SAXS")
+        self._cb_waxs  = QCheckBox("WAXS")
         for cb in (self._cb_usaxs, self._cb_saxs, self._cb_waxs):
             cb.setChecked(True)
             gv.addWidget(cb)
@@ -3049,8 +3050,8 @@ class DataSelectorPanel(QWidget):
         self.igor_import_button.setMinimumHeight(38)
         self.igor_import_button.setStyleSheet(_igor_import_style)
         self.igor_import_button.setToolTip(
-            "Open an Igor Pro packed experiment (.pxp) and export each\n"
-            "reduced USAXS/SAXS/WAXS sample into a NeXus (.h5) file.\n"
+            "Open an Igor Pro packed experiment (.pxp or .h5xp) and export\n"
+            "each reduced USAXS/SAXS/WAXS sample into a NeXus (.h5) file.\n"
             "Use this to bring legacy Igor data into pyIrena for analysis."
         )
         self.igor_import_button.clicked.connect(self.launch_igor_import)
@@ -4653,17 +4654,21 @@ class DataSelectorPanel(QWidget):
 
     # ── Igor packed experiment import ──────────────────────────────────────
     def launch_igor_import(self):
-        """Pick a .pxp file, extract its USAXS/SAXS/WAXS data to NeXus files,
-        and offer to load the output folder as the current data folder.
+        """Pick an Igor experiment (.pxp or .h5xp), extract its
+        USAXS/SAXS/WAXS data to NeXus files, and offer to load the
+        output folder as the current data folder.
         """
-        from pyirena.batch import pxp_to_nexus
+        from pyirena.batch import igor_to_nexus
 
         start_dir = self.last_folder if self.last_folder else QDir.homePath()
         pxp_path, _ = QFileDialog.getOpenFileName(
             self,
-            "Open Igor Packed Experiment",
+            "Open Igor Experiment",
             start_dir,
-            "Igor Packed Experiment (*.pxp);;All Files (*)",
+            "Igor Experiment (*.pxp *.h5xp);;"
+            "Igor Packed Experiment (*.pxp);;"
+            "Igor HDF5 Packed Experiment (*.h5xp);;"
+            "All Files (*)",
         )
         if not pxp_path:
             return
@@ -4682,8 +4687,8 @@ class DataSelectorPanel(QWidget):
         try:
             self.status_label.setText(f"Importing {pxp_path.name}…")
             QApplication.processEvents()
-            result = pxp_to_nexus(
-                pxp_file=str(pxp_path),
+            result = igor_to_nexus(
+                igor_file=str(pxp_path),
                 output_folder=opts['output_folder'],
                 techniques=opts['techniques'],
                 overwrite=opts['overwrite'],

--- a/pyirena/gui/data_selector.py
+++ b/pyirena/gui/data_selector.py
@@ -9,7 +9,7 @@ import os
 import sys
 import subprocess
 from pathlib import Path
-from typing import List, Optional
+from typing import Dict, List, Optional
 
 try:
     from PySide6.QtWidgets import (
@@ -2266,6 +2266,100 @@ class BatchWorker(QThread):
         self.finished.emit(n_ok, n_fail, messages)
 
 
+class _IgorImportDialog(QDialog):
+    """Modal dialog asking the user where to send extracted NeXus files and
+    which techniques to keep, before the actual pxp → NeXus import runs.
+
+    Used only by :meth:`DataSelectorPanel.launch_igor_import`. The dialog is
+    short and purely a settings prompt; the real work happens in
+    :func:`pyirena.batch.pxp_to_nexus`.
+    """
+
+    def __init__(self, pxp_path, parent=None):
+        super().__init__(parent)
+        self.setWindowTitle("Import Igor Experiment")
+        self.pxp_path = Path(pxp_path)
+        self.setMinimumWidth(540)
+
+        layout = QVBoxLayout(self)
+
+        info = QLabel(
+            f"<b>Source:</b> {self.pxp_path.name}<br>"
+            f"<b>Folder:</b> {self.pxp_path.parent}"
+        )
+        info.setTextFormat(Qt.TextFormat.RichText)
+        layout.addWidget(info)
+
+        layout.addSpacing(8)
+
+        # Output folder row
+        form = QFormLayout()
+        default_out = self.pxp_path.with_name(f"{self.pxp_path.stem}_data")
+        self._out_edit = QLineEdit(str(default_out))
+        out_row = QHBoxLayout()
+        out_row.addWidget(self._out_edit, stretch=1)
+        out_browse = QPushButton("Browse…")
+        out_browse.clicked.connect(self._browse_output)
+        out_row.addWidget(out_browse)
+        out_w = QWidget(); out_w.setLayout(out_row)
+        form.addRow("Output folder:", out_w)
+        layout.addLayout(form)
+
+        layout.addSpacing(4)
+
+        # Techniques group
+        grp = QGroupBox("Techniques to export")
+        gv = QVBoxLayout(grp)
+        self._cb_usaxs = QCheckBox("USAXS  (desmeared DSM_* waves)")
+        self._cb_saxs  = QCheckBox("SAXS   (R_Qvec / R_Int / R_Error)")
+        self._cb_waxs  = QCheckBox("WAXS   (R_Qvec / R_Int / R_Error)")
+        for cb in (self._cb_usaxs, self._cb_saxs, self._cb_waxs):
+            cb.setChecked(True)
+            gv.addWidget(cb)
+        layout.addWidget(grp)
+
+        # Overwrite option
+        self._cb_overwrite = QCheckBox(
+            "Overwrite existing files  (off = append _2, _3, … to keep both)"
+        )
+        layout.addWidget(self._cb_overwrite)
+
+        layout.addStretch()
+
+        # Buttons
+        btn_box = QDialogButtonBox(
+            QDialogButtonBox.StandardButton.Ok
+            | QDialogButtonBox.StandardButton.Cancel
+        )
+        btn_box.button(QDialogButtonBox.StandardButton.Ok).setText("Import")
+        btn_box.accepted.connect(self.accept)
+        btn_box.rejected.connect(self.reject)
+        layout.addWidget(btn_box)
+
+    def _browse_output(self):
+        start = self._out_edit.text() or str(self.pxp_path.parent)
+        folder = QFileDialog.getExistingDirectory(
+            self, "Output folder", start, QFileDialog.Option.ShowDirsOnly
+        )
+        if folder:
+            self._out_edit.setText(folder)
+
+    def options(self) -> Dict:
+        """Return a dict of the user's choices."""
+        techs: List[str] = []
+        if self._cb_usaxs.isChecked():
+            techs.append("USAXS")
+        if self._cb_saxs.isChecked():
+            techs.append("SAXS")
+        if self._cb_waxs.isChecked():
+            techs.append("WAXS")
+        return {
+            'output_folder': self._out_edit.text().strip() or None,
+            'techniques':    techs if techs else None,
+            'overwrite':     self._cb_overwrite.isChecked(),
+        }
+
+
 class DataSelectorPanel(QWidget):
     """
     Main data selector panel for pyIrena.
@@ -2945,10 +3039,27 @@ class DataSelectorPanel(QWidget):
         )
         self.fractals_button.clicked.connect(self.launch_fractals)
 
+        _igor_import_style = (
+            "QPushButton { background:#8e44ad; color:white; "
+            "font-weight:bold; border-radius:4px; padding:4px 8px; }"
+            "QPushButton:hover { background:#6c3483; }"
+            "QPushButton:disabled { background:#95a5a6; }"
+        )
+        self.igor_import_button = QPushButton("Import Igor Experiment…")
+        self.igor_import_button.setMinimumHeight(38)
+        self.igor_import_button.setStyleSheet(_igor_import_style)
+        self.igor_import_button.setToolTip(
+            "Open an Igor Pro packed experiment (.pxp) and export each\n"
+            "reduced USAXS/SAXS/WAXS sample into a NeXus (.h5) file.\n"
+            "Use this to bring legacy Igor data into pyIrena for analysis."
+        )
+        self.igor_import_button.clicked.connect(self.launch_igor_import)
+
         proc_grid.addWidget(self.data_merge_button, 0, 0)
         proc_grid.addWidget(self.data_manip_button, 0, 1)
         proc_grid.addWidget(self.contrast_button,   1, 0)
         proc_grid.addWidget(self.fractals_button,   1, 1)
+        proc_grid.addWidget(self.igor_import_button, 2, 0, 1, 2)  # span both cols
         right_layout.addWidget(grp_proc)
 
         right_layout.addStretch()
@@ -4539,6 +4650,132 @@ class DataSelectorPanel(QWidget):
         the underlying widget (triggered by WA_DeleteOnClose).
         """
         self.fractals_window = None
+
+    # ── Igor packed experiment import ──────────────────────────────────────
+    def launch_igor_import(self):
+        """Pick a .pxp file, extract its USAXS/SAXS/WAXS data to NeXus files,
+        and offer to load the output folder as the current data folder.
+        """
+        from pyirena.batch import pxp_to_nexus
+
+        start_dir = self.last_folder if self.last_folder else QDir.homePath()
+        pxp_path, _ = QFileDialog.getOpenFileName(
+            self,
+            "Open Igor Packed Experiment",
+            start_dir,
+            "Igor Packed Experiment (*.pxp);;All Files (*)",
+        )
+        if not pxp_path:
+            return
+
+        pxp_path = Path(pxp_path)
+        # Show the import options dialog.
+        dlg = _IgorImportDialog(pxp_path, parent=self)
+        if dlg.exec() != QDialog.DialogCode.Accepted:
+            return
+
+        opts = dlg.options()
+        # Run extraction synchronously — these files are small (~100s of KB
+        # each) and the parse is fast even for 16 MB pxp inputs. If users
+        # report 100+ MB experiments hanging the UI, move this to a
+        # QThread; for now keep it simple.
+        try:
+            self.status_label.setText(f"Importing {pxp_path.name}…")
+            QApplication.processEvents()
+            result = pxp_to_nexus(
+                pxp_file=str(pxp_path),
+                output_folder=opts['output_folder'],
+                techniques=opts['techniques'],
+                overwrite=opts['overwrite'],
+            )
+        except Exception as exc:
+            QMessageBox.critical(
+                self, "Import error",
+                f"Failed to import {pxp_path.name}:\n\n{exc}",
+            )
+            self.status_label.setText("Import failed.")
+            return
+
+        if result is None:
+            QMessageBox.warning(
+                self, "Import returned no result",
+                f"No data was extracted from {pxp_path.name}.",
+            )
+            return
+
+        # Summarise
+        msg_lines = [
+            f"Imported {pxp_path.name}",
+            "",
+            f"Output folder: {result['output_folder']}",
+            f"Files written: {result['n_written']}",
+            f"Skipped:       {result['n_skipped']}  (folders with no recognised wave triple)",
+            f"Errors:        {result['n_errors']}",
+        ]
+        if result.get('n_unparseable_records'):
+            msg_lines.append(
+                f"Note: {result['n_unparseable_records']} wave record(s) in the "
+                f"pxp could not be parsed (skipped)."
+            )
+
+        # Per-technique tally
+        tech_count: Dict[str, int] = {}
+        for fr in result['files']:
+            if fr['status'] == 'ok':
+                tech_count[fr['technique']] = tech_count.get(fr['technique'], 0) + 1
+        if tech_count:
+            msg_lines.append("")
+            msg_lines.append("By technique:")
+            for t in sorted(tech_count):
+                msg_lines.append(f"  {t}: {tech_count[t]}")
+
+        self.status_label.setText(
+            f"Imported {result['n_written']} files to {Path(result['output_folder']).name}"
+        )
+
+        # Offer to load the output folder
+        msg_box = QMessageBox(self)
+        msg_box.setIcon(QMessageBox.Icon.Information)
+        msg_box.setWindowTitle("Import complete")
+        msg_box.setText("\n".join(msg_lines))
+        if result['n_written'] > 0:
+            load_btn = msg_box.addButton(
+                "Load output folder",
+                QMessageBox.ButtonRole.AcceptRole,
+            )
+            tech_subdirs = sorted(tech_count)
+            if len(tech_subdirs) == 1:
+                load_btn.setText(f"Load {tech_subdirs[0]} folder")
+        msg_box.addButton(QMessageBox.StandardButton.Close)
+        msg_box.exec()
+
+        if (msg_box.clickedButton() is not None
+                and msg_box.clickedButton().text().startswith("Load")):
+            # If exactly one technique was written, jump directly into it
+            # so the file list shows files immediately. Otherwise open the
+            # parent output folder and let the user pick.
+            target = Path(result['output_folder'])
+            if len(tech_count) == 1:
+                only_tech = next(iter(tech_count))
+                tech_dir = target / only_tech
+                if tech_dir.is_dir():
+                    target = tech_dir
+            self._load_folder(str(target))
+
+    def _load_folder(self, folder: str) -> None:
+        """Set *folder* as the current data folder and refresh the file list.
+
+        Same effect as a successful ``select_folder`` dialog, but accepts a
+        path string directly. Used by import workflows.
+        """
+        self.current_folder = folder
+        self.last_folder = folder
+        self.save_last_folder(folder)
+        self.folder_label.setText(folder)
+        self.folder_label.setStyleSheet("color: #2c3e50;")
+        self.refresh_button.setEnabled(True)
+        self.refresh_file_list()
+        self.status_label.setText(f"Folder: {os.path.basename(folder)}")
 
     # ── Visualization for "Create Graph" with 3D-tool checkboxes ─────────
     #

--- a/pyirena/gui/data_selector.py
+++ b/pyirena/gui/data_selector.py
@@ -4723,6 +4723,26 @@ class DataSelectorPanel(QWidget):
                 f"pxp could not be parsed (skipped)."
             )
 
+        # Igor 8/10 long-name records (folders/waves > 31 chars) —
+        # igor2 cannot decode these, so samples are silently missing
+        # from the output. Surface this prominently so the user knows
+        # to re-save the experiment as .h5xp.
+        n_longname = result.get('n_igor8_longname_markers') or 0
+        if n_longname > 0:
+            msg_lines.append("")
+            msg_lines.append(
+                f"⚠ WARNING: this .pxp contains {n_longname} Igor-8 long-name "
+                f"record(s) (folders or waves with names > 31 chars)."
+            )
+            msg_lines.append(
+                "  igor2 cannot decode these, so SOME SAMPLES ARE MISSING "
+                "from the output above."
+            )
+            msg_lines.append(
+                "  Workaround: in Igor Pro, save the experiment as .h5xp "
+                "instead and re-import here."
+            )
+
         # Per-technique tally
         tech_count: Dict[str, int] = {}
         for fr in result['files']:
@@ -4740,8 +4760,14 @@ class DataSelectorPanel(QWidget):
 
         # Offer to load the output folder
         msg_box = QMessageBox(self)
-        msg_box.setIcon(QMessageBox.Icon.Information)
-        msg_box.setWindowTitle("Import complete")
+        # Warning icon when long-name markers were seen, since the
+        # user almost certainly has missing samples.
+        if n_longname > 0:
+            msg_box.setIcon(QMessageBox.Icon.Warning)
+            msg_box.setWindowTitle("Import complete — some samples missing")
+        else:
+            msg_box.setIcon(QMessageBox.Icon.Information)
+            msg_box.setWindowTitle("Import complete")
         msg_box.setText("\n".join(msg_lines))
         if result['n_written'] > 0:
             load_btn = msg_box.addButton(

--- a/pyirena/gui/fmt_utils.py
+++ b/pyirena/gui/fmt_utils.py
@@ -1,0 +1,67 @@
+"""Number formatting utilities for the pyirena GUI.
+
+Two functions cover all display contexts:
+
+eng_fmt(v, sig=4)
+    Engineering notation for display-only widgets (labels, graph annotations,
+    report tables).  Values in [0.001, 999] are shown as plain decimals; outside
+    that range the exponent is chosen as the nearest multiple of 3 and the value
+    is rendered as  "m.mmm×10^N"  (where N ∈ {…, -6, -3, 3, 6, …}).
+
+eng_fmt_edit(v, sig=4)
+    Same engineering-exponent logic but emits parseable text ("m.mmme+N") for
+    editable QLineEdit / wheel-scroll fields, so Python's float() can round-trip
+    the displayed string without modification.
+"""
+
+import math
+import numpy as np
+
+
+def eng_fmt(v: float, sig: int = 4) -> str:
+    """Format *v* for display using engineering notation (×10^N, N multiple of 3).
+
+    Values whose magnitude is in [0.001, 999] are shown as plain decimals
+    (no exponent).  Everything else uses engineering notation with the
+    multiplication-sign form, e.g. '1.234×10^-6'.
+    """
+    if v == 0.0:
+        return '0'
+    try:
+        if not np.isfinite(v):
+            return str(v)
+    except (TypeError, ValueError):
+        return str(v)
+
+    abs_v = abs(v)
+    if 0.001 <= abs_v < 1000:
+        return f'{v:.{sig}g}'
+
+    exp = int(math.floor(math.log10(abs_v) / 3)) * 3
+    mantissa = v / (10.0 ** exp)
+    return f'{mantissa:.{sig}g}×10^{exp}'
+
+
+def eng_fmt_edit(v: float, sig: int = 4) -> str:
+    """Format *v* for editable fields using parseable engineering notation.
+
+    Like eng_fmt() but emits 'me+N' / 'me-N' style text that Python's float()
+    can parse directly.  Values in [0.001, 999] are still shown as plain
+    decimals.
+    """
+    if v == 0.0:
+        return '0'
+    try:
+        if not np.isfinite(v):
+            return str(v)
+    except (TypeError, ValueError):
+        return str(v)
+
+    abs_v = abs(v)
+    if 0.001 <= abs_v < 1000:
+        return f'{v:.{sig}g}'
+
+    exp = int(math.floor(math.log10(abs_v) / 3)) * 3
+    mantissa = v / (10.0 ** exp)
+    sign = '+' if exp >= 0 else '-'
+    return f'{mantissa:.{sig}g}e{sign}{abs(exp):02d}'

--- a/pyirena/gui/modeling_panel.py
+++ b/pyirena/gui/modeling_panel.py
@@ -230,13 +230,8 @@ def _sep(orientation='h') -> QFrame:
 
 def _fmt(v: float) -> str:
     """Format float for display in parameter fields."""
-    if v == 0.0:
-        return '0'
-    if abs(v) < 0.01 or abs(v) >= 1e5:
-        return f'{v:.3e}'
-    if abs(v) < 10:
-        return f'{v:.4g}'
-    return f'{v:.4g}'
+    from pyirena.gui.fmt_utils import eng_fmt_edit
+    return eng_fmt_edit(v, sig=4)
 
 
 def _parse(text: str, default: float = 0.0) -> float:
@@ -976,9 +971,10 @@ class PopulationTab(QWidget):
         if not derived:
             self._derived_group.setVisible(False)
             return
+        from pyirena.gui.fmt_utils import eng_fmt
         for key, lbl in self._dr_labels.items():
             val = derived.get(key)
-            lbl.setText(f'{val:.5g}' if val is not None else '—')
+            lbl.setText(eng_fmt(val, sig=5) if val is not None else '—')
         self._derived_group.setVisible(True)
 
     def clear_derived(self):
@@ -2702,7 +2698,8 @@ class ModelingPanel(QWidget):
         self.graph.set_status('MC uncertainty estimation complete.', 'success')
 
         if stds:
-            lines = [f'  {k}: ± {v:.4g}' for k, v in sorted(stds.items())]
+            from pyirena.gui.fmt_utils import eng_fmt
+            lines = [f'  {k}: ± {eng_fmt(v)}' for k, v in sorted(stds.items())]
             QMessageBox.information(
                 self, 'MC Uncertainties',
                 'Parameter standard deviations:\n' + '\n'.join(lines),
@@ -2818,8 +2815,9 @@ class ModelingPanel(QWidget):
             QMessageBox.warning(self, 'No fit results',
                                 'Run a fit first to generate results.')
             return
+        from pyirena.gui.fmt_utils import eng_fmt
         result = self._last_result
-        lines = [f'χ²/dof = {result.reduced_chi_squared:.4g}']
+        lines = [f'χ²/dof = {eng_fmt(result.reduced_chi_squared)}']
         stds = result.params_std or {}
         for k, d in enumerate(result.derived):
             pi = result.pop_indices[k]
@@ -2831,9 +2829,9 @@ class ModelingPanel(QWidget):
                 std_key = f'pop{pi+1}_derived_{name}'
                 std = stds.get(std_key)
                 if std is not None and np.isfinite(std) and std > 0:
-                    lines.append(f'{pop_label}: {name} = {val:.4g} ± {std:.3g}')
+                    lines.append(f'{pop_label}: {name} = {eng_fmt(val)} ± {eng_fmt(std, sig=3)}')
                 else:
-                    lines.append(f'{pop_label}: {name} = {val:.4g}')
+                    lines.append(f'{pop_label}: {name} = {eng_fmt(val)}')
         self.graph.clear_result_annotations()
         self.graph.add_result_annotation('\n'.join(lines))
         self.graph.set_status('Results annotated on graph.', 'success')

--- a/pyirena/gui/simple_fits_panel.py
+++ b/pyirena/gui/simple_fits_panel.py
@@ -1061,10 +1061,11 @@ class SimpleFitsPanel(QWidget):
         self.fit_result = result
 
         # Update chi² display
+        from pyirena.gui.fmt_utils import eng_fmt
         chi2 = result.get('chi2', float('nan'))
         rchi2 = result.get('reduced_chi2', float('nan'))
-        self.chi2_label.setText(f'{chi2:.4g}')
-        self.rchi2_label.setText(f'{rchi2:.4g}')
+        self.chi2_label.setText(eng_fmt(chi2))
+        self.rchi2_label.setText(eng_fmt(rchi2))
 
         # Write fitted values back to widgets
         self._apply_result_to_widgets(result)
@@ -1072,10 +1073,10 @@ class SimpleFitsPanel(QWidget):
         # Update derived quantities if any
         derived = result.get('derived', {})
         if derived:
-            derived_txt = '   '.join(f'{k}={v:.4g}' for k, v in derived.items())
-            self.status_label.setText(f'Fit OK | χ²_red={rchi2:.3g} | {derived_txt}')
+            derived_txt = '   '.join(f'{k}={eng_fmt(v)}' for k, v in derived.items())
+            self.status_label.setText(f'Fit OK | χ²_red={eng_fmt(rchi2, sig=3)} | {derived_txt}')
         else:
-            self.status_label.setText(f'Fit OK | Reduced χ² = {rchi2:.4g}')
+            self.status_label.setText(f'Fit OK | Reduced χ² = {eng_fmt(rchi2)}')
 
         # Update all plots
         self._update_plots(result)

--- a/pyirena/gui/sizes_panel.py
+++ b/pyirena/gui/sizes_panel.py
@@ -75,11 +75,8 @@ class ScrubbableLineEdit(QLineEdit):
                 magnitude = 10 ** math.floor(math.log10(abs(value)))
                 step = magnitude * self._step_factor
                 value += direction * step
-            # Format nicely
-            if abs(value) < 0.01 or abs(value) >= 10000:
-                self.setText(f"{value:.3e}")
-            else:
-                self.setText(f"{value:.4g}")
+            from pyirena.gui.fmt_utils import eng_fmt_edit
+            self.setText(eng_fmt_edit(value, sig=4))
             self.editingFinished.emit()
             event.accept()   # stop the enclosing QScrollArea from also scrolling
         except (ValueError, OverflowError):
@@ -1658,7 +1655,8 @@ class SizesFitPanel(QWidget):
         """Multiply the numeric value in *edit* by *factor* (for ÷10 / ×10 buttons)."""
         try:
             val = float(edit.text()) * factor
-            edit.setText(f"{val:.3e}" if (abs(val) < 0.01 or abs(val) >= 10000) else f"{val:.4g}")
+            from pyirena.gui.fmt_utils import eng_fmt_edit
+            edit.setText(eng_fmt_edit(val, sig=4))
             edit.editingFinished.emit()
         except ValueError:
             pass
@@ -1772,8 +1770,9 @@ class SizesFitPanel(QWidget):
         if cursor_range is not None:
             q_min, q_max = cursor_range
             # Update Q range display
-            self.qmin_display.setText(f"{q_min:.4e}")
-            self.qmax_display.setText(f"{q_max:.4e}")
+            from pyirena.gui.fmt_utils import eng_fmt
+            self.qmin_display.setText(eng_fmt(q_min))
+            self.qmax_display.setText(eng_fmt(q_max))
             # D = 2π/Q: larger Q → smaller D, so D_min comes from Q_max
             self.rmax_display.setText(f"{np.pi/q_min:.1f}")
             self.rmin_display.setText(f"{np.pi/q_max:.1f}")

--- a/pyirena/gui/unified_fit.py
+++ b/pyirena/gui/unified_fit.py
@@ -139,18 +139,8 @@ class ScrubbableLineEdit(QLineEdit):
             # No validator, enforce >= 0
             new_value = max(minimum_value, new_value)
 
-        # Update the text field
-        # Determine appropriate precision
-        if abs(new_value) < 0.001:
-            text = f"{new_value:.2e}"
-        elif abs(new_value) < 1:
-            text = f"{new_value:.6f}".rstrip('0').rstrip('.')
-        elif abs(new_value) < 1000:
-            text = f"{new_value:.4f}".rstrip('0').rstrip('.')
-        else:
-            text = f"{new_value:.2e}"
-
-        self.setText(text)
+        from pyirena.gui.fmt_utils import eng_fmt_edit
+        self.setText(eng_fmt_edit(new_value, sig=4))
         self.editingFinished.emit()
 
         # Accept the event so it doesn't propagate
@@ -1487,14 +1477,8 @@ class LevelParametersWidget(QWidget):
 
     def _format_value(self, value: float) -> str:
         """Format a value to 3 significant digits."""
-        if value == 0:
-            return "0"
-        # Use scientific notation for very small or very large numbers
-        if abs(value) < 0.001 or abs(value) >= 10000:
-            return f"{value:.2e}"
-        else:
-            # Use fixed decimal for normal range numbers
-            return f"{value:.3g}"
+        from pyirena.gui.fmt_utils import eng_fmt_edit
+        return eng_fmt_edit(value, sig=3)
 
     def toggle_limits_visibility(self, show: bool):
         """Show or hide all limit fields and headers."""
@@ -2074,14 +2058,8 @@ class UnifiedFitPanel(QWidget):
 
     def format_value_3sig(self, value: float) -> str:
         """Format a value to 3 significant digits for display."""
-        if value == 0:
-            return "0"
-        # Use scientific notation with 2 decimal places (3 sig figs total)
-        if abs(value) < 0.01 or abs(value) >= 1000:
-            return f"{value:.2e}"
-        else:
-            # For values in normal range, use 3 significant figures
-            return f"{value:.3g}"
+        from pyirena.gui.fmt_utils import eng_fmt
+        return eng_fmt(value, sig=3)
 
     def create_control_panel(self) -> QWidget:
         """Create the left control panel."""
@@ -2798,14 +2776,15 @@ class UnifiedFitPanel(QWidget):
             chi2 = result.get('chi_squared', 0.0)
             reduced_chi2 = result.get('reduced_chi_squared', 0.0)
 
+            from pyirena.gui.fmt_utils import eng_fmt as _efmt
             if cursor_range is not None:
                 self.status_label.setText(
-                    f"Fit complete: {num_levels} level(s), {num_points} pts (Q: {q_min:.3e} - {q_max:.3e}), χ² = {chi2:.4f}"
+                    f"Fit complete: {num_levels} level(s), {num_points} pts (Q: {_efmt(q_min)} - {_efmt(q_max)}), χ² = {chi2:.4f}"
                 )
             else:
                 self.status_label.setText(f"Fit complete: {num_levels} level(s), χ² = {chi2:.4f}")
 
-            cursor_info = f" | Q: {q_min:.3e} - {q_max:.3e} ({num_points} pts)" if cursor_range else ""
+            cursor_info = f" | Q: {_efmt(q_min)} - {_efmt(q_max)} ({num_points} pts)" if cursor_range else ""
 
             self.graph_window.show_success_message(
                 f"Fit completed successfully! "
@@ -2956,16 +2935,17 @@ class UnifiedFitPanel(QWidget):
                 self.graph_unified()
 
             # Show success message
+            from pyirena.gui.fmt_utils import eng_fmt as _efmt
             self.status_label.setText(
                 f"Local Guinier fit complete for Level {level}: "
-                f"G = {fitted_g:.3e}, Rg = {fitted_rg:.3e} "
-                f"(Q: {q_min:.3e} - {q_max:.3e}, {len(q_fit)} pts)"
+                f"G = {_efmt(fitted_g)}, Rg = {_efmt(fitted_rg)} "
+                f"(Q: {_efmt(q_min)} - {_efmt(q_max)}, {len(q_fit)} pts)"
             )
 
             self.graph_window.show_success_message(
                 f"Local Guinier fit completed for Level {level}! "
-                f"G = {fitted_g:.4e}, Rg = {fitted_rg:.4e} | "
-                f"Q: {q_min:.3e} - {q_max:.3e} ({len(q_fit)} pts) | "
+                f"G = {_efmt(fitted_g)}, Rg = {_efmt(fitted_rg)} | "
+                f"Q: {_efmt(q_min)} - {_efmt(q_max)} ({len(q_fit)} pts) | "
                 f"Limits updated automatically."
             )
 
@@ -3116,16 +3096,17 @@ class UnifiedFitPanel(QWidget):
                 self.graph_unified()
 
             # Show success message
+            from pyirena.gui.fmt_utils import eng_fmt as _efmt
             self.status_label.setText(
                 f"Local Porod fit complete for Level {level}: "
-                f"B = {fitted_b:.3e}, P = {fitted_p:.3e} "
-                f"(Q: {q_min:.3e} - {q_max:.3e}, {len(q_fit)} pts)"
+                f"B = {_efmt(fitted_b)}, P = {_efmt(fitted_p)} "
+                f"(Q: {_efmt(q_min)} - {_efmt(q_max)}, {len(q_fit)} pts)"
             )
 
             self.graph_window.show_success_message(
                 f"Local Porod fit completed for Level {level}! "
-                f"B = {fitted_b:.4e}, P = {fitted_p:.4e} | "
-                f"Q: {q_min:.3e} - {q_max:.3e} ({len(q_fit)} pts) | "
+                f"B = {_efmt(fitted_b)}, P = {_efmt(fitted_p)} | "
+                f"Q: {_efmt(q_min)} - {_efmt(q_max)} ({len(q_fit)} pts) | "
                 f"Limits updated automatically."
             )
 
@@ -3731,11 +3712,13 @@ class UnifiedFitPanel(QWidget):
         If Monte Carlo uncertainties are available (from Analyze Results), each
         fitted parameter is shown as  value ± std_dev.
         """
+        from pyirena.gui.fmt_utils import eng_fmt
+
         def _fmt(val, err=0.0, fmt='e'):
             """Format a value with optional ±uncertainty."""
-            v_str = f"{val:.3{fmt}}"
+            v_str = eng_fmt(val, sig=4)
             if err > 0.0:
-                return f"{v_str} ± {err:.2e}"
+                return f"{v_str} ± {eng_fmt(err, sig=3)}"
             return v_str
 
         try:
@@ -3772,7 +3755,7 @@ class UnifiedFitPanel(QWidget):
                 text_lines.append(f"P  = {_fmt(params['P'],  ud['P'], fmt='f')}")
 
                 if params['RgCutoff'] > 0.01:
-                    text_lines.append(f"RgCO = {params['RgCutoff']:.3e}")
+                    text_lines.append(f"RgCO = {eng_fmt(params['RgCutoff'])}")
 
                 if params['correlated']:
                     text_lines.append(f"ETA  = {_fmt(params['ETA'],  ud['ETA'])}")

--- a/pyirena/io/nxcansas_unified.py
+++ b/pyirena/io/nxcansas_unified.py
@@ -15,7 +15,9 @@ from typing import Dict, List, Optional, Tuple
 
 def create_nxcansas_file(filepath: Path, q: np.ndarray, intensity: np.ndarray,
                          error: Optional[np.ndarray] = None,
-                         sample_name: str = "data") -> None:
+                         sample_name: str = "data",
+                         dq: Optional[np.ndarray] = None,
+                         metadata: Optional[Dict] = None) -> None:
     """
     Create a new NXcanSAS HDF5 file with experimental data.
 
@@ -25,8 +27,25 @@ def create_nxcansas_file(filepath: Path, q: np.ndarray, intensity: np.ndarray,
         intensity: Intensity data (1/cm)
         error: Error/uncertainty data (1/cm)
         sample_name: Name for the data entry
+        dq: Optional Q resolution / Q uncertainty (1/Angstrom). Written as the
+            `Qdev` dataset per the NXcanSAS standard.
+        metadata: Optional dict of provenance / instrument / sample metadata.
+            Recognised keys (all optional):
+              - ``title`` → ``entry/title``
+              - ``start_time`` / ``end_time`` → ``entry/start_time`` etc.
+              - ``run`` → overrides the default ``"pyirena_run"`` run string
+              - ``sample.<key>`` → datasets under ``entry/sample/<key>``
+                (e.g. ``sample.name``, ``sample.thickness``, ``sample.temperature``)
+              - ``instrument.<key>`` → datasets under ``entry/instrument/<key>``
+                (e.g. ``instrument.name``, ``instrument.wavelength``)
+              - ``source.<sub>`` → entry/raw_note/<sub>  (free-text provenance)
+
+            Numeric values become float64 datasets; strings become UTF-8
+            text datasets. Unknown top-level keys go into ``entry/notes/``
+            as text datasets so nothing is lost in translation.
     """
     timestamp = datetime.now().isoformat()
+    metadata = metadata or {}
 
     with h5py.File(filepath, "w") as f:
         # Root attributes
@@ -45,16 +64,63 @@ def create_nxcansas_file(filepath: Path, q: np.ndarray, intensity: np.ndarray,
         nxentry.attrs['default'] = sample_name
         nxentry.create_dataset('definition', data='NXsas')
 
+        # Entry-level scalar metadata (title / times / run)
+        title_val = metadata.get('title', sample_name)
+        run_val = metadata.get('run', 'pyirena_run')
+
         # Create subentry for data
         data_path = f"entry/{sample_name}"
         nxdata_entry = f.create_group(data_path)
         nxdata_entry.attrs['NX_class'] = 'NXsubentry'
         nxdata_entry.attrs['canSAS_class'] = 'SASentry'
         nxdata_entry.attrs['default'] = 'sasdata'
-        nxdata_entry.attrs['title'] = sample_name
+        nxdata_entry.attrs['title'] = str(title_val)
         nxdata_entry.create_dataset('definition', data='NXcanSAS')
-        nxdata_entry.create_dataset('title', data=sample_name)
-        nxdata_entry.create_dataset('run', data='pyirena_run')
+        nxdata_entry.create_dataset('title', data=str(title_val))
+        nxdata_entry.create_dataset('run', data=str(run_val))
+
+        # Optional entry-level timestamps
+        for k in ('start_time', 'end_time'):
+            if k in metadata and metadata[k] is not None:
+                nxentry.create_dataset(k, data=str(metadata[k]))
+
+        # ── sample / instrument groups ─────────────────────────────────────
+        sample_meta = {k[len('sample.'):]: v for k, v in metadata.items()
+                       if k.startswith('sample.')}
+        if sample_meta:
+            sample_grp = nxentry.create_group('sample')
+            sample_grp.attrs['NX_class'] = 'NXsample'
+            sample_grp.attrs['canSAS_class'] = 'SASsample'
+            _write_meta_items(sample_grp, sample_meta)
+
+        instr_meta = {k[len('instrument.'):]: v for k, v in metadata.items()
+                      if k.startswith('instrument.')}
+        if instr_meta:
+            instr_grp = nxentry.create_group('instrument')
+            instr_grp.attrs['NX_class'] = 'NXinstrument'
+            instr_grp.attrs['canSAS_class'] = 'SASinstrument'
+            _write_meta_items(instr_grp, instr_meta)
+            # Hoist wavelength into a beam sub-group so canSAS readers can
+            # find it at the expected NXcanSAS path.
+            wl = instr_meta.get('wavelength', instr_meta.get('incident_wavelength'))
+            if wl is not None:
+                try:
+                    wl_f = float(wl)
+                    beam = instr_grp.create_group('beam')
+                    beam.attrs['NX_class'] = 'NXbeam'
+                    ds_wl = beam.create_dataset('incident_wavelength', data=wl_f)
+                    ds_wl.attrs['units'] = 'angstrom'
+                except (TypeError, ValueError):
+                    pass
+
+        # ── catch-all: anything not recognised goes into entry/notes ──────
+        leftover = {k: v for k, v in metadata.items()
+                    if not k.startswith(('sample.', 'instrument.'))
+                    and k not in ('title', 'start_time', 'end_time', 'run')}
+        if leftover:
+            notes_grp = nxentry.create_group('notes')
+            notes_grp.attrs['NX_class'] = 'NXnote'
+            _write_meta_items(notes_grp, leftover)
 
         # Create sasdata group
         sasdata = nxdata_entry.create_group('sasdata')
@@ -74,12 +140,41 @@ def create_nxcansas_file(filepath: Path, q: np.ndarray, intensity: np.ndarray,
         ds_q = sasdata.create_dataset('Q', data=q)
         ds_q.attrs['units'] = '1/angstrom'
         ds_q.attrs['long_name'] = 'Q'
+        if dq is not None:
+            ds_q.attrs['resolutions'] = 'Qdev'
 
         # Store error data if provided
         if error is not None:
             ds_err = sasdata.create_dataset('Idev', data=error)
             ds_err.attrs['units'] = '1/cm'
             ds_err.attrs['long_name'] = 'Uncertainties'
+
+        # Store Q resolution if provided
+        if dq is not None:
+            ds_dq = sasdata.create_dataset('Qdev', data=dq)
+            ds_dq.attrs['units'] = '1/angstrom'
+            ds_dq.attrs['long_name'] = 'Q resolution'
+
+
+def _write_meta_items(group: 'h5py.Group', items: Dict) -> None:
+    """Write a flat dict of metadata into an HDF5 group.
+
+    Numeric values become scalar float64 datasets; everything else is stored
+    as a UTF-8 text dataset. Keys that contain dots are flattened with `_`
+    so they map to legal HDF5 dataset names.
+    """
+    for key, val in items.items():
+        if val is None:
+            continue
+        safe_key = key.replace('.', '_').replace('/', '_')
+        if isinstance(val, (bool, np.bool_)):
+            group.create_dataset(safe_key, data=int(val))
+        elif isinstance(val, (int, np.integer)):
+            group.create_dataset(safe_key, data=int(val))
+        elif isinstance(val, (float, np.floating)):
+            group.create_dataset(safe_key, data=float(val))
+        else:
+            group.create_dataset(safe_key, data=str(val))
 
 
 def save_unified_fit_results(filepath: Path,

--- a/pyirena/io/pxp_to_nexus.py
+++ b/pyirena/io/pxp_to_nexus.py
@@ -1,0 +1,764 @@
+"""
+pyirena/io/pxp_to_nexus.py — Import legacy Igor Pro packed experiments
+(``.pxp``) and export their reduced 1-D SAS data as per-sample NXcanSAS
+HDF5 files.
+
+This bridges old Igor-based analysis into the pyirena (Python / NeXus)
+world. Each ``.pxp`` typically holds many samples organised by technique
+(``root:USAXS:<sample>``, ``root:SAXS:<sample>``, ``root:WAXS:<sample>``).
+This module walks that tree, recognises the standard wave-name conventions
+used by the USAXS reduction pipeline, parses the rich wave-note metadata
+(when present), and writes one ``.h5`` per sample using the existing
+:func:`pyirena.io.nxcansas_unified.create_nxcansas_file`.
+
+Wave-name conventions recognised
+--------------------------------
+USAXS (desmeared, primary):
+    ``DSM_Qvec``, ``DSM_Int``, ``DSM_Error``  (+ optional ``DSM_dQ``)
+
+SAXS / WAXS (reduced):
+    ``R_Qvec``, ``R_Int``, ``R_Error``        (+ optional ``w_<folder>``
+    as dQ if present in the same folder)
+
+Samples that contain none of the above (e.g. blanks holding only raw
+detector counts) are silently skipped — they appear as ``skipped`` in
+the per-file summary.
+
+Folder-name conventions recognised
+----------------------------------
+Top-level Igor data-folder names that map to a technique:
+
+================ ==========
+Folder name      Technique
+================ ==========
+``USAXS``        USAXS
+``SAXS``         SAXS
+``WAXS``         WAXS
+``Imported SAXS`` SAXS (legacy ASCII-imported)
+``SAS``          SAXS (user convention)
+================ ==========
+
+The mapping is data-driven (see :data:`TECHNIQUE_FOLDERS`) and easy to
+extend. Folders not in the map are walked recursively — any descendant
+folder that contains a recognised wave triple is still exported, and its
+position in the tree is preserved in the output directory layout. This
+means in-situ experiments organised as
+``root:SAXS:<heater_run>:<step>:<sample>`` will round-trip into
+``out/SAXS/<heater_run>/<step>/<sample>.h5``.
+
+Wave-note parsing
+-----------------
+Igor wave notes use the convention ``key=value;key=value;``. Some pipelines
+(notably the APS USAXS instrument) inject NeXus-style metadata wrapped in
+sentinel markers — ``NXSampleStart`` / ``NXSampleEnd``,
+``NXInstrumentStart`` / ``NXInstrumentEnd``, ``NXMetadataStart`` /
+``NXMetadataEnd``. The parser extracts these into sectioned dicts that
+map cleanly to NXcanSAS sample/instrument groups; anything outside the
+sections (or in a note without sentinels) is preserved verbatim under
+``entry/notes/``.
+
+Typical usage
+-------------
+Headless::
+
+    from pyirena.io.pxp_to_nexus import extract_pxp_to_nexus
+
+    summaries = extract_pxp_to_nexus("legacy.pxp")
+    for s in summaries:
+        print(s.output_path, s.n_points, s.technique)
+
+Custom output folder, only USAXS::
+
+    extract_pxp_to_nexus("legacy.pxp",
+                         output_root="/tmp/nexus_out",
+                         techniques=["USAXS"])
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Iterable, Sequence
+
+import numpy as np
+
+from pyirena.io.nxcansas_unified import create_nxcansas_file
+
+
+__all__ = [
+    "extract_pxp_to_nexus",
+    "ExtractedFile",
+    "ExtractionResult",
+    "TECHNIQUE_FOLDERS",
+    "WAVE_PICKERS",
+]
+
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Configuration tables (data-driven, easy to extend)
+# ---------------------------------------------------------------------------
+
+#: Map of Igor folder name → canonical technique string. Folder name matching
+#: is case-insensitive and exact. Add aliases here when users follow other
+#: conventions (e.g. importing ASCII into a folder called ``"Imported SAXS"``).
+TECHNIQUE_FOLDERS: dict[str, str] = {
+    "USAXS":         "USAXS",
+    "SAXS":          "SAXS",
+    "WAXS":          "WAXS",
+    "Imported SAXS": "SAXS",
+    "SAS":           "SAXS",
+    "Imported":      "SAXS",
+}
+
+
+#: Wave-name picker per technique. Each entry is a list of ``(Q_name, I_name,
+#: Err_name, dQ_name_or_None)`` tuples tried in order. The first tuple whose
+#: Q, I, and Err waves all exist in a sample folder wins. dQ is optional —
+#: if its name is None or not present, the resulting file will not contain
+#: a Qdev dataset.
+WAVE_PICKERS: dict[str, list[tuple[str, str, str, str | None]]] = {
+    "USAXS": [
+        # Desmeared primary: matches the chosen "DSM_* only" policy.
+        ("DSM_Qvec", "DSM_Int", "DSM_Error", "DSM_dQ"),
+    ],
+    "SAXS": [
+        # R_* is the unified Q/I/error triple emitted by the SAXS reduction.
+        ("R_Qvec", "R_Int", "R_Error", None),
+    ],
+    "WAXS": [
+        ("R_Qvec", "R_Int", "R_Error", None),
+    ],
+}
+
+
+# ---------------------------------------------------------------------------
+# Result types
+# ---------------------------------------------------------------------------
+
+@dataclass
+class ExtractedFile:
+    """One row in the extraction summary.
+
+    Attributes
+    ----------
+    source_path:
+        Igor data-folder path inside the pxp, e.g. ``"root:SAXS:Sample01"``.
+    output_path:
+        Filesystem path of the NeXus file written, or ``None`` if skipped.
+    technique:
+        Canonical technique string (``"USAXS"`` / ``"SAXS"`` / ``"WAXS"``)
+        or ``"UNKNOWN"`` for skipped folders.
+    n_points:
+        Number of Q points in the exported dataset (0 if skipped).
+    status:
+        ``"ok"`` | ``"skipped"`` | ``"error"``.
+    message:
+        Human-readable explanation (reason for skip / error text / "").
+    """
+    source_path: str
+    output_path: Path | None
+    technique: str
+    n_points: int
+    status: str
+    message: str = ""
+
+
+@dataclass
+class ExtractionResult:
+    """Overall result of an :func:`extract_pxp_to_nexus` call."""
+    pxp_path: Path
+    output_root: Path
+    files: list[ExtractedFile] = field(default_factory=list)
+    n_unparseable_records: int = 0
+
+    @property
+    def n_written(self) -> int:
+        return sum(1 for f in self.files if f.status == "ok")
+
+    @property
+    def n_skipped(self) -> int:
+        return sum(1 for f in self.files if f.status == "skipped")
+
+    @property
+    def n_errors(self) -> int:
+        return sum(1 for f in self.files if f.status == "error")
+
+
+# ---------------------------------------------------------------------------
+# Defensive .pxp loader
+# ---------------------------------------------------------------------------
+
+def _load_pxp_filesystem(pxp_path: Path) -> tuple[dict, int]:
+    """Load a .pxp file and return ``(filesystem, n_skipped_records)``.
+
+    Unlike :func:`igor2.packed.load`, this never aborts on a single bad
+    wave record: the offending record is skipped (counted) and traversal
+    continues, so a legacy experiment with one weird wave still yields a
+    fully usable folder tree. Folder structure depends only on
+    ``FolderStartRecord`` / ``FolderEndRecord`` records, which parse
+    cheaply and reliably.
+    """
+    try:
+        from igor2.packed import (
+            setup_packed_file_record_header, _RECORD_TYPE,
+            _UnknownRecord, _UnusedRecord, PACKEDRECTYPE_MASK,
+            _byte_order, _need_to_reorder_bytes,
+        )
+        from igor2.record.folder import FolderStartRecord, FolderEndRecord
+        from igor2.record.wave import WaveRecord
+    except ImportError as e:
+        raise ImportError(
+            "The 'igor2' package is required to import Igor packed experiments. "
+            "Install it with:  pip install igor2"
+        ) from e
+
+    records: list[Any] = []
+    byte_order: str | None = None
+    header_struct = setup_packed_file_record_header()
+    skipped = 0
+
+    with open(pxp_path, "rb") as f:
+        while True:
+            b = f.read(header_struct.size)
+            if len(b) == 0:
+                break
+            if len(b) < header_struct.size:
+                break
+            header = header_struct.unpack_from(b)
+            if header["version"] and not byte_order:
+                need = _need_to_reorder_bytes(header["version"])
+                byte_order = _byte_order(need)
+                if need:
+                    header_struct = setup_packed_file_record_header(byte_order=byte_order)
+                    header = header_struct.unpack_from(b)
+            data = bytes(f.read(header["numDataBytes"]))
+            if len(data) < header["numDataBytes"]:
+                logger.warning("truncated record in %s — stopping", pxp_path)
+                break
+            rtype_id = header["recordType"] & PACKEDRECTYPE_MASK
+            rtype = _RECORD_TYPE.get(rtype_id, _UnknownRecord)
+            try:
+                rec = rtype(header, data, byte_order=byte_order)
+                records.append(rec)
+            except Exception as exc:
+                skipped += 1
+                records.append(None)
+                logger.debug("skipped %s record (rtype_id=%s): %s",
+                             rtype.__name__, rtype_id, exc)
+
+    # Build a folder tree from the surviving records.
+    filesystem = {"root": {}}
+    stack: list[tuple[str, dict]] = [("root", filesystem["root"])]
+
+    for rec in records:
+        if rec is None:
+            continue
+        if isinstance(rec, FolderStartRecord):
+            name = rec.null_terminated_text
+            if isinstance(name, bytes):
+                name = name.decode("utf-8", errors="replace")
+            parent = stack[-1][1]
+            parent.setdefault(name, {})
+            stack.append((name, parent[name]))
+        elif isinstance(rec, FolderEndRecord):
+            if len(stack) > 1:
+                stack.pop()
+        elif isinstance(rec, WaveRecord):
+            try:
+                bname = rec.wave["wave"]["wave_header"]["bname"]
+                if isinstance(bname, bytes):
+                    bname = bname.decode("utf-8", errors="replace").rstrip("\x00")
+                stack[-1][1][bname] = rec
+            except Exception:
+                # Unreadable wave name — drop silently; structure is the priority.
+                pass
+
+    return filesystem, skipped
+
+
+def _wave_array(wave_rec) -> np.ndarray | None:
+    """Extract the numpy data array from an igor2 WaveRecord."""
+    try:
+        data = wave_rec.wave["wave"]["wData"]
+        arr = np.asarray(data)
+        # Flatten 1-D wraps; reject text-typed or multi-dim arrays.
+        if arr.dtype.kind in ("U", "S", "O"):
+            return None
+        return np.asarray(arr.ravel(), dtype=np.float64)
+    except Exception:
+        return None
+
+
+def _wave_note(wave_rec) -> str:
+    """Decode a wave note to a string (empty if missing)."""
+    try:
+        note = wave_rec.wave["wave"].get("note", b"")
+        if isinstance(note, bytes):
+            return note.decode("utf-8", errors="replace")
+        return str(note)
+    except Exception:
+        return ""
+
+
+# ---------------------------------------------------------------------------
+# Wave-note → NeXus metadata parser
+# ---------------------------------------------------------------------------
+
+# Section markers used by the APS USAXS pipeline. Each entry maps
+# (start_marker, end_marker) → metadata key prefix that
+# `create_nxcansas_file` understands.
+_NOTE_SECTIONS: list[tuple[str, str, str]] = [
+    ("NXSampleStart",    "NXSampleEnd",    "sample."),
+    ("NXInstrumentStart", "NXInstrumentEnd", "instrument."),
+    ("NXUserStart",      "NXUserEnd",      "user."),
+    ("NXMetadataStart",  "NXMetadataEnd",  ""),   # general — goes to entry/notes
+]
+
+
+def _parse_kv_pairs(text: str) -> dict[str, str]:
+    """Parse Igor-style ``key=value;key=value;`` into a dict.
+
+    Values are stripped; trailing empty entries are dropped. Values that
+    look numeric are left as strings — the caller decides what to coerce.
+    """
+    out: dict[str, str] = {}
+    for chunk in text.split(";"):
+        chunk = chunk.strip()
+        if not chunk or "=" not in chunk:
+            continue
+        k, _, v = chunk.partition("=")
+        k = k.strip()
+        v = v.strip()
+        if k:
+            out[k] = v
+    return out
+
+
+def _coerce(val: str) -> Any:
+    """Best-effort string→number coercion. Leaves unparseable strings alone."""
+    if val == "" or val.lower() in ("nan", "inf", "-inf"):
+        return val
+    try:
+        if "." in val or "e" in val.lower():
+            return float(val)
+        return int(val)
+    except ValueError:
+        return val
+
+
+def parse_wave_note(note: str) -> dict[str, Any]:
+    """Convert an Igor wave note into a NXcanSAS-friendly metadata dict.
+
+    Returns a dict whose keys use the conventions understood by
+    :func:`pyirena.io.nxcansas_unified.create_nxcansas_file` —
+    ``sample.<key>``, ``instrument.<key>``, plus top-level ``title`` etc.
+
+    The parser handles three layers:
+
+    1. **Section markers** (``NXSampleStart`` … ``NXSampleEnd`` etc.) —
+       contents are flattened into ``sample.<key>`` keys.
+    2. **Top-level fields outside sections** (e.g. ``DATAFILE=..``,
+       ``DATE=..``, ``COMMENT=..``) — mapped to ``title``, ``start_time``,
+       and ``notes/<original_key>``.
+    3. **Bare units / long_name** (e.g. ``units=arb;long_name=Intensity;``) —
+       these are wave-level annotations, not sample metadata, so they are
+       dropped from the output dict.
+    """
+    if not note or "=" not in note:
+        return {}
+
+    meta: dict[str, Any] = {}
+
+    # First, peel off each known section. We work on a mutable copy of the
+    # note and remove sections as we go so the remainder can be parsed
+    # as flat top-level pairs.
+    remainder = note
+    for start, end, prefix in _NOTE_SECTIONS:
+        i_start = remainder.find(start)
+        if i_start < 0:
+            continue
+        i_end = remainder.find(end, i_start + len(start))
+        if i_end < 0:
+            continue
+        section_body = remainder[i_start + len(start): i_end]
+        # Strip leading/trailing semicolons that bracket the section.
+        section_body = section_body.strip(";").strip()
+        section_kv = _parse_kv_pairs(section_body)
+        for k, v in section_kv.items():
+            meta[f"{prefix}{k}" if prefix else k] = _coerce(v)
+        # Remove the entire ``StartMarker..EndMarker`` chunk including
+        # the markers themselves.
+        remainder = (remainder[:i_start].rstrip(";") + ";"
+                     + remainder[i_end + len(end):].lstrip(";"))
+
+    # Remove section sentinels that have no end-marker (defensive).
+    for start, end, _ in _NOTE_SECTIONS:
+        remainder = remainder.replace(start, "").replace(end, "")
+    # Remove the marker pair labels themselves (e.g. ``Nexus_attributesStartHere``)
+    for marker in ("Nexus_attributesStartHere", "Nexus_attributesEndHere"):
+        remainder = remainder.replace(marker, "")
+
+    # Now parse what's left as flat key=value pairs. Map a few well-known
+    # keys to NXcanSAS-canonical names; route everything else into
+    # ``notes/<key>`` to preserve provenance without polluting sample/.
+    flat = _parse_kv_pairs(remainder)
+
+    # Wave-level annotation keys that should not become entry-level metadata.
+    _IGNORE = {"units", "long_name", "Units", "Wname"}
+
+    for k, v in flat.items():
+        if k in _IGNORE:
+            continue
+        kl = k.lower()
+        if kl == "datafile":
+            meta.setdefault("title", v)
+            meta[f"notes.{k}"] = v
+        elif kl == "date":
+            meta.setdefault("start_time", v)
+            meta[f"notes.{k}"] = v
+        elif kl == "comment":
+            # Use comment as title only if no explicit title already.
+            meta.setdefault("title", v)
+            meta[f"notes.{k}"] = v
+        else:
+            meta[f"notes.{k}"] = _coerce(v)
+
+    return meta
+
+
+# ---------------------------------------------------------------------------
+# Filename / folder-name sanitisers
+# ---------------------------------------------------------------------------
+
+_INVALID_FS_CHARS = re.compile(r'[<>:"/\\|?*\x00-\x1f]')
+
+
+def _safe_filename(name: str) -> str:
+    """Sanitise an Igor folder name for use as a filesystem path component."""
+    cleaned = _INVALID_FS_CHARS.sub("_", name).strip(" .")
+    return cleaned or "unnamed"
+
+
+def _unique_path(path: Path) -> Path:
+    """Return *path* if it doesn't exist, else append ``_2``, ``_3``, … to the stem."""
+    if not path.exists():
+        return path
+    n = 2
+    while True:
+        candidate = path.with_stem(f"{path.stem}_{n}")
+        if not candidate.exists():
+            return candidate
+        n += 1
+
+
+# ---------------------------------------------------------------------------
+# Tree traversal
+# ---------------------------------------------------------------------------
+
+def _classify_folder(folder_name: str) -> str | None:
+    """Return the canonical technique string for a top-level folder, or None."""
+    if folder_name in TECHNIQUE_FOLDERS:
+        return TECHNIQUE_FOLDERS[folder_name]
+    # Case-insensitive fallback.
+    for k, v in TECHNIQUE_FOLDERS.items():
+        if folder_name.lower() == k.lower():
+            return v
+    return None
+
+
+def _pick_waves(folder: dict, technique: str
+                ) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray | None, str] | None:
+    """Try each picker for *technique*; return (Q, I, err, dq, note) on first hit."""
+    pickers = WAVE_PICKERS.get(technique, [])
+    for q_name, i_name, e_name, dq_name in pickers:
+        if q_name not in folder or i_name not in folder or e_name not in folder:
+            continue
+        q_rec = folder[q_name]
+        i_rec = folder[i_name]
+        e_rec = folder[e_name]
+        if any(isinstance(r, dict) for r in (q_rec, i_rec, e_rec)):
+            continue   # one of them is a sub-folder, not a wave
+        q = _wave_array(q_rec)
+        intensity = _wave_array(i_rec)
+        err = _wave_array(e_rec)
+        if q is None or intensity is None or err is None:
+            continue
+        # Trim to common length defensively (real files match, but be safe)
+        n = min(len(q), len(intensity), len(err))
+        if n < 2:
+            continue
+        q, intensity, err = q[:n], intensity[:n], err[:n]
+
+        dq: np.ndarray | None = None
+        if dq_name and dq_name in folder and not isinstance(folder[dq_name], dict):
+            dq_arr = _wave_array(folder[dq_name])
+            if dq_arr is not None and len(dq_arr) >= n:
+                dq = dq_arr[:n]
+
+        # Wave note comes from the intensity wave (richest metadata).
+        note = _wave_note(i_rec)
+        return q, intensity, err, dq, note
+    return None
+
+
+def _walk_tree(node: dict, parent_technique: str | None, rel_path: tuple[str, ...]
+               ) -> Iterable[tuple[tuple[str, ...], str, dict]]:
+    """Yield ``(rel_path, technique, folder_dict)`` for each sample-bearing folder.
+
+    Walks *node* depth-first. At each folder, attempts wave extraction with
+    the inherited technique. Folders that don't yield data are still walked
+    into (their children may). Top-level folders that match
+    ``TECHNIQUE_FOLDERS`` set/override the inherited technique for the
+    subtree.
+    """
+    for name, child in node.items():
+        if not isinstance(child, dict):
+            continue
+        # Top-level folders set the technique. (Also accept re-declaration
+        # mid-tree, e.g. root:Custom:USAXS:..., for robustness.)
+        own_tech = _classify_folder(name)
+        new_technique = own_tech if own_tech is not None else parent_technique
+        new_rel = rel_path + (name,)
+
+        # Try wave extraction here (only meaningful if we know the technique).
+        if new_technique is not None and parent_technique is not None:
+            # Already inside a technique subtree — try to harvest waves
+            yield (new_rel, new_technique, child)
+        elif new_technique is not None and own_tech is not None:
+            # Entered a technique-root folder; do NOT yield the folder itself
+            # (it holds sample sub-folders, not waves). Just descend.
+            pass
+
+        # Recurse — children may hold more samples (in-situ sub-runs, etc.)
+        yield from _walk_tree(child, new_technique, new_rel)
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+def extract_pxp_to_nexus(
+    pxp_path: str | Path,
+    output_root: str | Path | None = None,
+    techniques: Sequence[str] | None = None,
+    overwrite: bool = False,
+) -> ExtractionResult:
+    """Extract reduced 1-D SAS data from a packed Igor experiment into NeXus files.
+
+    Parameters
+    ----------
+    pxp_path:
+        Path to the input ``.pxp`` file.
+    output_root:
+        Destination folder. If ``None`` (default), a sibling folder named
+        ``<pxp_stem>_data`` is created next to the input file. The folder
+        is created if it does not exist. Inside, one sub-folder per
+        technique (``USAXS/``, ``SAXS/``, ``WAXS/``) is created on demand.
+    techniques:
+        Optional iterable of technique strings to keep
+        (``["USAXS", "SAXS", "WAXS"]``). ``None`` (default) keeps every
+        technique present in the file.
+    overwrite:
+        If ``True``, existing files in the destination are overwritten.
+        If ``False`` (default), an unused suffix (``_2``, ``_3``, …) is
+        appended to keep both copies.
+
+    Returns
+    -------
+    ExtractionResult
+        Container with per-file summaries (:class:`ExtractedFile`) and
+        counts of unparseable records. Use ``.n_written`` /
+        ``.n_skipped`` / ``.n_errors`` for quick reporting.
+
+    Notes
+    -----
+    The extractor is intentionally conservative: it only writes a NeXus
+    file when it finds the full Q/I/error triple defined in
+    :data:`WAVE_PICKERS` for the relevant technique. Sample folders that
+    hold only raw detector counts (typical for "blank" measurements)
+    silently appear in the result as ``status="skipped"``.
+
+    The Igor folder hierarchy is **mirrored** in the output:
+    ``root:SAXS:in_situ_run_42:step_03:Sa1`` becomes
+    ``out/SAXS/in_situ_run_42/step_03/Sa1.h5``. This preserves the
+    user's organisation of in-situ experiments.
+    """
+    pxp_path = Path(pxp_path)
+    if not pxp_path.is_file():
+        raise FileNotFoundError(f"PXP file not found: {pxp_path}")
+
+    if output_root is None:
+        output_root = pxp_path.with_name(f"{pxp_path.stem}_data")
+    output_root = Path(output_root)
+    output_root.mkdir(parents=True, exist_ok=True)
+
+    keep_techniques: set[str] | None = None
+    if techniques is not None:
+        keep_techniques = {t.upper() for t in techniques}
+
+    logger.info("Loading %s…", pxp_path)
+    filesystem, n_skipped_records = _load_pxp_filesystem(pxp_path)
+    logger.info("Loaded %d folders; %d wave records were unparseable",
+                _count_folders(filesystem["root"]), n_skipped_records)
+
+    result = ExtractionResult(
+        pxp_path=pxp_path,
+        output_root=output_root,
+        n_unparseable_records=n_skipped_records,
+    )
+
+    # Walk and write
+    for rel_path, technique, folder in _walk_tree(filesystem["root"], None, ()):
+        if keep_techniques and technique.upper() not in keep_techniques:
+            continue
+
+        igor_path = "root:" + ":".join(rel_path)
+
+        picked = _pick_waves(folder, technique)
+        if picked is None:
+            # This folder is in a known technique subtree but doesn't carry
+            # the expected wave triple. Skip silently (probably an
+            # intermediate / blank folder).
+            #
+            # Don't emit a skipped row for nested non-leaf folders (would
+            # spam the summary). Only record skips for the leaf-looking
+            # ones: folders that contain at least one wave.
+            has_any_wave = any(not isinstance(v, dict) for v in folder.values())
+            if has_any_wave:
+                result.files.append(ExtractedFile(
+                    source_path=igor_path,
+                    output_path=None,
+                    technique=technique,
+                    n_points=0,
+                    status="skipped",
+                    message=f"no recognised {technique} wave triple in folder",
+                ))
+            continue
+
+        q, intensity, err, dq, note = picked
+        meta = parse_wave_note(note)
+
+        # Build the output path: <root>/<technique>/<rel_path_without_root_tech>/<sample>.h5
+        # rel_path is e.g. ('SAXS', 'Sa10_brRigNP_05mg__0013')  or
+        #                 ('SAXS', 'heater_run', 'step03', 'Sa1')
+        # The first element is the technique-root folder; strip it.
+        sub_components = [_safe_filename(c) for c in rel_path[1:]]
+        if not sub_components:
+            sub_components = ["unnamed"]
+        sample_name = sub_components[-1]
+        sample_dir = output_root / technique
+        if len(sub_components) > 1:
+            sample_dir = sample_dir.joinpath(*sub_components[:-1])
+        sample_dir.mkdir(parents=True, exist_ok=True)
+
+        out_path = sample_dir / f"{sample_name}.h5"
+        if not overwrite:
+            out_path = _unique_path(out_path)
+
+        try:
+            create_nxcansas_file(
+                filepath=out_path,
+                q=q,
+                intensity=intensity,
+                error=err,
+                dq=dq,
+                sample_name=sample_name,
+                metadata=meta,
+            )
+        except Exception as exc:
+            result.files.append(ExtractedFile(
+                source_path=igor_path,
+                output_path=out_path,
+                technique=technique,
+                n_points=len(q),
+                status="error",
+                message=str(exc),
+            ))
+            logger.exception("Failed to write %s", out_path)
+            continue
+
+        result.files.append(ExtractedFile(
+            source_path=igor_path,
+            output_path=out_path,
+            technique=technique,
+            n_points=len(q),
+            status="ok",
+        ))
+
+    logger.info("Extraction finished: %d written, %d skipped, %d errors",
+                result.n_written, result.n_skipped, result.n_errors)
+    return result
+
+
+def _count_folders(node: dict) -> int:
+    """Recursively count folders in the filesystem tree."""
+    n = 0
+    for v in node.values():
+        if isinstance(v, dict):
+            n += 1 + _count_folders(v)
+    return n
+
+
+# ---------------------------------------------------------------------------
+# CLI entry point (for quick testing without the GUI)
+# ---------------------------------------------------------------------------
+
+def _main(argv: Sequence[str] | None = None) -> int:
+    """``python -m pyirena.io.pxp_to_nexus <file.pxp> [output_dir] [TECH ...]``"""
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="Extract reduced SAS data from an Igor packed experiment "
+                    "into per-sample NXcanSAS HDF5 files.",
+    )
+    parser.add_argument("pxp", help="Path to the .pxp file")
+    parser.add_argument("-o", "--output", help="Output folder (default: <pxp>_data)")
+    parser.add_argument("-t", "--technique", action="append",
+                        help="Only export this technique (USAXS/SAXS/WAXS). "
+                             "Repeat for multiple; omit for all.")
+    parser.add_argument("--overwrite", action="store_true",
+                        help="Overwrite existing output files")
+    parser.add_argument("-v", "--verbose", action="store_true",
+                        help="Verbose logging")
+
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(
+        level=logging.INFO if args.verbose else logging.WARNING,
+        format="%(levelname)s  %(message)s",
+    )
+
+    result = extract_pxp_to_nexus(
+        args.pxp,
+        output_root=args.output,
+        techniques=args.technique,
+        overwrite=args.overwrite,
+    )
+
+    print(f"\nSource:   {result.pxp_path}")
+    print(f"Output:   {result.output_root}")
+    print(f"Written:  {result.n_written}")
+    print(f"Skipped:  {result.n_skipped}")
+    print(f"Errors:   {result.n_errors}")
+    if result.n_unparseable_records:
+        print(f"Note:     {result.n_unparseable_records} wave record(s) could not be parsed")
+
+    if args.verbose:
+        print("\nPer-file summary:")
+        for f in result.files:
+            tag = {"ok": "OK ", "skipped": "-- ", "error": "ERR"}.get(f.status, "?")
+            extra = f" [{f.message}]" if f.message else ""
+            out = str(f.output_path) if f.output_path else "(no output)"
+            print(f"  {tag} {f.technique:6s} {f.source_path:60s} -> {out}{extra}")
+
+    return 0 if result.n_errors == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(_main())

--- a/pyirena/io/pxp_to_nexus.py
+++ b/pyirena/io/pxp_to_nexus.py
@@ -256,8 +256,17 @@ def _load_pxp_filesystem(pxp_path: Path) -> tuple[dict, int]:
     header_struct = setup_packed_file_record_header()
     skipped = 0
 
+    # Hard upper bound on a single record. No legitimate Igor wave or
+    # procedure-file record approaches this; anything larger means we
+    # drifted out of alignment (e.g. on a record type we don't handle)
+    # and the next 4 bytes are misread as a record size. Bail rather
+    # than allocate gigabytes and OOM.
+    file_size = pxp_path.stat().st_size
+    _MAX_RECORD_BYTES = 256 * 1024 * 1024  # 256 MB
+
     with open(pxp_path, "rb") as f:
         while True:
+            pos = f.tell()
             b = f.read(header_struct.size)
             if len(b) == 0:
                 break
@@ -270,8 +279,25 @@ def _load_pxp_filesystem(pxp_path: Path) -> tuple[dict, int]:
                 if need:
                     header_struct = setup_packed_file_record_header(byte_order=byte_order)
                     header = header_struct.unpack_from(b)
-            data = bytes(f.read(header["numDataBytes"]))
-            if len(data) < header["numDataBytes"]:
+
+            num_bytes = header["numDataBytes"]
+            # Sanity-check the record-size field. A negative or absurdly
+            # large value almost always means the loop is out of
+            # alignment (we read past the end of a record type we don't
+            # handle). Stop cleanly so we don't OOM trying to allocate
+            # gigabytes of garbage.
+            if (num_bytes < 0
+                    or num_bytes > _MAX_RECORD_BYTES
+                    or pos + header_struct.size + num_bytes > file_size):
+                logger.warning(
+                    "%s: implausible record size %d at offset 0x%x "
+                    "(file is %d bytes). Stopping load; %d records read so far.",
+                    pxp_path.name, num_bytes, pos, file_size, len(records),
+                )
+                break
+
+            data = bytes(f.read(num_bytes))
+            if len(data) < num_bytes:
                 logger.warning("truncated record in %s — stopping", pxp_path)
                 break
             rtype_id = header["recordType"] & PACKEDRECTYPE_MASK

--- a/pyirena/io/pxp_to_nexus.py
+++ b/pyirena/io/pxp_to_nexus.py
@@ -227,6 +227,43 @@ class ExtractionResult:
 # Defensive .pxp loader
 # ---------------------------------------------------------------------------
 
+#: Igor binary-wave version that igor2 0.5.x doesn't recognise. v7 was added
+#: in Igor Pro 8 to support wave names / dimension labels longer than 31
+#: bytes; binary layout is identical to v5 up to the optional sections, so
+#: a v7 wave can be parsed as v5 if we patch the version field and ignore
+#: the trailing long-name block.
+_IGOR_WAVE_VERSION_V5 = 5
+_IGOR_WAVE_VERSION_V7 = 7
+
+
+def _patch_v7_wave_to_v5(data: bytes, byte_order: str) -> bytes:
+    """Rewrite the leading version field of a binary-wave payload from
+    7 to 5 so igor2 0.5.x will accept it.
+
+    A v7 wave has the same BinHeader5 + WaveHeader5 + wave-data layout as
+    v5; the only additions are:
+    - ``optionsSize1`` (4 bytes at offset 60) is reinterpreted as
+      ``longWaveNameSize`` (2 bytes) + ``optionsSize1`` (2 bytes)
+    - a long-wave-name block is appended after the string-indices section
+    The numeric wave data — which is all we need for SAS extraction —
+    sits at the same offset as in v5 and reads identically. The trailing
+    long-name section is harmless because BinHeader5's recorded wfmSize
+    tells igor2 when to stop reading the wave data, and our caller never
+    inspects what's after the wData section.
+    """
+    if len(data) < 2:
+        return data
+    import struct
+    ver_fmt = "<h" if byte_order in ("<", "=") else ">h"
+    try:
+        version = struct.unpack_from(ver_fmt, data, 0)[0]
+    except struct.error:
+        return data
+    if version != _IGOR_WAVE_VERSION_V7:
+        return data
+    return struct.pack(ver_fmt, _IGOR_WAVE_VERSION_V5) + data[2:]
+
+
 def _load_pxp_filesystem(pxp_path: Path) -> tuple[dict, int]:
     """Load a .pxp file and return ``(filesystem, n_skipped_records)``.
 
@@ -328,6 +365,21 @@ def _load_pxp_filesystem(pxp_path: Path) -> tuple[dict, int]:
                 rec = rtype(header, data, byte_order=byte_order)
                 records.append(rec)
             except Exception as exc:
+                # If this looks like a v7 wave (long-name format from
+                # Igor Pro 8/10), patch the version field to 5 and retry.
+                # igor2 0.5.x doesn't know about v7 even though the
+                # binary layout is identical up to the trailing
+                # long-name block.
+                if rtype is WaveRecord:
+                    patched = _patch_v7_wave_to_v5(data, byte_order)
+                    if patched is not data:
+                        try:
+                            rec = WaveRecord(header, patched, byte_order=byte_order)
+                            records.append(rec)
+                            continue
+                        except Exception as exc2:
+                            exc = exc2  # fall through to "skipped" path below
+
                 skipped += 1
                 records.append(None)
                 logger.debug("skipped %s record (rtype_id=%s): %s",

--- a/pyirena/io/pxp_to_nexus.py
+++ b/pyirena/io/pxp_to_nexus.py
@@ -90,10 +90,14 @@ from pyirena.io.nxcansas_unified import create_nxcansas_file
 
 __all__ = [
     "extract_pxp_to_nexus",
+    "extract_h5xp_to_nexus",
+    "extract_igor_experiment",
     "ExtractedFile",
     "ExtractionResult",
     "TECHNIQUE_FOLDERS",
     "WAVE_PICKERS",
+    "WAVE_PICKERS_H5XP",
+    "parse_wave_note",
 ]
 
 
@@ -117,11 +121,11 @@ TECHNIQUE_FOLDERS: dict[str, str] = {
 }
 
 
-#: Wave-name picker per technique. Each entry is a list of ``(Q_name, I_name,
-#: Err_name, dQ_name_or_None)`` tuples tried in order. The first tuple whose
-#: Q, I, and Err waves all exist in a sample folder wins. dQ is optional —
-#: if its name is None or not present, the resulting file will not contain
-#: a Qdev dataset.
+#: Wave-name picker per technique for **.pxp** experiments. Each entry is a
+#: list of ``(Q_name, I_name, Err_name, dQ_name_or_None)`` tuples tried in
+#: order. The first tuple whose Q, I, and Err waves all exist in a sample
+#: folder wins. dQ is optional — if its name is None or not present, the
+#: resulting file will not contain a Qdev dataset.
 WAVE_PICKERS: dict[str, list[tuple[str, str, str, str | None]]] = {
     "USAXS": [
         # Desmeared primary: matches the chosen "DSM_* only" policy.
@@ -133,6 +137,35 @@ WAVE_PICKERS: dict[str, list[tuple[str, str, str, str | None]]] = {
     ],
     "WAXS": [
         ("R_Qvec", "R_Int", "R_Error", None),
+    ],
+}
+
+
+#: Wave-name picker per technique for **.h5xp** files (Wavemetrics' HDF5
+#: packed-experiment format). Same tuple shape as :data:`WAVE_PICKERS`,
+#: but the literal token ``"<folder>"`` inside a name is substituted with
+#: the actual sample folder name at lookup time. This matches the two
+#: conventions produced by :mod:`pyirena.io.h5xp_writer`:
+#:
+#: * lowercase ``q_<folder>`` / ``r_<folder>`` / ``s_<folder>`` /
+#:   ``dq_<folder>`` — the per-sample-folder default of
+#:   :func:`pyirena.io.h5xp_writer.write_iq_data`
+#: * uppercase ``Q`` / ``R`` / ``S`` / ``dQ`` — older Igor-side export
+#:   helpers and some hand-built h5xp files
+#:
+#: Both are tried in order; the first match wins.
+WAVE_PICKERS_H5XP: dict[str, list[tuple[str, str, str, str | None]]] = {
+    "USAXS": [
+        ("q_<folder>", "r_<folder>", "s_<folder>", "dq_<folder>"),
+        ("Q", "R", "S", "dQ"),
+    ],
+    "SAXS": [
+        ("q_<folder>", "r_<folder>", "s_<folder>", "dq_<folder>"),
+        ("Q", "R", "S", "dQ"),
+    ],
+    "WAXS": [
+        ("q_<folder>", "r_<folder>", "s_<folder>", "dq_<folder>"),
+        ("Q", "R", "S", "dQ"),
     ],
 }
 
@@ -321,23 +354,74 @@ _NOTE_SECTIONS: list[tuple[str, str, str]] = [
 ]
 
 
-def _parse_kv_pairs(text: str) -> dict[str, str]:
-    """Parse Igor-style ``key=value;key=value;`` into a dict.
+def _parse_kv_pairs(text: str, sep: str = "=") -> dict[str, str]:
+    """Parse Igor-style ``key<sep>value;key<sep>value;`` into a dict.
 
-    Values are stripped; trailing empty entries are dropped. Values that
-    look numeric are left as strings — the caller decides what to coerce.
+    The two flavours seen in the wild:
+
+    * **.pxp files** (Igor itself + APS USAXS reduction) → ``key=value;``
+    * **.h5xp files** (Wavemetrics-documented HDF5 export format, and
+      what :mod:`pyirena.io.h5xp_writer` emits) → ``key:value;``
+
+    Pass ``sep=":"`` for h5xp notes. Quoted values
+    (``key:"some;string;with;semicolons"``) are honoured for h5xp,
+    matching what :func:`pyirena.io.h5xp_writer.make_wave_note` writes.
+
+    Values are stripped of surrounding whitespace and matching outer
+    double-quotes; trailing empty chunks are dropped. Numeric coercion is
+    the caller's job (see :func:`_coerce`).
     """
     out: dict[str, str] = {}
-    for chunk in text.split(";"):
+    # Split on ";" but respect double-quoted segments so a quoted value
+    # containing a semicolon is not chopped in half.
+    chunks: list[str] = []
+    buf: list[str] = []
+    in_quote = False
+    for ch in text:
+        if ch == '"':
+            in_quote = not in_quote
+            buf.append(ch)
+        elif ch == ";" and not in_quote:
+            chunks.append("".join(buf))
+            buf = []
+        else:
+            buf.append(ch)
+    if buf:
+        chunks.append("".join(buf))
+
+    for chunk in chunks:
         chunk = chunk.strip()
-        if not chunk or "=" not in chunk:
+        if not chunk or sep not in chunk:
             continue
-        k, _, v = chunk.partition("=")
+        k, _, v = chunk.partition(sep)
         k = k.strip()
         v = v.strip()
+        # Strip matching outer double-quotes
+        if len(v) >= 2 and v[0] == '"' and v[-1] == '"':
+            v = v[1:-1]
         if k:
             out[k] = v
     return out
+
+
+def _detect_kv_separator(note: str) -> str:
+    """Return ``"="`` or ``":"`` for a given note. Defaults to ``"="``.
+
+    Decision rule: count delimiters at the top level (outside quotes).
+    Whichever wins is the format. Ties go to ``"="`` because that's the
+    pxp default and the historical case.
+    """
+    n_eq = n_co = 0
+    in_quote = False
+    for ch in note:
+        if ch == '"':
+            in_quote = not in_quote
+        elif not in_quote:
+            if ch == "=":
+                n_eq += 1
+            elif ch == ":":
+                n_co += 1
+    return ":" if n_co > n_eq else "="
 
 
 def _coerce(val: str) -> Any:
@@ -370,8 +454,12 @@ def parse_wave_note(note: str) -> dict[str, Any]:
        these are wave-level annotations, not sample metadata, so they are
        dropped from the output dict.
     """
-    if not note or "=" not in note:
+    if not note or ("=" not in note and ":" not in note):
         return {}
+
+    # h5xp notes use "key:value;", pxp notes use "key=value;". Auto-detect
+    # so callers can stay agnostic.
+    sep = _detect_kv_separator(note)
 
     meta: dict[str, Any] = {}
 
@@ -389,7 +477,7 @@ def parse_wave_note(note: str) -> dict[str, Any]:
         section_body = remainder[i_start + len(start): i_end]
         # Strip leading/trailing semicolons that bracket the section.
         section_body = section_body.strip(";").strip()
-        section_kv = _parse_kv_pairs(section_body)
+        section_kv = _parse_kv_pairs(section_body, sep=sep)
         for k, v in section_kv.items():
             meta[f"{prefix}{k}" if prefix else k] = _coerce(v)
         # Remove the entire ``StartMarker..EndMarker`` chunk including
@@ -404,13 +492,13 @@ def parse_wave_note(note: str) -> dict[str, Any]:
     for marker in ("Nexus_attributesStartHere", "Nexus_attributesEndHere"):
         remainder = remainder.replace(marker, "")
 
-    # Now parse what's left as flat key=value pairs. Map a few well-known
+    # Now parse what's left as flat key/value pairs. Map a few well-known
     # keys to NXcanSAS-canonical names; route everything else into
     # ``notes/<key>`` to preserve provenance without polluting sample/.
-    flat = _parse_kv_pairs(remainder)
+    flat = _parse_kv_pairs(remainder, sep=sep)
 
     # Wave-level annotation keys that should not become entry-level metadata.
-    _IGNORE = {"units", "long_name", "Units", "Wname"}
+    _IGNORE = {"units", "long_name", "Units", "Wname", "IgorFolder"}
 
     for k, v in flat.items():
         if k in _IGNORE:
@@ -472,11 +560,34 @@ def _classify_folder(folder_name: str) -> str | None:
     return None
 
 
-def _pick_waves(folder: dict, technique: str
+def _pick_waves(folder: dict, technique: str,
+                pickers_table: dict | None = None,
+                folder_name: str | None = None,
                 ) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray | None, str] | None:
-    """Try each picker for *technique*; return (Q, I, err, dq, note) on first hit."""
-    pickers = WAVE_PICKERS.get(technique, [])
-    for q_name, i_name, e_name, dq_name in pickers:
+    """Try each picker for *technique*; return (Q, I, err, dq, note) on first hit.
+
+    *pickers_table* defaults to :data:`WAVE_PICKERS` (pxp conventions).
+    Pass :data:`WAVE_PICKERS_H5XP` for h5xp imports.
+
+    The literal token ``"<folder>"`` inside any picker entry is replaced
+    with *folder_name* before lookup (used by the h5xp picker to match
+    the ``q_<folder>``/``r_<folder>``/``s_<folder>`` naming produced by
+    :func:`pyirena.io.h5xp_writer.write_iq_data`).
+    """
+    if pickers_table is None:
+        pickers_table = WAVE_PICKERS
+    pickers = pickers_table.get(technique, [])
+
+    def _resolve(name: str | None) -> str | None:
+        if name is None or folder_name is None:
+            return name
+        return name.replace("<folder>", folder_name)
+
+    for q_name_raw, i_name_raw, e_name_raw, dq_name_raw in pickers:
+        q_name  = _resolve(q_name_raw)
+        i_name  = _resolve(i_name_raw)
+        e_name  = _resolve(e_name_raw)
+        dq_name = _resolve(dq_name_raw)
         if q_name not in folder or i_name not in folder or e_name not in folder:
             continue
         q_rec = folder[q_name]
@@ -537,6 +648,210 @@ def _walk_tree(node: dict, parent_technique: str | None, rel_path: tuple[str, ..
 
         # Recurse — children may hold more samples (in-situ sub-runs, etc.)
         yield from _walk_tree(child, new_technique, new_rel)
+
+
+# ---------------------------------------------------------------------------
+# h5xp loader
+# ---------------------------------------------------------------------------
+
+class _H5Wave:
+    """Wave adapter that quacks like an igor2 ``WaveRecord`` for the
+    extractor pipeline.
+
+    Wraps an open ``h5py.Dataset`` so :func:`_wave_array` and
+    :func:`_wave_note` can treat both pxp wave records and h5xp datasets
+    uniformly. Reads the data eagerly (small 1-D arrays) so we don't have
+    to keep file handles open during traversal.
+    """
+
+    __slots__ = ("wave",)
+
+    def __init__(self, dataset: "h5py.Dataset"):
+        # Mirror the nested dict shape that igor2.record.wave.WaveRecord
+        # exposes, so _wave_array / _wave_note work without branching.
+        try:
+            data = np.asarray(dataset[()])
+        except Exception:
+            data = None
+        note_attr = dataset.attrs.get("IGORWaveNote", b"")
+        if isinstance(note_attr, np.ndarray):
+            note_attr = note_attr.item() if note_attr.size else b""
+        if isinstance(note_attr, bytes):
+            note_attr = note_attr.decode("utf-8", errors="replace")
+        else:
+            note_attr = str(note_attr)
+        bname = dataset.name.rsplit("/", 1)[-1]
+        self.wave = {
+            "wave": {
+                "wave_header": {"bname": bname},
+                "wData": data,
+                "note": note_attr,
+            }
+        }
+
+
+def _load_h5xp_filesystem(h5xp_path: Path) -> tuple[dict, int]:
+    """Load the ``/Packed Data/`` tree from an h5xp file as the same
+    nested-dict structure that :func:`_load_pxp_filesystem` produces.
+
+    Only the ``Packed Data/`` subtree is walked — ``History``,
+    ``Recreation``, ``Symbolic Paths`` etc. are ignored because they
+    never contain reduced 1-D scattering data. The ``Packed Data/Results/``
+    subtree (collected scalar tables written by the h5xp batch extractor)
+    is also skipped: it holds per-parameter waves indexed by sample,
+    which don't match the per-sample-folder shape this extractor expects.
+
+    Returns ``(filesystem, 0)`` — h5xp uses standard HDF5 so there is no
+    "unparseable record" failure mode equivalent to the pxp one.
+    """
+    import h5py
+
+    filesystem: dict = {"root": {}}
+
+    with h5py.File(h5xp_path, "r") as f:
+        if "Packed Data" not in f:
+            return filesystem, 0
+        packed = f["Packed Data"]
+        for tech_name in packed:
+            tech_grp = packed[tech_name]
+            if not isinstance(tech_grp, h5py.Group):
+                continue
+            if tech_name == "Results":
+                continue   # scalar collection — not per-sample data
+
+            tech_dict: dict = {}
+            _h5xp_collect_into(tech_grp, tech_dict)
+            if tech_dict:
+                filesystem["root"][tech_name] = tech_dict
+
+    return filesystem, 0
+
+
+def _h5xp_collect_into(group: "h5py.Group", out: dict) -> None:
+    """Recurse into *group*, mirroring the h5py group/dataset tree into
+    a nested dict of dicts/_H5Wave objects that the extractor pipeline
+    can consume.
+    """
+    import h5py
+
+    for name, item in group.items():
+        if isinstance(item, h5py.Group):
+            child: dict = {}
+            _h5xp_collect_into(item, child)
+            out[name] = child
+        elif isinstance(item, h5py.Dataset):
+            # Skip non-numeric / scalar datasets that aren't waves
+            # (e.g. text waves carrying SampleNames). The picker drops
+            # anything that isn't a 1-D numeric array anyway.
+            out[name] = _H5Wave(item)
+
+
+# ---------------------------------------------------------------------------
+# Shared extraction engine
+# ---------------------------------------------------------------------------
+
+def _extract_filesystem_to_nexus(
+    source_path: Path,
+    filesystem: dict,
+    output_root: Path,
+    keep_techniques: set[str] | None,
+    overwrite: bool,
+    pickers_table: dict,
+    n_unparseable_records: int = 0,
+) -> ExtractionResult:
+    """Walk an already-loaded *filesystem* dict and write per-sample NeXus
+    files. Shared by both :func:`extract_pxp_to_nexus` and
+    :func:`extract_h5xp_to_nexus` — the only difference between them is
+    how the filesystem dict was built and which picker table to use.
+    """
+    result = ExtractionResult(
+        pxp_path=source_path,
+        output_root=output_root,
+        n_unparseable_records=n_unparseable_records,
+    )
+
+    for rel_path, technique, folder in _walk_tree(filesystem["root"], None, ()):
+        if keep_techniques and technique.upper() not in keep_techniques:
+            continue
+
+        igor_path = "root:" + ":".join(rel_path)
+        # The last component of rel_path is the sample folder name, used
+        # by h5xp pickers for <folder> substitution.
+        sample_folder_name = rel_path[-1] if rel_path else None
+
+        picked = _pick_waves(folder, technique,
+                              pickers_table=pickers_table,
+                              folder_name=sample_folder_name)
+        if picked is None:
+            # Folder is in a known technique subtree but lacks the
+            # expected wave triple. Only record a skip row for "leaf-ish"
+            # folders (those containing waves) to keep the summary
+            # readable for deeply nested trees.
+            has_any_wave = any(not isinstance(v, dict) for v in folder.values())
+            if has_any_wave:
+                result.files.append(ExtractedFile(
+                    source_path=igor_path,
+                    output_path=None,
+                    technique=technique,
+                    n_points=0,
+                    status="skipped",
+                    message=f"no recognised {technique} wave triple in folder",
+                ))
+            continue
+
+        q, intensity, err, dq, note = picked
+        meta = parse_wave_note(note)
+
+        # Build the output path: <root>/<technique>/<rel_path_without_root_tech>/<sample>.h5
+        # rel_path is e.g. ('SAXS', 'Sa10_brRigNP_05mg__0013')  or
+        #                 ('SAXS', 'heater_run', 'step03', 'Sa1')
+        # The first element is the technique-root folder; strip it.
+        sub_components = [_safe_filename(c) for c in rel_path[1:]]
+        if not sub_components:
+            sub_components = ["unnamed"]
+        sample_name = sub_components[-1]
+        sample_dir = output_root / technique
+        if len(sub_components) > 1:
+            sample_dir = sample_dir.joinpath(*sub_components[:-1])
+        sample_dir.mkdir(parents=True, exist_ok=True)
+
+        out_path = sample_dir / f"{sample_name}.h5"
+        if not overwrite:
+            out_path = _unique_path(out_path)
+
+        try:
+            create_nxcansas_file(
+                filepath=out_path,
+                q=q,
+                intensity=intensity,
+                error=err,
+                dq=dq,
+                sample_name=sample_name,
+                metadata=meta,
+            )
+        except Exception as exc:
+            result.files.append(ExtractedFile(
+                source_path=igor_path,
+                output_path=out_path,
+                technique=technique,
+                n_points=len(q),
+                status="error",
+                message=str(exc),
+            ))
+            logger.exception("Failed to write %s", out_path)
+            continue
+
+        result.files.append(ExtractedFile(
+            source_path=igor_path,
+            output_path=out_path,
+            technique=technique,
+            n_points=len(q),
+            status="ok",
+        ))
+
+    logger.info("Extraction finished: %d written, %d skipped, %d errors",
+                result.n_written, result.n_skipped, result.n_errors)
+    return result
 
 
 # ---------------------------------------------------------------------------
@@ -607,93 +922,121 @@ def extract_pxp_to_nexus(
     logger.info("Loaded %d folders; %d wave records were unparseable",
                 _count_folders(filesystem["root"]), n_skipped_records)
 
-    result = ExtractionResult(
-        pxp_path=pxp_path,
+    return _extract_filesystem_to_nexus(
+        source_path=pxp_path,
+        filesystem=filesystem,
         output_root=output_root,
+        keep_techniques=keep_techniques,
+        overwrite=overwrite,
+        pickers_table=WAVE_PICKERS,
         n_unparseable_records=n_skipped_records,
     )
 
-    # Walk and write
-    for rel_path, technique, folder in _walk_tree(filesystem["root"], None, ()):
-        if keep_techniques and technique.upper() not in keep_techniques:
-            continue
 
-        igor_path = "root:" + ":".join(rel_path)
+def extract_h5xp_to_nexus(
+    h5xp_path: str | Path,
+    output_root: str | Path | None = None,
+    techniques: Sequence[str] | None = None,
+    overwrite: bool = False,
+) -> ExtractionResult:
+    """Extract reduced 1-D SAS data from an Igor h5xp packed experiment
+    into per-sample NeXus files.
 
-        picked = _pick_waves(folder, technique)
-        if picked is None:
-            # This folder is in a known technique subtree but doesn't carry
-            # the expected wave triple. Skip silently (probably an
-            # intermediate / blank folder).
-            #
-            # Don't emit a skipped row for nested non-leaf folders (would
-            # spam the summary). Only record skips for the leaf-looking
-            # ones: folders that contain at least one wave.
-            has_any_wave = any(not isinstance(v, dict) for v in folder.values())
-            if has_any_wave:
-                result.files.append(ExtractedFile(
-                    source_path=igor_path,
-                    output_path=None,
-                    technique=technique,
-                    n_points=0,
-                    status="skipped",
-                    message=f"no recognised {technique} wave triple in folder",
-                ))
-            continue
+    Same shape and contract as :func:`extract_pxp_to_nexus`, but reads
+    the Wavemetrics HDF5 packed-experiment format (``.h5xp``) instead of
+    the legacy binary ``.pxp`` format. h5xp is what pyirena's own
+    :mod:`pyirena.io.h5xp_writer` produces and what modern Igor 9+
+    exports — so this is the natural import path for files that already
+    came from Python or were saved in the new format.
 
-        q, intensity, err, dq, note = picked
-        meta = parse_wave_note(note)
+    Parameters
+    ----------
+    h5xp_path:
+        Path to the input ``.h5xp`` file.
+    output_root, techniques, overwrite:
+        See :func:`extract_pxp_to_nexus`.
 
-        # Build the output path: <root>/<technique>/<rel_path_without_root_tech>/<sample>.h5
-        # rel_path is e.g. ('SAXS', 'Sa10_brRigNP_05mg__0013')  or
-        #                 ('SAXS', 'heater_run', 'step03', 'Sa1')
-        # The first element is the technique-root folder; strip it.
-        sub_components = [_safe_filename(c) for c in rel_path[1:]]
-        if not sub_components:
-            sub_components = ["unnamed"]
-        sample_name = sub_components[-1]
-        sample_dir = output_root / technique
-        if len(sub_components) > 1:
-            sample_dir = sample_dir.joinpath(*sub_components[:-1])
-        sample_dir.mkdir(parents=True, exist_ok=True)
+    Returns
+    -------
+    ExtractionResult
+        Same container type, but ``n_unparseable_records`` will always
+        be 0 because h5xp uses standard HDF5 and never fails per-record.
 
-        out_path = sample_dir / f"{sample_name}.h5"
-        if not overwrite:
-            out_path = _unique_path(out_path)
+    Notes
+    -----
+    Only the ``/Packed Data/`` subtree is walked. h5xp metadata
+    sections (``History``, ``Recreation``, ``Symbolic Paths``,
+    ``Packed Procedure Files``) are ignored — they never contain
+    reduced 1-D data. The ``Packed Data/Results/`` group (per-parameter
+    collected-value waves) is also skipped because it doesn't follow
+    the per-sample-folder shape this extractor needs.
 
+    The wave-name convention is ``Q``/``R``/``S``(+``dQ``) per
+    :data:`WAVE_PICKERS_H5XP` — matches what
+    :func:`pyirena.io.h5xp_writer.write_iq_data` emits.
+    """
+    h5xp_path = Path(h5xp_path)
+    if not h5xp_path.is_file():
+        raise FileNotFoundError(f"h5xp file not found: {h5xp_path}")
+
+    if output_root is None:
+        output_root = h5xp_path.with_name(f"{h5xp_path.stem}_data")
+    output_root = Path(output_root)
+    output_root.mkdir(parents=True, exist_ok=True)
+
+    keep_techniques: set[str] | None = None
+    if techniques is not None:
+        keep_techniques = {t.upper() for t in techniques}
+
+    logger.info("Loading %s…", h5xp_path)
+    filesystem, _ = _load_h5xp_filesystem(h5xp_path)
+    logger.info("Loaded %d folders from h5xp", _count_folders(filesystem["root"]))
+
+    return _extract_filesystem_to_nexus(
+        source_path=h5xp_path,
+        filesystem=filesystem,
+        output_root=output_root,
+        keep_techniques=keep_techniques,
+        overwrite=overwrite,
+        pickers_table=WAVE_PICKERS_H5XP,
+    )
+
+
+def extract_igor_experiment(
+    path: str | Path,
+    output_root: str | Path | None = None,
+    techniques: Sequence[str] | None = None,
+    overwrite: bool = False,
+) -> ExtractionResult:
+    """Auto-dispatch to :func:`extract_pxp_to_nexus` or
+    :func:`extract_h5xp_to_nexus` based on the file extension.
+
+    Use this from GUIs / CLIs where the caller doesn't want to care
+    which Igor format the user picked.
+
+    Recognised extensions (case-insensitive): ``.pxp``, ``.pxt``
+    (Igor packed binary) → pxp route; ``.h5xp``, ``.hxp``, ``.h5`` whose
+    root contains a ``/Packed Data/`` group → h5xp route.
+    """
+    p = Path(path)
+    ext = p.suffix.lower()
+    if ext in (".pxp", ".pxt"):
+        return extract_pxp_to_nexus(p, output_root, techniques, overwrite)
+    if ext in (".h5xp", ".hxp"):
+        return extract_h5xp_to_nexus(p, output_root, techniques, overwrite)
+    # .h5 fallback: peek at the structure
+    if ext in (".h5", ".hdf5"):
         try:
-            create_nxcansas_file(
-                filepath=out_path,
-                q=q,
-                intensity=intensity,
-                error=err,
-                dq=dq,
-                sample_name=sample_name,
-                metadata=meta,
-            )
-        except Exception as exc:
-            result.files.append(ExtractedFile(
-                source_path=igor_path,
-                output_path=out_path,
-                technique=technique,
-                n_points=len(q),
-                status="error",
-                message=str(exc),
-            ))
-            logger.exception("Failed to write %s", out_path)
-            continue
-
-        result.files.append(ExtractedFile(
-            source_path=igor_path,
-            output_path=out_path,
-            technique=technique,
-            n_points=len(q),
-            status="ok",
-        ))
-
-    logger.info("Extraction finished: %d written, %d skipped, %d errors",
-                result.n_written, result.n_skipped, result.n_errors)
-    return result
+            import h5py
+            with h5py.File(p, "r") as f:
+                if "Packed Data" in f:
+                    return extract_h5xp_to_nexus(p, output_root, techniques, overwrite)
+        except Exception:
+            pass
+    raise ValueError(
+        f"{p.name}: unsupported Igor experiment format. "
+        f"Expected .pxp, .pxt, .h5xp, or .hxp."
+    )
 
 
 def _count_folders(node: dict) -> int:
@@ -710,15 +1053,20 @@ def _count_folders(node: dict) -> int:
 # ---------------------------------------------------------------------------
 
 def _main(argv: Sequence[str] | None = None) -> int:
-    """``python -m pyirena.io.pxp_to_nexus <file.pxp> [output_dir] [TECH ...]``"""
+    """``python -m pyirena.io.pxp_to_nexus <file.pxp|.h5xp> [-o DIR] [-t TECH ...]``
+
+    Accepts both ``.pxp`` (binary Igor packed) and ``.h5xp`` (Wavemetrics
+    HDF5 packed-experiment) inputs; the format is dispatched automatically
+    on the file extension.
+    """
     import argparse
 
     parser = argparse.ArgumentParser(
         description="Extract reduced SAS data from an Igor packed experiment "
-                    "into per-sample NXcanSAS HDF5 files.",
+                    "(.pxp or .h5xp) into per-sample NXcanSAS HDF5 files.",
     )
-    parser.add_argument("pxp", help="Path to the .pxp file")
-    parser.add_argument("-o", "--output", help="Output folder (default: <pxp>_data)")
+    parser.add_argument("input", help="Path to the .pxp or .h5xp file")
+    parser.add_argument("-o", "--output", help="Output folder (default: <input>_data)")
     parser.add_argument("-t", "--technique", action="append",
                         help="Only export this technique (USAXS/SAXS/WAXS). "
                              "Repeat for multiple; omit for all.")
@@ -734,8 +1082,8 @@ def _main(argv: Sequence[str] | None = None) -> int:
         format="%(levelname)s  %(message)s",
     )
 
-    result = extract_pxp_to_nexus(
-        args.pxp,
+    result = extract_igor_experiment(
+        args.input,
         output_root=args.output,
         techniques=args.technique,
         overwrite=args.overwrite,

--- a/pyirena/io/pxp_to_nexus.py
+++ b/pyirena/io/pxp_to_nexus.py
@@ -252,9 +252,28 @@ def _load_pxp_filesystem(pxp_path: Path) -> tuple[dict, int]:
         ) from e
 
     records: list[Any] = []
-    byte_order: str | None = None
-    header_struct = setup_packed_file_record_header()
     skipped = 0
+
+    # Always force an explicit byte order on the record header. The
+    # default ``setup_packed_file_record_header()`` (no argument) uses
+    # native byte order *with native alignment padding*, which on some
+    # platforms (notably macOS Python builds) inflates the 8-byte logical
+    # header to 16 bytes — and immediately misreads numDataBytes from
+    # what it thinks is the trailing pad of a record that doesn't have
+    # one. Probe the first two bytes to choose endianness, then build
+    # the struct with explicit byte order so size is reliably 8 and
+    # there's no alignment padding.
+    with open(pxp_path, "rb") as f:
+        peek = f.read(2)
+    if len(peek) < 2:
+        return {"root": {}}, 0
+    # Igor packed file records start with `short recordType`. Valid
+    # record-type IDs are 1..11 (plus high bits), so the first byte is
+    # always small; on little-endian it occupies byte 0, on big-endian
+    # byte 1. peek[0] != 0 → little-endian; peek[0] == 0 → big-endian.
+    initial_byte_order = "<" if peek[0] != 0 else ">"
+    header_struct = setup_packed_file_record_header(byte_order=initial_byte_order)
+    byte_order: str = initial_byte_order
 
     # Hard upper bound on a single record. No legitimate Igor wave or
     # procedure-file record approaches this; anything larger means we
@@ -273,10 +292,13 @@ def _load_pxp_filesystem(pxp_path: Path) -> tuple[dict, int]:
             if len(b) < header_struct.size:
                 break
             header = header_struct.unpack_from(b)
-            if header["version"] and not byte_order:
+            # Refine byte-order detection if the first record carries a
+            # non-zero version field (matches upstream igor2 behaviour).
+            if header["version"]:
                 need = _need_to_reorder_bytes(header["version"])
-                byte_order = _byte_order(need)
-                if need:
+                refined = _byte_order(need)
+                if refined != byte_order:
+                    byte_order = refined
                     header_struct = setup_packed_file_record_header(byte_order=byte_order)
                     header = header_struct.unpack_from(b)
 

--- a/pyirena/io/pxp_to_nexus.py
+++ b/pyirena/io/pxp_to_nexus.py
@@ -108,6 +108,17 @@ logger = logging.getLogger(__name__)
 # Configuration tables (data-driven, easy to extend)
 # ---------------------------------------------------------------------------
 
+#: Top-level Igor folder names that are infrastructure / configuration
+#: and never carry sample data. Skipped entirely (their subtrees are not
+#: walked). Add here if your experiment uses other reserved folders.
+INFRASTRUCTURE_FOLDERS: frozenset[str] = frozenset({
+    "Packages",          # Igor's own package data — never sample data
+    "SavedSampleSets",   # Indra/Irena sample-set bookkeeping
+    "WindowMacros",
+    "WMTemp",
+})
+
+
 #: Map of Igor folder name → canonical technique string. Folder name matching
 #: is case-insensitive and exact. Add aliases here when users follow other
 #: conventions (e.g. importing ASCII into a folder called ``"Imported SAXS"``).
@@ -719,32 +730,59 @@ def _pick_waves(folder: dict, technique: str,
 
 
 def _walk_tree(node: dict, parent_technique: str | None, rel_path: tuple[str, ...]
-               ) -> Iterable[tuple[tuple[str, ...], str, dict]]:
-    """Yield ``(rel_path, technique, folder_dict)`` for each sample-bearing folder.
+               ) -> Iterable[tuple[tuple[str, ...], list[str], dict]]:
+    """Yield ``(rel_path, candidate_techniques, folder_dict)`` for each
+    sample-bearing folder discovered in *node*.
 
-    Walks *node* depth-first. At each folder, attempts wave extraction with
-    the inherited technique. Folders that don't yield data are still walked
-    into (their children may). Top-level folders that match
-    ``TECHNIQUE_FOLDERS`` set/override the inherited technique for the
-    subtree.
+    *candidate_techniques* is a list because some Igor experiments
+    organise data by sample rather than by technique — a single folder
+    at root level can contain USAXS, SAXS, **and** WAXS wave triples
+    side by side (the per-sample layout seen e.g. when in-situ time
+    series are saved as one folder per timepoint). In that case the
+    caller must try every technique's picker against the folder and
+    emit one output file per technique whose triple is present.
+
+    Walking rules:
+      * Inside a known technique subtree → yield with
+        ``[parent_technique]`` so only that one picker is tried.
+      * At root level (no parent technique) for a folder that holds at
+        least one wave → yield with ``["USAXS", "SAXS", "WAXS"]``.
+      * Technique-root folders (``root:USAXS:`` etc.) are not yielded
+        themselves; only their children are.
+
+    Top-level folder names matching :data:`TECHNIQUE_FOLDERS` set the
+    technique for the subtree (case-insensitive). Re-declaring a
+    technique mid-tree is also accepted, for files that nest e.g.
+    ``root:Custom:USAXS:Sample``.
     """
     for name, child in node.items():
         if not isinstance(child, dict):
             continue
-        # Top-level folders set the technique. (Also accept re-declaration
-        # mid-tree, e.g. root:Custom:USAXS:..., for robustness.)
+
+        # Skip known infrastructure folders entirely (and don't descend
+        # into them) so their sub-folders don't pollute the summary with
+        # "no wave triple" skip rows.
+        if parent_technique is None and name in INFRASTRUCTURE_FOLDERS:
+            continue
+
         own_tech = _classify_folder(name)
         new_technique = own_tech if own_tech is not None else parent_technique
         new_rel = rel_path + (name,)
 
-        # Try wave extraction here (only meaningful if we know the technique).
         if new_technique is not None and parent_technique is not None:
-            # Already inside a technique subtree — try to harvest waves
-            yield (new_rel, new_technique, child)
-        elif new_technique is not None and own_tech is not None:
-            # Entered a technique-root folder; do NOT yield the folder itself
-            # (it holds sample sub-folders, not waves). Just descend.
+            # Already inside a technique subtree — exactly one candidate.
+            yield (new_rel, [new_technique], child)
+        elif own_tech is not None:
+            # Entered a technique-root folder; do not yield the folder
+            # itself (it holds sample sub-folders). Just descend.
             pass
+        elif parent_technique is None:
+            # Root-level folder with no technique parent. If it contains
+            # any waves, treat it as a sample-by-sample folder that may
+            # carry up to three technique-specific wave triples.
+            has_any_wave = any(not isinstance(v, dict) for v in child.values())
+            if has_any_wave:
+                yield (new_rel, ["USAXS", "SAXS", "WAXS"], child)
 
         # Recurse — children may hold more samples (in-situ sub-runs, etc.)
         yield from _walk_tree(child, new_technique, new_rel)
@@ -870,84 +908,107 @@ def _extract_filesystem_to_nexus(
         n_unparseable_records=n_unparseable_records,
     )
 
-    for rel_path, technique, folder in _walk_tree(filesystem["root"], None, ()):
-        if keep_techniques and technique.upper() not in keep_techniques:
-            continue
-
+    for rel_path, candidate_techniques, folder in _walk_tree(
+        filesystem["root"], None, ()
+    ):
         igor_path = "root:" + ":".join(rel_path)
-        # The last component of rel_path is the sample folder name, used
-        # by h5xp pickers for <folder> substitution.
         sample_folder_name = rel_path[-1] if rel_path else None
 
-        picked = _pick_waves(folder, technique,
-                              pickers_table=pickers_table,
-                              folder_name=sample_folder_name)
-        if picked is None:
-            # Folder is in a known technique subtree but lacks the
-            # expected wave triple. Only record a skip row for "leaf-ish"
-            # folders (those containing waves) to keep the summary
-            # readable for deeply nested trees.
-            has_any_wave = any(not isinstance(v, dict) for v in folder.values())
-            if has_any_wave:
+        # Determine whether the first path component is a technique
+        # root (USAXS / SAXS / WAXS) so we know which path components
+        # are "sample subfolders" for output-path mirroring.
+        first_is_technique_root = (
+            len(rel_path) > 0 and _classify_folder(rel_path[0]) is not None
+        )
+
+        any_matched = False
+        for technique in candidate_techniques:
+            if keep_techniques and technique.upper() not in keep_techniques:
+                continue
+            picked = _pick_waves(folder, technique,
+                                  pickers_table=pickers_table,
+                                  folder_name=sample_folder_name)
+            if picked is None:
+                continue
+            any_matched = True
+
+            q, intensity, err, dq, note = picked
+            meta = parse_wave_note(note)
+
+            # Output path layout:
+            #   <root>/<technique>/<sub_components>/<sample_name>.h5
+            #
+            # If the folder was found *inside* a technique-root parent
+            # (rel_path = ('USAXS', 'Sample01')), drop the technique
+            # element and mirror the remaining path. Otherwise (root
+            # level, e.g. ('AMC_..._0033',)), mirror the whole path
+            # under the matched technique.
+            if first_is_technique_root:
+                source_components = rel_path[1:]
+            else:
+                source_components = rel_path
+            sub_components = [_safe_filename(c) for c in source_components]
+            if not sub_components:
+                sub_components = ["unnamed"]
+            sample_name = sub_components[-1]
+            sample_dir = output_root / technique
+            if len(sub_components) > 1:
+                sample_dir = sample_dir.joinpath(*sub_components[:-1])
+            sample_dir.mkdir(parents=True, exist_ok=True)
+
+            out_path = sample_dir / f"{sample_name}.h5"
+            if not overwrite:
+                out_path = _unique_path(out_path)
+
+            try:
+                create_nxcansas_file(
+                    filepath=out_path,
+                    q=q,
+                    intensity=intensity,
+                    error=err,
+                    dq=dq,
+                    sample_name=sample_name,
+                    metadata=meta,
+                )
+            except Exception as exc:
                 result.files.append(ExtractedFile(
                     source_path=igor_path,
-                    output_path=None,
+                    output_path=out_path,
                     technique=technique,
-                    n_points=0,
-                    status="skipped",
-                    message=f"no recognised {technique} wave triple in folder",
+                    n_points=len(q),
+                    status="error",
+                    message=str(exc),
                 ))
-            continue
+                logger.exception("Failed to write %s", out_path)
+                continue
 
-        q, intensity, err, dq, note = picked
-        meta = parse_wave_note(note)
-
-        # Build the output path: <root>/<technique>/<rel_path_without_root_tech>/<sample>.h5
-        # rel_path is e.g. ('SAXS', 'Sa10_brRigNP_05mg__0013')  or
-        #                 ('SAXS', 'heater_run', 'step03', 'Sa1')
-        # The first element is the technique-root folder; strip it.
-        sub_components = [_safe_filename(c) for c in rel_path[1:]]
-        if not sub_components:
-            sub_components = ["unnamed"]
-        sample_name = sub_components[-1]
-        sample_dir = output_root / technique
-        if len(sub_components) > 1:
-            sample_dir = sample_dir.joinpath(*sub_components[:-1])
-        sample_dir.mkdir(parents=True, exist_ok=True)
-
-        out_path = sample_dir / f"{sample_name}.h5"
-        if not overwrite:
-            out_path = _unique_path(out_path)
-
-        try:
-            create_nxcansas_file(
-                filepath=out_path,
-                q=q,
-                intensity=intensity,
-                error=err,
-                dq=dq,
-                sample_name=sample_name,
-                metadata=meta,
-            )
-        except Exception as exc:
             result.files.append(ExtractedFile(
                 source_path=igor_path,
                 output_path=out_path,
                 technique=technique,
                 n_points=len(q),
-                status="error",
-                message=str(exc),
+                status="ok",
             ))
-            logger.exception("Failed to write %s", out_path)
-            continue
 
-        result.files.append(ExtractedFile(
-            source_path=igor_path,
-            output_path=out_path,
-            technique=technique,
-            n_points=len(q),
-            status="ok",
-        ))
+        if not any_matched:
+            # Folder had waves but none of the candidate techniques' wave
+            # triples matched. Only record skips for "leaf-ish" folders
+            # (those that contain waves) to keep the summary readable
+            # for deeply nested trees that don't carry data.
+            has_any_wave = any(not isinstance(v, dict) for v in folder.values())
+            if has_any_wave:
+                tech_label = (candidate_techniques[0]
+                              if len(candidate_techniques) == 1
+                              else "/".join(candidate_techniques))
+                result.files.append(ExtractedFile(
+                    source_path=igor_path,
+                    output_path=None,
+                    technique=tech_label,
+                    n_points=0,
+                    status="skipped",
+                    message=f"no recognised wave triple in folder "
+                            f"(tried {', '.join(candidate_techniques)})",
+                ))
 
     logger.info("Extraction finished: %d written, %d skipped, %d errors",
                 result.n_written, result.n_skipped, result.n_errors)

--- a/pyirena/io/pxp_to_nexus.py
+++ b/pyirena/io/pxp_to_nexus.py
@@ -215,11 +215,26 @@ class ExtractedFile:
 
 @dataclass
 class ExtractionResult:
-    """Overall result of an :func:`extract_pxp_to_nexus` call."""
+    """Overall result of an :func:`extract_pxp_to_nexus` call.
+
+    Attributes
+    ----------
+    pxp_path, output_root, files, n_unparseable_records:
+        Self-explanatory.
+    n_igor8_longname_markers:
+        Count of Igor-8-only record types (26 and 33) seen in the
+        ``.pxp``. A non-zero value means the experiment contains folder
+        or wave names longer than 31 characters that ``igor2`` cannot
+        decode — and therefore the importer probably missed entire
+        samples whose folder names are too long. Callers should warn
+        the user and suggest re-saving the experiment as ``.h5xp``.
+        Always 0 for h5xp imports (which have no such limitation).
+    """
     pxp_path: Path
     output_root: Path
     files: list[ExtractedFile] = field(default_factory=list)
     n_unparseable_records: int = 0
+    n_igor8_longname_markers: int = 0
 
     @property
     def n_written(self) -> int:
@@ -275,8 +290,18 @@ def _patch_v7_wave_to_v5(data: bytes, byte_order: str) -> bytes:
     return struct.pack(ver_fmt, _IGOR_WAVE_VERSION_V5) + data[2:]
 
 
-def _load_pxp_filesystem(pxp_path: Path) -> tuple[dict, int]:
-    """Load a .pxp file and return ``(filesystem, n_skipped_records)``.
+#: Packed record-type IDs introduced by Igor Pro 8 to support folder/
+#: wave names longer than 31 chars. ``igor2 0.5.x`` doesn't know what
+#: they are, so it treats them as ``_UnknownRecord`` and skips them.
+#: We just count them so the importer can warn the user that the
+#: experiment likely has folders we can't see, and recommend re-saving
+#: as ``.h5xp`` (which has no name-length limit).
+_IGOR8_LONGNAME_RECORD_TYPES: frozenset[int] = frozenset({26, 33})
+
+
+def _load_pxp_filesystem(pxp_path: Path) -> tuple[dict, int, int]:
+    """Load a .pxp file and return
+    ``(filesystem, n_skipped_records, n_igor8_longname_markers)``.
 
     Unlike :func:`igor2.packed.load`, this never aborts on a single bad
     wave record: the offending record is skipped (counted) and traversal
@@ -284,6 +309,14 @@ def _load_pxp_filesystem(pxp_path: Path) -> tuple[dict, int]:
     fully usable folder tree. Folder structure depends only on
     ``FolderStartRecord`` / ``FolderEndRecord`` records, which parse
     cheaply and reliably.
+
+    The third return value counts how many ``Unknown`` records of the
+    Igor-8 long-name marker types (26, 33) were seen. A non-zero count
+    means the experiment was saved by Igor Pro 8 or later **and**
+    contains folder or wave names longer than 31 characters, which
+    ``igor2 0.5.x`` cannot decode. The high-level summary uses this to
+    tell the user to re-save the experiment as ``.h5xp`` (which has no
+    such limit).
     """
     try:
         from igor2.packed import (
@@ -301,6 +334,7 @@ def _load_pxp_filesystem(pxp_path: Path) -> tuple[dict, int]:
 
     records: list[Any] = []
     skipped = 0
+    igor8_longname_markers = 0
 
     # Always force an explicit byte order on the record header. The
     # default ``setup_packed_file_record_header()`` (no argument) uses
@@ -314,7 +348,7 @@ def _load_pxp_filesystem(pxp_path: Path) -> tuple[dict, int]:
     with open(pxp_path, "rb") as f:
         peek = f.read(2)
     if len(peek) < 2:
-        return {"root": {}}, 0
+        return {"root": {}}, 0, 0
     # Igor packed file records start with `short recordType`. Valid
     # record-type IDs are 1..11 (plus high bits), so the first byte is
     # always small; on little-endian it occupies byte 0, on big-endian
@@ -371,6 +405,8 @@ def _load_pxp_filesystem(pxp_path: Path) -> tuple[dict, int]:
                 logger.warning("truncated record in %s — stopping", pxp_path)
                 break
             rtype_id = header["recordType"] & PACKEDRECTYPE_MASK
+            if rtype_id in _IGOR8_LONGNAME_RECORD_TYPES:
+                igor8_longname_markers += 1
             rtype = _RECORD_TYPE.get(rtype_id, _UnknownRecord)
             try:
                 rec = rtype(header, data, byte_order=byte_order)
@@ -423,7 +459,7 @@ def _load_pxp_filesystem(pxp_path: Path) -> tuple[dict, int]:
                 # Unreadable wave name — drop silently; structure is the priority.
                 pass
 
-    return filesystem, skipped
+    return filesystem, skipped, igor8_longname_markers
 
 
 def _wave_array(wave_rec) -> np.ndarray | None:
@@ -896,6 +932,7 @@ def _extract_filesystem_to_nexus(
     overwrite: bool,
     pickers_table: dict,
     n_unparseable_records: int = 0,
+    n_igor8_longname_markers: int = 0,
 ) -> ExtractionResult:
     """Walk an already-loaded *filesystem* dict and write per-sample NeXus
     files. Shared by both :func:`extract_pxp_to_nexus` and
@@ -906,6 +943,7 @@ def _extract_filesystem_to_nexus(
         pxp_path=source_path,
         output_root=output_root,
         n_unparseable_records=n_unparseable_records,
+        n_igor8_longname_markers=n_igor8_longname_markers,
     )
 
     for rel_path, candidate_techniques, folder in _walk_tree(
@@ -1079,9 +1117,20 @@ def extract_pxp_to_nexus(
         keep_techniques = {t.upper() for t in techniques}
 
     logger.info("Loading %s…", pxp_path)
-    filesystem, n_skipped_records = _load_pxp_filesystem(pxp_path)
-    logger.info("Loaded %d folders; %d wave records were unparseable",
-                _count_folders(filesystem["root"]), n_skipped_records)
+    filesystem, n_skipped_records, n_igor8_markers = _load_pxp_filesystem(pxp_path)
+    logger.info(
+        "Loaded %d folders; %d wave records were unparseable; "
+        "%d Igor-8 long-name marker(s) seen",
+        _count_folders(filesystem["root"]), n_skipped_records, n_igor8_markers,
+    )
+    if n_igor8_markers > 0:
+        logger.warning(
+            "%s contains %d Igor-8 long-name record(s) (folders/waves with "
+            "names > 31 chars). igor2 cannot decode these, so some samples "
+            "will be missing from the output. Re-save the experiment as "
+            ".h5xp from Igor and re-import to capture them.",
+            pxp_path.name, n_igor8_markers,
+        )
 
     return _extract_filesystem_to_nexus(
         source_path=pxp_path,
@@ -1091,6 +1140,7 @@ def extract_pxp_to_nexus(
         overwrite=overwrite,
         pickers_table=WAVE_PICKERS,
         n_unparseable_records=n_skipped_records,
+        n_igor8_longname_markers=n_igor8_markers,
     )
 
 
@@ -1257,6 +1307,16 @@ def _main(argv: Sequence[str] | None = None) -> int:
     print(f"Errors:   {result.n_errors}")
     if result.n_unparseable_records:
         print(f"Note:     {result.n_unparseable_records} wave record(s) could not be parsed")
+    if result.n_igor8_longname_markers:
+        print(
+            f"\n*** WARNING: this .pxp contains "
+            f"{result.n_igor8_longname_markers} Igor-8 long-name record(s) "
+            f"(folders or waves with names > 31 chars).\n"
+            f"  igor2 cannot decode these, so some samples are MISSING from "
+            f"the output above.\n"
+            f"  Workaround: in Igor Pro, save the experiment as .h5xp instead "
+            f"and re-import."
+        )
 
     if args.verbose:
         print("\nPer-file summary:")

--- a/pyirena/mcp/server.py
+++ b/pyirena/mcp/server.py
@@ -3,6 +3,10 @@
 Run via:    pyirena-mcp
 Or in code: python -m pyirena.mcp.server
 
+All MCP tools are prefixed ``pyirena_`` so they are globally unambiguous
+when the client connects to multiple MCP servers and so small LLMs are
+not confused by clients that render ``server-tool`` with a dash.
+
 Environment overrides (see also pyirena.api):
     PYIRENA_DATA_ROOT       restrict file access to this subtree
     PYIRENA_MAX_ARRAY_POINTS default decimation cap (default 500)
@@ -28,10 +32,11 @@ mcp = FastMCP(
     "pyirena",
     instructions=(
         "Tools for reading pyirena SAXS/USAXS analysis results from NXcanSAS "
-        "HDF5 files. Start with summarize_folder() or list_files() to "
-        "discover what is available, then drill in with inspect_file() or "
-        "one of the read_<tool>() functions. Use plot_iq() / "
-        "plot_parameter_trend() to visualize."
+        "HDF5 files. All tool names are prefixed 'pyirena_'. Start with "
+        "pyirena_summarize_folder() or pyirena_list_files() to discover what "
+        "is available, then drill in with pyirena_inspect_file() or one of "
+        "the pyirena_read_<tool>() functions. Use pyirena_plot_iq() / "
+        "pyirena_plot_parameter_trend() to visualize."
     ),
 )
 
@@ -41,7 +46,7 @@ mcp = FastMCP(
 # ---------------------------------------------------------------------------
 
 @mcp.tool()
-def list_files(
+def pyirena_list_files(
     folder: str,
     pattern: str = "*.h5,*.hdf5,*.hdf,*.nx,*.nxs",
     sort: str = "mtime_desc",
@@ -59,7 +64,7 @@ def list_files(
 
 
 @mcp.tool()
-def summarize_folder(folder: str, sample_filter: Optional[str] = None) -> dict:
+def pyirena_summarize_folder(folder: str, sample_filter: Optional[str] = None) -> dict:
     """Get an aggregate snapshot of a folder of SAS data.
 
     Returns file count, unique samples, per-analysis file counts, and mtime
@@ -70,7 +75,7 @@ def summarize_folder(folder: str, sample_filter: Optional[str] = None) -> dict:
 
 
 @mcp.tool()
-def inspect_file(path: str) -> dict:
+def pyirena_inspect_file(path: str) -> dict:
     """Inspect a single file: sample name, analyses present, Q range, n_points."""
     return papi.inspect_file(path)
 
@@ -80,8 +85,8 @@ def inspect_file(path: str) -> dict:
 # ---------------------------------------------------------------------------
 
 @mcp.tool()
-def read_reduced_data(path: str, decimate: int = 500,
-                      include_full: bool = False) -> dict:
+def pyirena_read_reduced_data(path: str, decimate: int = 500,
+                              include_full: bool = False) -> dict:
     """Read the raw reduced I(Q) curve from a SAS file.
 
     Arrays are decimated to ~*decimate* points by default to keep the
@@ -93,7 +98,7 @@ def read_reduced_data(path: str, decimate: int = 500,
 
 
 @mcp.tool()
-def read_metadata(path: str) -> dict:
+def pyirena_read_metadata(path: str) -> dict:
     """Read sample / experiment metadata from a SAS file."""
     return papi.read_metadata(path)
 
@@ -103,8 +108,8 @@ def read_metadata(path: str) -> dict:
 # ---------------------------------------------------------------------------
 
 @mcp.tool()
-def read_simple_fit(path: str, include_arrays: bool = False,
-                    max_points: int = 500) -> dict:
+def pyirena_read_simple_fit(path: str, include_arrays: bool = False,
+                            max_points: int = 500) -> dict:
     """Read Simple Fits results (Guinier, Porod, etc.).
 
     Arrays (Q, I_model, residuals) are omitted by default. Set
@@ -115,32 +120,32 @@ def read_simple_fit(path: str, include_arrays: bool = False,
 
 
 @mcp.tool()
-def read_unified_fit(path: str, include_arrays: bool = False,
-                     max_points: int = 500) -> dict:
+def pyirena_read_unified_fit(path: str, include_arrays: bool = False,
+                             max_points: int = 500) -> dict:
     """Read Unified Fit (Beaucage) results — multi-level Rg/G/B/P + correlations."""
     return papi.read_unified_fit(path=path, include_arrays=include_arrays,
                                   max_points=max_points)
 
 
 @mcp.tool()
-def read_size_distribution(path: str, include_arrays: bool = False,
-                           max_points: int = 500) -> dict:
+def pyirena_read_size_distribution(path: str, include_arrays: bool = False,
+                                   max_points: int = 500) -> dict:
     """Read Size Distribution fit results — Vf, Rg, r_grid, distribution."""
     return papi.read_size_distribution(path=path, include_arrays=include_arrays,
                                         max_points=max_points)
 
 
 @mcp.tool()
-def read_modeling(path: str, include_arrays: bool = False,
-                  max_points: int = 500) -> dict:
+def pyirena_read_modeling(path: str, include_arrays: bool = False,
+                          max_points: int = 500) -> dict:
     """Read parametric Modeling results (size_dist / unified_level / diff_peak / fractal pops)."""
     return papi.read_modeling(path=path, include_arrays=include_arrays,
                                max_points=max_points)
 
 
 @mcp.tool()
-def read_saxs_morph(path: str, include_arrays: bool = False,
-                    max_points: int = 500) -> dict:
+def pyirena_read_saxs_morph(path: str, include_arrays: bool = False,
+                            max_points: int = 500) -> dict:
     """Read SAXS Morph results — voxelgram-based forward modeling output.
 
     Note: the 3-D voxelgram itself is intentionally not returned; only
@@ -151,27 +156,27 @@ def read_saxs_morph(path: str, include_arrays: bool = False,
 
 
 @mcp.tool()
-def read_waxs_peakfit(path: str, include_arrays: bool = False,
-                      max_points: int = 500) -> dict:
+def pyirena_read_waxs_peakfit(path: str, include_arrays: bool = False,
+                              max_points: int = 500) -> dict:
     """Read WAXS Peak Fit results — per-peak Q0, FWHM, A, eta, area."""
     return papi.read_waxs_peakfit(path=path, include_arrays=include_arrays,
                                    max_points=max_points)
 
 
 @mcp.tool()
-def read_fractals(path: str) -> dict:
+def pyirena_read_fractals(path: str) -> dict:
     """List fractal aggregates stored in a file (Z, df, dmin, c, Rg per aggregate)."""
     return papi.read_fractals(path)
 
 
 @mcp.tool()
-def read_merge_provenance(path: str) -> dict:
+def pyirena_read_merge_provenance(path: str) -> dict:
     """Read Data Merge provenance: scale, q_shift, background, source files."""
     return papi.read_merge_provenance(path)
 
 
 @mcp.tool()
-def read_manipulation_provenance(path: str) -> dict:
+def pyirena_read_manipulation_provenance(path: str) -> dict:
     """Read Data Manipulation provenance: operation, parameters, source file."""
     return papi.read_manipulation_provenance(path)
 
@@ -181,7 +186,7 @@ def read_manipulation_provenance(path: str) -> dict:
 # ---------------------------------------------------------------------------
 
 @mcp.tool()
-def tabulate_parameter(
+def pyirena_tabulate_parameter(
     folder: str,
     tool: str,
     parameter: str,
@@ -204,7 +209,7 @@ def tabulate_parameter(
 
 
 @mcp.tool()
-def summarize_sample(folder: str, sample: str) -> dict:
+def pyirena_summarize_sample(folder: str, sample: str) -> dict:
     """Condense everything known about one sample across a folder.
 
     File list, per-analysis file count, and min/max/n of every top-level
@@ -218,7 +223,7 @@ def summarize_sample(folder: str, sample: str) -> dict:
 # ---------------------------------------------------------------------------
 
 @mcp.tool()
-def plot_iq(
+def pyirena_plot_iq(
     paths: list[str],
     overlay: bool = True,
     log_x: bool = True,
@@ -240,7 +245,7 @@ def plot_iq(
 
 
 @mcp.tool()
-def plot_parameter_trend(
+def pyirena_plot_parameter_trend(
     folder: str,
     tool: str,
     parameter: str,
@@ -251,9 +256,9 @@ def plot_parameter_trend(
 ) -> Image:
     """Plot a parameter trend across many files; returns the PNG inline.
 
-    See tabulate_parameter() for the *tool* / *parameter* / *subgroup_index*
-    semantics. Useful for time-series questions like "how is Rg evolving
-    across the latest 30 scans?"
+    See pyirena_tabulate_parameter() for the *tool* / *parameter* /
+    *subgroup_index* semantics. Useful for time-series questions like
+    "how is Rg evolving across the latest 30 scans?"
     """
     result = papi.plot_parameter_trend(
         folder=folder, tool=tool, parameter=parameter, x_axis=x_axis,

--- a/pyirena/mcp/server.py
+++ b/pyirena/mcp/server.py
@@ -15,7 +15,8 @@ Environment overrides (see also pyirena.api):
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Optional
+from typing import Optional, Any
+
 
 try:
     from mcp.server.fastmcp import FastMCP, Image
@@ -225,6 +226,22 @@ def pyirena_summarize_sample(folder: str, sample: str) -> dict:
 # Plotting — returns inline images
 # ---------------------------------------------------------------------------
 
+def _plot_result_as_mcp_content(result: dict) -> list[Any]:
+    """Return plot output as mixed MCP content for clients such as AnythingLLM.
+
+    AnythingLLM's MCP image renderer looks for image-bearing items in the
+    MCP tool result content array. Returning a short text item followed by a
+    FastMCP Image keeps the saved file path visible while still allowing
+    FastMCP to serialize the PNG as:
+        {"type": "image", "data": "...base64...", "mimeType": "image/png"}
+    """
+    path = Path(result["path"])
+    return [
+        f"Plot saved to: {path}",
+        Image(data=path.read_bytes(), format="png"),
+    ]
+
+
 @mcp.tool()
 def pyirena_plot_iq(
     paths: list[str],
@@ -232,7 +249,7 @@ def pyirena_plot_iq(
     log_x: bool = True,
     log_y: bool = True,
     output_path: Optional[str] = None,
-) -> Image:
+) -> list[Any]:
     """Plot I(Q) for one or more files; returns the PNG inline.
 
     overlay=True puts all curves on one axes; False uses a grid.
@@ -244,7 +261,7 @@ def pyirena_plot_iq(
         paths=paths, overlay=overlay, log_x=log_x, log_y=log_y,
         output_path=output_path, return_base64=False,
     )
-    return Image(data=Path(result["path"]).read_bytes(), format="png")
+    return _plot_result_as_mcp_content(result)
 
 
 @mcp.tool()
@@ -256,7 +273,7 @@ def pyirena_plot_parameter_trend(
     subgroup_index: Optional[int] = None,
     sample_filter: Optional[str] = None,
     output_path: Optional[str] = None,
-) -> Image:
+) -> list[Any]:
     """Plot a parameter trend across many files; returns the PNG inline.
 
     See pyirena_tabulate_parameter() for the *tool* / *parameter* /
@@ -268,7 +285,7 @@ def pyirena_plot_parameter_trend(
         subgroup_index=subgroup_index, sample_filter=sample_filter,
         output_path=output_path, return_base64=False,
     )
-    return Image(data=Path(result["path"]).read_bytes(), format="png")
+    return _plot_result_as_mcp_content(result)
 
 
 # ---------------------------------------------------------------------------

--- a/pyirena/mcp/server.py
+++ b/pyirena/mcp/server.py
@@ -198,9 +198,12 @@ def pyirena_tabulate_parameter(
 
     *tool* is a pyirena tool key (e.g. 'unified_fit', 'modeling',
     'size_distribution'). *parameter* is a scalar key declared by that
-    tool's schema (e.g. 'Rg', 'background', 'volume_fraction'). For
-    per-subgroup parameters (Unified Fit levels, modeling populations,
-    WAXS peaks) supply subgroup_index (1-based, default 1).
+    tool's schema. Parameter names are case-insensitive. Common examples:
+      - size_distribution: 'rg', 'volume_fraction', 'chi_squared', 'q_power'
+      - unified_fit:       'Rg', 'G', 'B', 'P' (per-level; use subgroup_index)
+      - modeling:          'pop_Rg', 'background', 'chi_squared'
+      - waxs_peakfit:      'peak_Q0', 'peak_FWHM', 'peak_A' (per-peak)
+    For per-subgroup parameters supply subgroup_index (1-based, default 1).
     """
     return papi.tabulate_parameter(
         folder=folder, tool=tool, parameter=parameter, x_axis=x_axis,

--- a/pyirena/tests/api/test_mcp_smoke.py
+++ b/pyirena/tests/api/test_mcp_smoke.py
@@ -14,14 +14,16 @@ def test_mcp_module_imports_and_registers_tools():
     # FastMCP stores tools in a _tools dict or similar (depends on version);
     # safest is to introspect the public interface if it exists.
     expected = {
-        "list_files", "summarize_folder", "inspect_file",
-        "read_reduced_data", "read_metadata",
-        "read_simple_fit", "read_unified_fit", "read_size_distribution",
-        "read_modeling", "read_saxs_morph", "read_waxs_peakfit",
-        "read_fractals", "read_merge_provenance",
-        "read_manipulation_provenance",
-        "tabulate_parameter", "summarize_sample",
-        "plot_iq", "plot_parameter_trend",
+        "pyirena_list_files", "pyirena_summarize_folder", "pyirena_inspect_file",
+        "pyirena_read_reduced_data", "pyirena_read_metadata",
+        "pyirena_read_simple_fit", "pyirena_read_unified_fit",
+        "pyirena_read_size_distribution",
+        "pyirena_read_modeling", "pyirena_read_saxs_morph",
+        "pyirena_read_waxs_peakfit",
+        "pyirena_read_fractals", "pyirena_read_merge_provenance",
+        "pyirena_read_manipulation_provenance",
+        "pyirena_tabulate_parameter", "pyirena_summarize_sample",
+        "pyirena_plot_iq", "pyirena_plot_parameter_trend",
     }
     # Try the documented public method first
     if hasattr(mcp, "list_tools"):

--- a/pyirena/tests/test_pxp_to_nexus.py
+++ b/pyirena/tests/test_pxp_to_nexus.py
@@ -1,0 +1,252 @@
+"""
+Unit + integration tests for the pxp → NeXus importer.
+
+The IBW-v5 binary format is intricate (324-byte WaveHeader5 with nested
+pointers and platform-dependent padding) and igor2 ships no writer, so
+synthesising a fake .pxp in pure Python is fragile and adds no real
+coverage. Instead this suite focuses on:
+
+  * Parser unit tests for the wave-note → metadata mapping
+    (:func:`parse_wave_note`) — pure-Python, no .pxp file needed.
+  * Folder-name classification table behaviour.
+  * Integration tests that run against ``temp/test.pxp`` when it exists.
+    These are skipped when the file is absent so a clean clone still
+    passes CI.
+
+Maintainers: the developer fixture ``temp/test.pxp`` is a real legacy
+APS USAXS experiment kept out of git (16 MB binary). When you add new
+recognised wave-name patterns or note-section markers, exercise them
+locally with this fixture before merging.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import h5py
+import pytest
+
+
+pytest.importorskip("igor2", reason="igor2 is required for the importer to run")
+
+
+# ---------------------------------------------------------------------------
+# Pure-Python unit tests (no .pxp file required)
+# ---------------------------------------------------------------------------
+
+def test_parse_wave_note_full_round_trip():
+    """The note parser splits sentinel-bracketed sections correctly and
+    routes bare key=value pairs to ``notes.*`` without polluting
+    ``sample.*`` / ``instrument.*``.
+    """
+    from pyirena.io.pxp_to_nexus import parse_wave_note
+
+    note = (
+        "DATAFILE=foo.dat;DATE=2026-05-25;COMMENT=hello;"
+        "Nexus_attributesStartHere;"
+        "NXSampleStart;name=Bar;thickness=4;temperature=22.5;NXSampleEnd;"
+        "NXInstrumentStart;name=APS;wavelength=0.6;NXInstrumentEnd;"
+        "Nexus_attributesEndHere;"
+        "extra_key=extra_value;Wname=DSM_Int;Units=cm2/cm3;"
+    )
+    meta = parse_wave_note(note)
+
+    # Section content lands in sample.*/instrument.*
+    assert meta["sample.name"] == "Bar"
+    assert meta["sample.thickness"] == 4
+    assert meta["sample.temperature"] == pytest.approx(22.5)
+    assert meta["instrument.name"] == "APS"
+    assert meta["instrument.wavelength"] == pytest.approx(0.6)
+
+    # Well-known top-level keys mapped to canonical names
+    assert meta["title"] == "foo.dat"        # DATAFILE
+    assert meta["start_time"] == "2026-05-25"
+
+    # Unknown top-level keys go into notes.*
+    assert meta["notes.extra_key"] == "extra_value"
+
+    # Wave-level annotations are dropped
+    assert "notes.Wname" not in meta
+    assert "notes.Units" not in meta
+
+
+def test_parse_wave_note_handles_empty_and_plain():
+    from pyirena.io.pxp_to_nexus import parse_wave_note
+
+    # Empty / plain notes never crash.
+    assert parse_wave_note("") == {}
+    assert parse_wave_note("no equals here") == {}
+
+    # A note with only wave-level fields should yield an empty dict.
+    bare = "units=arb;long_name=Intensity;"
+    assert parse_wave_note(bare) == {}
+
+
+def test_parse_wave_note_section_without_end_marker():
+    """A start marker with no matching end marker should not crash —
+    section is ignored and the rest of the note is still parsed."""
+    from pyirena.io.pxp_to_nexus import parse_wave_note
+
+    note = "NXSampleStart;name=Lost;DATAFILE=ok.dat;"
+    meta = parse_wave_note(note)
+    # The malformed section is skipped, but DATAFILE is still picked up.
+    assert meta["title"] == "ok.dat"
+    assert "sample.name" not in meta
+
+
+def test_technique_folders_table_is_data_driven():
+    """The folder-name classification table is the single source of truth.
+    A user can add a new mapping here without touching extractor code."""
+    from pyirena.io.pxp_to_nexus import TECHNIQUE_FOLDERS, _classify_folder
+
+    assert _classify_folder("USAXS") == "USAXS"
+    assert _classify_folder("SAXS") == "SAXS"
+    assert _classify_folder("WAXS") == "WAXS"
+    assert _classify_folder("Imported SAXS") == "SAXS"
+    assert _classify_folder("unknown_folder") is None
+
+    # Case-insensitive fallback
+    assert _classify_folder("usaxs") == "USAXS"
+    assert _classify_folder("Saxs") == "SAXS"
+
+
+def test_wave_pickers_table_lists_dsm_for_usaxs():
+    """USAXS picker is DSM_* (per design choice)."""
+    from pyirena.io.pxp_to_nexus import WAVE_PICKERS
+
+    usaxs = WAVE_PICKERS["USAXS"]
+    assert any(t[:3] == ("DSM_Qvec", "DSM_Int", "DSM_Error") for t in usaxs)
+
+    saxs = WAVE_PICKERS["SAXS"]
+    assert any(t[:3] == ("R_Qvec", "R_Int", "R_Error") for t in saxs)
+
+
+def test_safe_filename_strips_illegal_chars():
+    from pyirena.io.pxp_to_nexus import _safe_filename
+
+    assert _safe_filename("normal_name") == "normal_name"
+    assert "/" not in _safe_filename("a/b/c")
+    assert ":" not in _safe_filename("a:b")
+    assert _safe_filename("") == "unnamed"
+    assert _safe_filename("   ...") == "unnamed"
+
+
+def test_unique_path_appends_suffix(tmp_path):
+    from pyirena.io.pxp_to_nexus import _unique_path
+
+    base = tmp_path / "thing.h5"
+    base.write_text("x")
+    next_path = _unique_path(base)
+    assert next_path.name == "thing_2.h5"
+
+
+# ---------------------------------------------------------------------------
+# Integration tests against a real legacy .pxp
+# ---------------------------------------------------------------------------
+
+_REAL_PXP = Path(__file__).resolve().parents[2] / "temp" / "test.pxp"
+
+
+@pytest.mark.skipif(not _REAL_PXP.is_file(),
+                    reason="temp/test.pxp not present (developer-only fixture)")
+def test_real_legacy_pxp_writes_expected_count(tmp_path):
+    """The bundled APS USAXS experiment should yield ~50+ NeXus files across
+    USAXS, SAXS, and WAXS without any extraction errors."""
+    from pyirena.io.pxp_to_nexus import extract_pxp_to_nexus
+
+    result = extract_pxp_to_nexus(_REAL_PXP, output_root=tmp_path / "out")
+
+    assert result.n_errors == 0
+    assert result.n_written >= 50
+
+    # All three techniques produced something.
+    techs = {f.technique for f in result.files if f.status == "ok"}
+    assert techs == {"USAXS", "SAXS", "WAXS"}
+
+
+@pytest.mark.skipif(not _REAL_PXP.is_file(),
+                    reason="temp/test.pxp not present (developer-only fixture)")
+def test_real_legacy_pxp_usaxs_has_qdev_and_metadata(tmp_path):
+    """A USAXS file written from the bundled experiment must carry the dQ
+    resolution column AND the rich NeXus sample/instrument metadata that
+    the APS USAXS pipeline embeds in wave notes."""
+    from pyirena.io.pxp_to_nexus import extract_pxp_to_nexus
+
+    result = extract_pxp_to_nexus(_REAL_PXP, output_root=tmp_path / "out",
+                                  techniques=["USAXS"])
+    assert result.n_written > 0
+
+    # Verify the structural invariants on every USAXS file: Q + I + Idev
+    # must be present, and Qdev must be present on at least some files
+    # (DSM_dQ is optional per wave; APS USAXS does emit it). At least one
+    # file must carry the NeXus-style sample/instrument metadata.
+    n_with_qdev = 0
+    n_with_sample_name = 0
+    n_with_wavelength = 0
+    for fr in result.files:
+        if fr.status != "ok" or fr.output_path is None:
+            continue
+        with h5py.File(fr.output_path, "r") as f:
+            sas_paths = [p for p in _walk_paths(f)
+                         if p.endswith("/sasdata") and isinstance(f[p], h5py.Group)]
+            assert sas_paths, f"no sasdata group in {fr.output_path}"
+            sas = f[sas_paths[0]]
+            assert "Q" in sas and "I" in sas and "Idev" in sas
+            if "Qdev" in sas:
+                n_with_qdev += 1
+            if "entry/sample/name" in f:
+                n_with_sample_name += 1
+            if "entry/instrument/beam/incident_wavelength" in f:
+                n_with_wavelength += 1
+
+    assert n_with_qdev > 0, "no USAXS files had a Qdev column"
+    assert n_with_sample_name > 0, "no USAXS files had sample.name metadata"
+    assert n_with_wavelength > 0, "no USAXS files had wavelength metadata"
+
+
+@pytest.mark.skipif(not _REAL_PXP.is_file(),
+                    reason="temp/test.pxp not present (developer-only fixture)")
+def test_real_legacy_pxp_round_trips_through_pyirena_reader(tmp_path):
+    """Every NeXus file the importer writes must be discoverable by
+    pyirena's own NXcanSAS group locator. If this breaks, the imported
+    files won't appear in the Data Selector even though they're valid
+    HDF5."""
+    from pyirena.io.pxp_to_nexus import extract_pxp_to_nexus
+    from pyirena.io.hdf5 import find_matching_groups
+
+    result = extract_pxp_to_nexus(_REAL_PXP, output_root=tmp_path / "out")
+    n_checked = 0
+    for fr in result.files:
+        if fr.status != "ok" or fr.output_path is None:
+            continue
+        with h5py.File(fr.output_path, "r") as f:
+            paths = find_matching_groups(f, {"canSAS_class": "SASdata"}, {})
+            assert paths, f"no SASdata group in {fr.output_path}"
+            sas = f[paths[0]]
+            assert sas["I"].shape == (fr.n_points,)
+        n_checked += 1
+    assert n_checked >= 1
+
+
+@pytest.mark.skipif(not _REAL_PXP.is_file(),
+                    reason="temp/test.pxp not present (developer-only fixture)")
+def test_real_legacy_pxp_technique_filter(tmp_path):
+    """`techniques=['SAXS']` must skip USAXS and WAXS entirely."""
+    from pyirena.io.pxp_to_nexus import extract_pxp_to_nexus
+
+    result = extract_pxp_to_nexus(_REAL_PXP, output_root=tmp_path / "out",
+                                  techniques=["SAXS"])
+    techs = {f.technique for f in result.files if f.status == "ok"}
+    assert techs == {"SAXS"}
+    assert not (tmp_path / "out" / "USAXS").exists()
+    assert not (tmp_path / "out" / "WAXS").exists()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _walk_paths(h5root):
+    out: list[str] = []
+    h5root.visit(out.append)
+    return out

--- a/pyirena/tests/test_pxp_to_nexus.py
+++ b/pyirena/tests/test_pxp_to_nexus.py
@@ -243,6 +243,186 @@ def test_real_legacy_pxp_technique_filter(tmp_path):
 
 
 # ---------------------------------------------------------------------------
+# h5xp tests — use pyirena's own writer to synthesise fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def synthetic_h5xp(tmp_path: Path) -> Path:
+    """Create a small .h5xp containing one USAXS, one SAXS, one WAXS sample.
+
+    Uses :func:`pyirena.io.h5xp_writer.create_h5xp` + ``write_iq_data``,
+    which is the same code path Igor users hit via the Data Explorer's
+    "Export to Igor" — guarantees the fixture matches what the importer
+    will encounter in the wild.
+    """
+    import numpy as np
+    from pyirena.io.h5xp_writer import create_h5xp, write_iq_data
+
+    pxp_path = tmp_path / "synthetic.h5xp"
+    n = 32
+    q = np.logspace(-3, 0, n)
+    intensity = 1.0 / (1.0 + (q * 30) ** 2)
+    err = 0.1 * intensity
+    dq = 0.05 * q
+
+    with create_h5xp(pxp_path) as f:
+        write_iq_data(f, "Sample_U", q, intensity, error=err, dq=dq,
+                      wave_note={"SampleName": "Sample_U", "Title": "USAXS sample",
+                                 "Wavelength_A": 0.5904},
+                      category="USAXS")
+        write_iq_data(f, "Sample_S", q, intensity, error=err,
+                      wave_note={"SampleName": "Sample_S"},
+                      category="SAXS")
+        write_iq_data(f, "Sample_W", q, intensity, error=err,
+                      wave_note={"SampleName": "Sample_W"},
+                      category="WAXS")
+    return pxp_path
+
+
+def test_h5xp_extract_writes_one_file_per_sample(synthetic_h5xp, tmp_path):
+    from pyirena.io.pxp_to_nexus import extract_h5xp_to_nexus
+
+    out_dir = tmp_path / "out"
+    result = extract_h5xp_to_nexus(synthetic_h5xp, output_root=out_dir)
+
+    assert result.n_written == 3
+    assert result.n_errors == 0
+    assert result.n_unparseable_records == 0
+    written = {f.output_path for f in result.files if f.status == "ok"}
+    assert (out_dir / "USAXS" / "Sample_U.h5") in written
+    assert (out_dir / "SAXS"  / "Sample_S.h5") in written
+    assert (out_dir / "WAXS"  / "Sample_W.h5") in written
+
+
+def test_h5xp_extracted_file_has_q_i_idev_qdev(synthetic_h5xp, tmp_path):
+    """USAXS sample written with `dq=` should produce a Qdev column."""
+    from pyirena.io.pxp_to_nexus import extract_h5xp_to_nexus
+
+    out_dir = tmp_path / "out"
+    extract_h5xp_to_nexus(synthetic_h5xp, output_root=out_dir)
+
+    with h5py.File(out_dir / "USAXS" / "Sample_U.h5", "r") as f:
+        sas = f["entry/Sample_U/sasdata"]
+        assert "Q" in sas and "I" in sas and "Idev" in sas
+        assert "Qdev" in sas
+
+    # SAXS sample had no dq → no Qdev
+    with h5py.File(out_dir / "SAXS" / "Sample_S.h5", "r") as f:
+        sas = f["entry/Sample_S/sasdata"]
+        assert "Qdev" not in sas
+
+
+def test_h5xp_wave_note_parsed_into_metadata(synthetic_h5xp, tmp_path):
+    """SampleName from the h5xp wave note must reach entry/notes/SampleName
+    (h5xp writer uses the literal ``SampleName`` key, not the prefixed
+    ``sample.name`` form)."""
+    from pyirena.io.pxp_to_nexus import extract_h5xp_to_nexus
+
+    out_dir = tmp_path / "out"
+    extract_h5xp_to_nexus(synthetic_h5xp, output_root=out_dir)
+
+    with h5py.File(out_dir / "USAXS" / "Sample_U.h5", "r") as f:
+        # h5xp writer puts SampleName as a top-level note key (not in a
+        # section block), so it lands under entry/notes/SampleName.
+        assert "entry/notes" in f
+        # The wavelength key from the wave-note dict
+        notes = f["entry/notes"]
+        note_keys = list(notes.keys())
+        # SampleName should be present somewhere in notes
+        assert any("SampleName" in k for k in note_keys)
+
+
+def test_h5xp_round_trips_through_pyirena_reader(synthetic_h5xp, tmp_path):
+    """Every NeXus file the importer writes must be discoverable by
+    pyirena's own NXcanSAS locator."""
+    from pyirena.io.pxp_to_nexus import extract_h5xp_to_nexus
+    from pyirena.io.hdf5 import find_matching_groups
+
+    out_dir = tmp_path / "out"
+    result = extract_h5xp_to_nexus(synthetic_h5xp, output_root=out_dir)
+    n_checked = 0
+    for fr in result.files:
+        if fr.status != "ok" or fr.output_path is None:
+            continue
+        with h5py.File(fr.output_path, "r") as f:
+            paths = find_matching_groups(f, {"canSAS_class": "SASdata"}, {})
+            assert paths, f"no SASdata group in {fr.output_path}"
+            sas = f[paths[0]]
+            assert sas["I"].shape == (32,)
+        n_checked += 1
+    assert n_checked == 3
+
+
+def test_h5xp_technique_filter(synthetic_h5xp, tmp_path):
+    from pyirena.io.pxp_to_nexus import extract_h5xp_to_nexus
+
+    out_dir = tmp_path / "out"
+    result = extract_h5xp_to_nexus(synthetic_h5xp, output_root=out_dir,
+                                   techniques=["USAXS"])
+    assert result.n_written == 1
+    assert (out_dir / "USAXS").exists()
+    assert not (out_dir / "SAXS").exists()
+    assert not (out_dir / "WAXS").exists()
+
+
+def test_h5xp_overwrite_false_appends_suffix(synthetic_h5xp, tmp_path):
+    from pyirena.io.pxp_to_nexus import extract_h5xp_to_nexus
+
+    out_dir = tmp_path / "out"
+    extract_h5xp_to_nexus(synthetic_h5xp, output_root=out_dir)
+    extract_h5xp_to_nexus(synthetic_h5xp, output_root=out_dir, overwrite=False)
+
+    usaxs_files = sorted((out_dir / "USAXS").glob("*.h5"))
+    assert len(usaxs_files) == 2
+    assert usaxs_files[1].name == "Sample_U_2.h5"
+
+
+def test_extract_igor_experiment_dispatches_on_extension(synthetic_h5xp, tmp_path):
+    """The dispatcher must route .h5xp to the h5xp reader without the
+    caller specifying which one to use."""
+    from pyirena.io.pxp_to_nexus import extract_igor_experiment
+
+    out_dir = tmp_path / "out"
+    result = extract_igor_experiment(synthetic_h5xp, output_root=out_dir)
+    assert result.n_written == 3
+    assert (out_dir / "USAXS" / "Sample_U.h5").is_file()
+
+
+def test_extract_igor_experiment_rejects_unknown_extension(tmp_path):
+    """A random .csv or .txt file must raise ValueError, not silently
+    do nothing."""
+    from pyirena.io.pxp_to_nexus import extract_igor_experiment
+
+    junk = tmp_path / "not_an_igor_file.csv"
+    junk.write_text("not igor\n")
+    with pytest.raises(ValueError, match="unsupported Igor experiment format"):
+        extract_igor_experiment(junk)
+
+
+def test_parse_wave_note_handles_h5xp_colon_format():
+    """h5xp notes use ``key:value;`` instead of pxp's ``key=value;``.
+    The parser must detect the separator and produce the same output."""
+    from pyirena.io.pxp_to_nexus import parse_wave_note
+
+    h5xp_note = (
+        "DATAFILE:foo.dat;DATE:2026-05-25;"
+        "NXSampleStart;name:Bar;thickness:4;NXSampleEnd;"
+        "NXInstrumentStart;wavelength:0.6;NXInstrumentEnd;"
+        "IgorFolder:my_folder;Wname:DSM_Int;Units:cm2/cm3;"
+    )
+    meta = parse_wave_note(h5xp_note)
+    assert meta["sample.name"] == "Bar"
+    assert meta["sample.thickness"] == 4
+    assert meta["instrument.wavelength"] == pytest.approx(0.6)
+    assert meta["title"] == "foo.dat"
+    assert meta["start_time"] == "2026-05-25"
+    # IgorFolder / Wname / Units are wave-level, should not appear
+    assert "notes.IgorFolder" not in meta
+    assert "notes.Wname" not in meta
+    assert "notes.Units" not in meta
+
+
+# ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
 

--- a/pyirena/tests/test_pxp_to_nexus.py
+++ b/pyirena/tests/test_pxp_to_nexus.py
@@ -142,6 +142,55 @@ def test_wave_pickers_table_lists_dsm_for_usaxs():
     assert any(t[:3] == ("R_Qvec", "R_Int", "R_Error") for t in saxs)
 
 
+def test_walk_tree_yields_root_level_wave_folders_as_multi_technique():
+    """Folders that sit at root level (no USAXS/SAXS/WAXS parent) and
+    contain at least one wave should be yielded with all three
+    techniques as candidates. This is the 'per-sample' layout used by
+    in-situ time-series experiments where one folder per timepoint
+    holds USAXS, SAXS, and WAXS waves side by side.
+    """
+    from pyirena.io.pxp_to_nexus import _walk_tree
+
+    # Simulate a filesystem dict: one sample-by-sample folder at root,
+    # one technique-organised structure alongside it.
+    fake_wave = object()  # any non-dict value counts as a "wave"
+    fs = {
+        "AMC_3min_0033": {
+            "DSM_Int": fake_wave,
+            "R_Int": fake_wave,
+        },
+        "USAXS": {
+            "Sample01": {
+                "DSM_Int": fake_wave,
+            },
+        },
+        "Packages": {"junk": {}},   # should be skipped as infrastructure
+    }
+    yielded = list(_walk_tree(fs, None, ()))
+    paths = {rp: techs for rp, techs, _ in yielded}
+
+    assert ("AMC_3min_0033",) in paths
+    assert paths[("AMC_3min_0033",)] == ["USAXS", "SAXS", "WAXS"]
+    assert ("USAXS", "Sample01") in paths
+    assert paths[("USAXS", "Sample01")] == ["USAXS"]
+    # Packages/* must not appear at all
+    assert not any("Packages" in rp for rp in paths)
+
+
+def test_infrastructure_folders_skipped():
+    """Igor's own Packages/, SavedSampleSets/ etc. must be ignored at
+    root level so they don't pollute the summary with skip rows."""
+    from pyirena.io.pxp_to_nexus import _walk_tree, INFRASTRUCTURE_FOLDERS
+
+    assert "Packages" in INFRASTRUCTURE_FOLDERS
+    assert "SavedSampleSets" in INFRASTRUCTURE_FOLDERS
+
+    fake_wave = object()
+    fs = {"Packages": {"AMC_sample": {"R_Int": fake_wave}}}
+    yielded = list(_walk_tree(fs, None, ()))
+    assert yielded == []
+
+
 def test_safe_filename_strips_illegal_chars():
     from pyirena.io.pxp_to_nexus import _safe_filename
 

--- a/pyirena/tests/test_pxp_to_nexus.py
+++ b/pyirena/tests/test_pxp_to_nexus.py
@@ -110,6 +110,27 @@ def test_technique_folders_table_is_data_driven():
     assert _classify_folder("Saxs") == "SAXS"
 
 
+def test_patch_v7_wave_to_v5_rewrites_version_byte():
+    """The v7→v5 patcher must swap the leading version short from 7 to 5
+    in-place, leaving the rest of the payload untouched. v7 waves are
+    binary-identical to v5 in their numeric data section."""
+    import struct
+    from pyirena.io.pxp_to_nexus import _patch_v7_wave_to_v5
+
+    v7_payload = struct.pack("<h", 7) + b"\xff" * 100
+    patched = _patch_v7_wave_to_v5(v7_payload, byte_order="<")
+    assert struct.unpack("<h", patched[:2])[0] == 5
+    assert patched[2:] == v7_payload[2:]
+
+    # v5 input should pass through unchanged (same bytes returned).
+    v5_payload = struct.pack("<h", 5) + b"\xaa" * 50
+    assert _patch_v7_wave_to_v5(v5_payload, byte_order="<") is v5_payload
+
+    # Empty / truncated input should not crash.
+    assert _patch_v7_wave_to_v5(b"", byte_order="<") == b""
+    assert _patch_v7_wave_to_v5(b"\x05", byte_order="<") == b"\x05"
+
+
 def test_wave_pickers_table_lists_dsm_for_usaxs():
     """USAXS picker is DSM_* (per design choice)."""
     from pyirena.io.pxp_to_nexus import WAVE_PICKERS

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pyirena"
-version = "0.8.0"
+version = "0.8.1"
 description = "Python tools for small-angle scattering data analysis."
 readme = {file = "README.md", content-type = "text/markdown"}
 requires-python = ">=3.9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pyirena"
-version = "0.7.2"
+version = "0.8.0"
 description = "Python tools for small-angle scattering data analysis."
 readme = {file = "README.md", content-type = "text/markdown"}
 requires-python = ">=3.9"
@@ -38,6 +38,7 @@ dependencies = [
     "numpy>=1.22.0",
     "scipy>=1.8.0",
     "h5py>=3.0.0",
+    "igor2>=0.5.13",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pyirena"
-version = "0.8.1"
+version = "0.8.2"
 description = "Python tools for small-angle scattering data analysis."
 readme = {file = "README.md", content-type = "text/markdown"}
 requires-python = ">=3.9"

--- a/scripts/diag_folder_bytes.py
+++ b/scripts/diag_folder_bytes.py
@@ -1,0 +1,111 @@
+"""Scan a .pxp for FolderStart records and dump raw bytes for any whose
+payload contains a given substring. Used to confirm whether 'missing'
+long-named folders are even present in the file and what their on-disk
+encoding looks like.
+
+Usage:
+    python scripts/diag_folder_bytes.py /path/to/Big.pxp "crystalline"
+"""
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from igor2.packed import (
+    setup_packed_file_record_header,
+    PACKEDRECTYPE_MASK,
+)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("pxp", help="Path to the .pxp file")
+    ap.add_argument("needle", help="Substring to search for in folder-record payloads")
+    ap.add_argument("--show-context", type=int, default=2,
+                    help="How many records before/after to show (default 2)")
+    args = ap.parse_args()
+
+    pxp = Path(args.pxp)
+    print(f"Loading {pxp} ({pxp.stat().st_size:,} bytes)\n")
+
+    with open(pxp, "rb") as f:
+        peek = f.read(2)
+    initial = "<" if peek[0] != 0 else ">"
+    hs = setup_packed_file_record_header(byte_order=initial)
+    print(f"byte order: {initial}, header size: {hs.size}")
+
+    needle = args.needle.encode("latin-1")
+    needle_low = args.needle.lower().encode("latin-1")
+
+    # First pass: collect all records as (index, offset, recordType, version, num_bytes, data)
+    records: list[tuple[int, int, int, int, int, bytes]] = []
+    with open(pxp, "rb") as f:
+        idx = 0
+        while True:
+            pos = f.tell()
+            b = f.read(hs.size)
+            if len(b) < hs.size:
+                break
+            h = hs.unpack_from(b)
+            n = h["numDataBytes"]
+            if n < 0 or n > 256 * 1024 * 1024:
+                break
+            data = f.read(n)
+            if len(data) < n:
+                break
+            records.append((idx, pos, h["recordType"] & PACKEDRECTYPE_MASK,
+                             h.get("version", 0), n, data))
+            idx += 1
+
+    print(f"Read {len(records)} records total\n")
+
+    # Second pass: find matches and show context
+    matches = []
+    for i, (idx, pos, rtype, ver, n, data) in enumerate(records):
+        if needle in data or needle_low in data.lower():
+            matches.append(i)
+
+    if not matches:
+        print(f"No record payload contains {args.needle!r}")
+        # As a sanity check, also search for the FIRST 8 chars only — long
+        # names might be wrapped or stored with prefixes.
+        short_needle = args.needle.encode("latin-1")[:8]
+        for i, (idx, pos, rtype, ver, n, data) in enumerate(records):
+            if short_needle in data:
+                print(f"  (but record {idx} contains the 8-char prefix {short_needle!r})")
+                matches.append(i)
+                break
+        if not matches:
+            return 0
+
+    print(f"Found {len(matches)} matching record(s); showing first 5:\n")
+    for hit in matches[:5]:
+        lo = max(0, hit - args.show_context)
+        hi = min(len(records), hit + args.show_context + 1)
+        print(f"=== match at record index {hit} ===")
+        for j in range(lo, hi):
+            idx, pos, rtype, ver, n, data = records[j]
+            tag = ">>>" if j == hit else "   "
+            rtname = _rtype_name(rtype)
+            preview_bytes = data[:80]
+            preview_repr = preview_bytes.decode("latin-1", errors="replace")
+            print(f"{tag} #{idx:5d} @0x{pos:08x} type={rtype:2d}({rtname:18s}) "
+                  f"ver={ver:3d} n={n:6d}  data[:80]={preview_repr!r}")
+            if j == hit and rtype != 9:
+                # If the match isn't a folder, also show raw hex of first 64 bytes
+                print(f"            raw hex: {data[:64].hex(' ')}")
+        print()
+    return 0
+
+
+def _rtype_name(rt: int) -> str:
+    return {
+        0: "Unused", 1: "Variables", 2: "History", 3: "Wave",
+        4: "Recreation", 5: "Procedure", 6: "Unused",
+        7: "GetHistory", 8: "PackedFile",
+        9: "FolderStart", 10: "FolderEnd",
+    }.get(rt, f"Unknown{rt}")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/diag_folders.py
+++ b/scripts/diag_folders.py
@@ -1,0 +1,77 @@
+"""Diagnose which USAXS/SAXS/WAXS sample folders the pxp importer sees,
+and which of those have the expected DSM_*/R_* wave triple.
+
+Usage:
+    python scripts/diag_folders.py /path/to/Big.pxp [--technique USAXS]
+"""
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from pyirena.io.pxp_to_nexus import (
+    _load_pxp_filesystem, _walk_tree, _pick_waves,
+    WAVE_PICKERS, TECHNIQUE_FOLDERS,
+)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("pxp", help="Path to the .pxp file")
+    ap.add_argument("--technique", choices=["USAXS", "SAXS", "WAXS"], default=None,
+                    help="Only show folders for this technique (default: all)")
+    ap.add_argument("--show-waves", action="store_true",
+                    help="For each folder, list every wave name it contains")
+    args = ap.parse_args()
+
+    pxp = Path(args.pxp)
+    print(f"Loading {pxp} ({pxp.stat().st_size:,} bytes)\n")
+
+    filesystem, n_skipped = _load_pxp_filesystem(pxp)
+    print(f"Loaded; {n_skipped} record(s) unparseable\n")
+
+    n_with_waves = 0
+    n_missing_triple = 0
+    n_total = 0
+
+    for rel_path, technique, folder in _walk_tree(filesystem["root"], None, ()):
+        if args.technique and technique != args.technique:
+            continue
+        n_total += 1
+        igor_path = "root:" + ":".join(rel_path)
+
+        picked = _pick_waves(folder, technique)
+        wave_names = sorted(k for k, v in folder.items() if not isinstance(v, dict))
+
+        if picked is not None:
+            n_with_waves += 1
+            status = "OK "
+            extra = f"{len(picked[0])} pts"
+        else:
+            n_missing_triple += 1
+            # Inspect the picker requirements to show what's missing
+            req = WAVE_PICKERS.get(technique, [])
+            missing = []
+            for q, i, e, dq in req:
+                have = [w for w in (q, i, e) if w in folder]
+                if len(have) == 3:
+                    # All 3 present in folder dict, but _pick_waves still
+                    # returned None — must be a sub-folder collision
+                    extra = f"all 3 present but _pick_waves failed (sub-folder collision?)"
+                    break
+                missing.append(f"{q}/{i}/{e}")
+            else:
+                extra = f"missing wave triple: tried {missing}"
+            status = "-- "
+
+        print(f"  {status} {technique:6s} {igor_path:70s} {extra}")
+        if args.show_waves:
+            print(f"             waves ({len(wave_names)}): {wave_names}")
+
+    print(f"\nTotals: {n_with_waves} importable, {n_missing_triple} missing triple, "
+          f"{n_total} total sample folders (in selected techniques)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/diag_pxp.py
+++ b/scripts/diag_pxp.py
@@ -1,0 +1,168 @@
+"""Diagnose how many records in an Igor .pxp file pyirena can decode.
+
+Mirrors the same retry logic that ``pyirena.io.pxp_to_nexus`` uses, so the
+SKIPPED count printed here matches what the importer will report.
+
+Usage::
+
+    python scripts/diag_pxp.py /path/to/Big.pxp
+    python scripts/diag_pxp.py /path/to/Big.pxp --show-folders
+"""
+from __future__ import annotations
+
+import argparse
+from collections import Counter
+from pathlib import Path
+
+from igor2.packed import (
+    setup_packed_file_record_header, _RECORD_TYPE,
+    _UnknownRecord, PACKEDRECTYPE_MASK,
+    _byte_order, _need_to_reorder_bytes,
+)
+from igor2.record.wave import WaveRecord
+from igor2.record.folder import FolderStartRecord, FolderEndRecord
+
+from pyirena.io.pxp_to_nexus import _patch_v7_wave_to_v5
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("pxp", help="Path to the .pxp file")
+    ap.add_argument("--show-folders", action="store_true",
+                    help="Print the top-level folder structure as discovered")
+    args = ap.parse_args()
+
+    pxp = Path(args.pxp)
+    print(f"Loading {pxp} ({pxp.stat().st_size:,} bytes)\n")
+
+    # Match the loader's byte-order detection (peek first 2 bytes).
+    with open(pxp, "rb") as f:
+        peek = f.read(2)
+    initial_byte_order = "<" if peek[0] != 0 else ">"
+    print(f"Detected byte order: {initial_byte_order}")
+    header_struct = setup_packed_file_record_header(byte_order=initial_byte_order)
+    byte_order = initial_byte_order
+    print(f"Header size: {header_struct.size}")
+
+    n_ok = 0
+    n_skipped = 0
+    n_recovered_v7 = 0
+    by_type_ok: Counter[str] = Counter()
+    by_type_skipped: Counter[str] = Counter()
+    size_buckets_skipped: Counter[str] = Counter()
+    errors_by_type: dict[str, list[str]] = {}
+    total_size_skipped = 0
+    total_size_ok = 0
+    folder_stack: list[str] = []
+    top_folders: Counter[str] = Counter()
+
+    with open(pxp, "rb") as f:
+        while True:
+            pos = f.tell()
+            b = f.read(header_struct.size)
+            if len(b) < header_struct.size:
+                break
+            header = header_struct.unpack_from(b)
+            if header["version"]:
+                need = _need_to_reorder_bytes(header["version"])
+                refined = _byte_order(need)
+                if refined != byte_order:
+                    byte_order = refined
+                    header_struct = setup_packed_file_record_header(byte_order=byte_order)
+                    header = header_struct.unpack_from(b)
+            num_bytes = header["numDataBytes"]
+            if num_bytes < 0 or num_bytes > 256 * 1024 * 1024:
+                print(f"  bad size {num_bytes} at offset 0x{pos:x}; stopping")
+                break
+            data = bytes(f.read(num_bytes))
+            if len(data) < num_bytes:
+                print(f"  truncated at offset 0x{pos:x}; stopping")
+                break
+
+            rtype_id = header["recordType"] & PACKEDRECTYPE_MASK
+            rtype = _RECORD_TYPE.get(rtype_id, _UnknownRecord)
+            tname = rtype.__name__
+
+            # Track folder context so failures can be attributed to a tree path
+            if rtype is FolderStartRecord:
+                try:
+                    rec = rtype(header, data, byte_order=byte_order)
+                    name = rec.null_terminated_text
+                    if isinstance(name, bytes):
+                        name = name.decode("utf-8", errors="replace")
+                    folder_stack.append(name)
+                    if len(folder_stack) == 1:
+                        top_folders[name] += 1
+                except Exception:
+                    folder_stack.append("?")
+            elif rtype is FolderEndRecord:
+                if folder_stack:
+                    folder_stack.pop()
+
+            try:
+                rec = rtype(header, data, byte_order=byte_order)
+                n_ok += 1
+                by_type_ok[tname] += 1
+                total_size_ok += num_bytes
+                continue
+            except Exception as exc:
+                # Match the loader's v7 retry path.
+                if rtype is WaveRecord:
+                    patched = _patch_v7_wave_to_v5(data, byte_order)
+                    if patched is not data:
+                        try:
+                            WaveRecord(header, patched, byte_order=byte_order)
+                            n_ok += 1
+                            n_recovered_v7 += 1
+                            by_type_ok[tname] += 1
+                            total_size_ok += num_bytes
+                            continue
+                        except Exception as exc2:
+                            exc = exc2
+
+                n_skipped += 1
+                by_type_skipped[tname] += 1
+                total_size_skipped += num_bytes
+                if num_bytes < 1024:
+                    bucket = "<1 KB"
+                elif num_bytes < 64 * 1024:
+                    bucket = "1-64 KB"
+                elif num_bytes < 1024 * 1024:
+                    bucket = "64 KB - 1 MB"
+                else:
+                    bucket = ">1 MB"
+                size_buckets_skipped[bucket] += 1
+                key = f"{tname}:{type(exc).__name__}"
+                msgs = errors_by_type.setdefault(key, [])
+                short = f"{exc}".splitlines()[0][:120]
+                if short not in msgs and len(msgs) < 3:
+                    msgs.append(short)
+
+    print(f"\nRecords OK:        {n_ok:6d}  ({total_size_ok/1e6:.1f} MB)")
+    if n_recovered_v7:
+        print(f"  of which v7→v5 recovered: {n_recovered_v7}")
+    print(f"Records skipped:   {n_skipped:6d}  ({total_size_skipped/1e6:.1f} MB)")
+
+    print("\nBy record type (OK):")
+    for t, n in by_type_ok.most_common():
+        print(f"  {n:6d}  {t}")
+    print("\nBy record type (SKIPPED):")
+    for t, n in by_type_skipped.most_common():
+        print(f"  {n:6d}  {t}")
+    print("\nSkipped record size distribution:")
+    for b, n in size_buckets_skipped.most_common():
+        print(f"  {n:6d}  {b}")
+    print("\nSample error messages (first 3 distinct per type):")
+    for key, msgs in errors_by_type.items():
+        print(f"  [{key}]")
+        for m in msgs:
+            print(f"      {m}")
+    if args.show_folders:
+        print("\nTop-level folders seen:")
+        for name, n in top_folders.most_common():
+            print(f"  {n:4d}  {name}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/diag_tree.py
+++ b/scripts/diag_tree.py
@@ -1,0 +1,81 @@
+"""Print the full folder tree of a .pxp file, with optional filter.
+
+Usage:
+    python scripts/diag_tree.py /path/to/Big.pxp
+    python scripts/diag_tree.py /path/to/Big.pxp --filter AMC
+    python scripts/diag_tree.py /path/to/Big.pxp --max-depth 4
+"""
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from pyirena.io.pxp_to_nexus import _load_pxp_filesystem
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("pxp", help="Path to the .pxp file")
+    ap.add_argument("--filter", default=None,
+                    help="Only print folder paths whose name contains this substring "
+                         "(case-insensitive). Also prints their parents for context.")
+    ap.add_argument("--max-depth", type=int, default=4,
+                    help="Maximum tree depth to print (default: 4)")
+    args = ap.parse_args()
+
+    pxp = Path(args.pxp)
+    print(f"Loading {pxp} ({pxp.stat().st_size:,} bytes)\n")
+    filesystem, n_skipped = _load_pxp_filesystem(pxp)
+    print(f"Loaded; {n_skipped} record(s) unparseable\n")
+
+    filt = args.filter.lower() if args.filter else None
+
+    def walk(d: dict, path: list[str], depth: int) -> bool:
+        """Return True if this subtree contained anything to print."""
+        printed = False
+        for k in sorted(d.keys()):
+            v = d[k]
+            if not isinstance(v, dict):
+                continue
+            new_path = path + [k]
+            full = "root:" + ":".join(new_path)
+            n_waves = sum(1 for x in v.values() if not isinstance(x, dict))
+            n_subs = sum(1 for x in v.values() if isinstance(x, dict))
+
+            this_matches = filt is None or filt in k.lower()
+            child_matched = False
+            if depth + 1 < args.max_depth:
+                # Recurse to know if children matched (so we print parents
+                # of matches even if the parent name itself doesn't match).
+                child_matched = _walk_check(v, filt, args.max_depth, depth + 1)
+
+            if this_matches or child_matched:
+                indent = "  " * depth
+                print(f"{indent}{k}/  ({n_subs} subfolders, {n_waves} waves)  [{full}]")
+                printed = True
+                if depth + 1 < args.max_depth:
+                    walk(v, new_path, depth + 1)
+        return printed
+
+    walk(filesystem["root"], [], 0)
+    return 0
+
+
+def _walk_check(d: dict, filt: str | None, max_depth: int, depth: int) -> bool:
+    """Recursive existence check: any folder name in this subtree matches?"""
+    if filt is None:
+        return True
+    if depth >= max_depth:
+        return False
+    for k, v in d.items():
+        if not isinstance(v, dict):
+            continue
+        if filt in k.lower():
+            return True
+        if _walk_check(v, filt, max_depth, depth + 1):
+            return True
+    return False
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- **MCP tool prefix** — all 18 MCP tools renamed with a `pyirena_` prefix (e.g. `summarize_folder` → `pyirena_summarize_folder`) for unambiguous identification when a client connects to multiple MCP servers.
- **Igor PXP / H5XP importer** — new `pyirena/io/pxp_to_nexus.py` reads Igor packed experiments (`.pxp`, `.h5xp`) and exports each sample as a NeXus HDF5 file; supports Igor v5 and v7 wave formats, macOS byte-order quirk, per-sample layouts, and Igor 8 long-name records (with `.h5xp` workaround guidance).
- **MCP plot tools: mixed content response** — `pyirena_plot_iq` and `pyirena_plot_parameter_trend` now return a two-item content list (`text` file-path + `image` base64 PNG) instead of a bare `Image`, so AI clients can display the saved path alongside the inline image.
- **GUI engineering notation** — numbers throughout the GUI are formatted in engineering notation via new `pyirena/gui/fmt_utils.py`.
- **Docs** — `ai_tools_reference.md` and `ai_integration.md` updated to document the mixed content plot response and warn against printing image content as text.
- **Diagnostic scripts** — four `scripts/diag_*.py` helpers for debugging PXP imports.

## Test plan

- [ ] `pytest pyirena/tests/` — 136 pass, 4 skip; 2 pre-existing failures on `main` unchanged (`test_model_iq_smooth_no_gibbs_ripples`, `test_calculate_invariant`)
- [ ] MCP smoke: connect a client, confirm all tool names carry `pyirena_` prefix
- [ ] PXP import: run `pyirena-import` on a `.pxp` file and verify NeXus output
- [ ] Plot tool: call `pyirena_plot_iq` and confirm two content items (text + image)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)