### PR TITLE
Feature/parallel mc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Parallel Monte-Carlo uncertainty in the Modeling tool.** Each MC pass is an
+  independent refit of noise-perturbed data, so passes now run across worker
+  processes instead of one after another. This was impractical before for the
+  models that need it most: a complex form factor (core-shell,
+  core-shell-shell) or several populations can take minutes per pass, making a
+  20-pass estimate a coffee break. A new **cores** spin box next to
+  *Modeling → Passes:* controls it — **auto** (the default: all cores but two),
+  **1** for the previous serial behaviour, or an explicit count. The same
+  setting is available to scripts as `fit_modeling(..., mc_workers=N)` and as
+  the `"mc_workers"` key in the exported JSON config. See
+  [MC Uncertainty](docs/modeling_gui.md#mc-uncertainty).
+  - Uncertainties are unchanged by the worker count: all the noise is drawn in
+    the parent process before any pass starts, so a given run produces the same
+    numbers serially and in parallel.
+  - Short runs stay serial automatically. The first pass is timed and the pool
+    is only started when the remaining passes are projected to take more than a
+    few seconds, so simple models never pay for worker startup.
+  - If the host cannot start worker processes the passes fall back to serial
+    with a warning rather than failing.
+- **Cancel for Modeling MC runs.** The **Calc. Uncertainty (MC)** button becomes
+  **Cancel MC** while a run is in progress. Cancelling does not interrupt passes
+  already in flight, so it takes effect within roughly one pass, and the
+  uncertainties from the passes that did finish are still reported along with
+  how many were used.
+
 ## [1.1.0b3] - 2026-08-03
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,42 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`pyirena-doctor` — installation troubleshooter.** A new console command
+  that reports the running interpreter, every required and optional
+  dependency, and whether the `pyirena-gui` launcher uses the same Python as
+  your `pip`. Each dependency is classified as installed, missing, or
+  *installed but failing to load* — the three states that the previous error
+  messages collapsed into one. Users can paste its output into a bug report.
+  See [Installation → Troubleshooting](docs/installation.md#troubleshooting).
+
+### Fixed
+
+- **"GUI dependencies not installed" when they demonstrably were.** `ImportError`
+  covers both a genuinely absent package and one that is present but whose
+  binaries will not load (wrong CPU architecture, missing system libraries,
+  shiboken6/PySide6 version skew). pyIrena reported the second as the first,
+  telling users to reinstall something they already had. Qt import failures are
+  now diagnosed: the message says which of the two happened, where the package
+  lives, the original loader error, the interpreter that failed, and — for
+  recognised errors such as `incompatible architecture` or `libGL.so.1` — the
+  likely cause and fix.
+- **Wrong-environment installs are now detected.** When the `pyirena-gui`
+  launcher script points at a different Python than the one running, both paths
+  are printed along with the `python -m pip` / `python -m pyirena.gui.launch`
+  form that keeps them in sync. This is the most common cause of the report
+  above.
+- **GUI startup errors are no longer flattened into a dependency message.** An
+  `ImportError` from an internal module is now identified as a probable bug
+  (with an issue-tracker pointer) rather than blamed on missing packages, and
+  the full traceback is always written to `~/.pyirena/logs/gui.log`.
+  `PYIRENA_DEBUG=1` also prints it to the terminal.
+- `pyirena-viewer` imported Qt directly instead of going through
+  `pyirena.gui._qt`, so it produced a bare `ModuleNotFoundError` instead of the
+  diagnosed message.
+- A Modeling test (`test_export_includes_selected_fit_method`) failed instead
+  of skipping in environments without Qt, because `pytest.importorskip` treats
+  a re-raised plain `ImportError` as a broken module rather than a missing one.
+
 - **Parallel Monte-Carlo uncertainty in the Modeling tool.** Each MC pass is an
   independent refit of noise-perturbed data, so passes now run across worker
   processes instead of one after another. This was impractical before for the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,45 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.0b4] - 2026-08-06
+
 ### Added
+
+- **Parallel Monte-Carlo uncertainty in the Modeling tool.** Each MC pass is an
+  independent refit of noise-perturbed data, so passes now run across worker
+  processes instead of one after another. This was impractical before for the
+  models that need it most: a complex form factor (core-shell,
+  core-shell-shell) or several populations can take minutes per pass, making a
+  20-pass estimate a coffee break. A new **cores** spin box next to
+  *Modeling → Passes:* controls it — **auto** (the default: all cores but two),
+  **1** for the previous serial behaviour, or an explicit count. The same
+  setting is available to scripts as `fit_modeling(..., mc_workers=N)` and as
+  the `"mc_workers"` key in the exported JSON config. See
+  [MC Uncertainty](docs/modeling_gui.md#mc-uncertainty).
+  - Uncertainties are unchanged by the worker count: all the noise is drawn in
+    the parent process before any pass starts, so a given run produces the same
+    numbers serially and in parallel.
+  - Short runs stay serial automatically. The first pass is timed and the pool
+    is only started when the remaining passes are projected to take more than a
+    few seconds, so simple models never pay for worker startup.
+  - If the host cannot start worker processes the passes fall back to serial
+    with a warning rather than failing.
+- **Cancel for Modeling MC runs.** The **Calc. Uncertainty (MC)** button becomes
+  **Cancel MC** while a run is in progress. Cancelling does not interrupt passes
+  already in flight, so it takes effect within roughly one pass, and the
+  uncertainties from the passes that did finish are still reported along with
+  how many were used.
+
+- **Regular expressions in every file Filter box.** The documentation promised
+  grep-like filtering, but only the HDF5 Viewer actually interpreted the Filter
+  text as a regex — Data Selector, Data Manipulation and Data Merge did a plain
+  case-insensitive substring test, so patterns like `60C|100C`, `0[12]min`,
+  `^sample`, `\.h5$` or `^(?!.*bkg)` silently matched nothing. All four
+  browsers now share one implementation (`pyirena.gui.file_filter`) using full
+  Python regular expressions matched anywhere in the name, case-insensitively.
+  A plain fragment such as `Rg50` behaves exactly as before, and an incomplete
+  or invalid pattern (common while typing) falls back to a substring match
+  rather than emptying the list.
 
 - **`pyirena-doctor` — installation troubleshooter.** A new console command
   that reports the running interpreter, every required and optional
@@ -45,30 +83,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   of skipping in environments without Qt, because `pytest.importorskip` treats
   a re-raised plain `ImportError` as a broken module rather than a missing one.
 
-- **Parallel Monte-Carlo uncertainty in the Modeling tool.** Each MC pass is an
-  independent refit of noise-perturbed data, so passes now run across worker
-  processes instead of one after another. This was impractical before for the
-  models that need it most: a complex form factor (core-shell,
-  core-shell-shell) or several populations can take minutes per pass, making a
-  20-pass estimate a coffee break. A new **cores** spin box next to
-  *Modeling → Passes:* controls it — **auto** (the default: all cores but two),
-  **1** for the previous serial behaviour, or an explicit count. The same
-  setting is available to scripts as `fit_modeling(..., mc_workers=N)` and as
-  the `"mc_workers"` key in the exported JSON config. See
-  [MC Uncertainty](docs/modeling_gui.md#mc-uncertainty).
-  - Uncertainties are unchanged by the worker count: all the noise is drawn in
-    the parent process before any pass starts, so a given run produces the same
-    numbers serially and in parallel.
-  - Short runs stay serial automatically. The first pass is timed and the pool
-    is only started when the remaining passes are projected to take more than a
-    few seconds, so simple models never pay for worker startup.
-  - If the host cannot start worker processes the passes fall back to serial
-    with a warning rather than failing.
-- **Cancel for Modeling MC runs.** The **Calc. Uncertainty (MC)** button becomes
-  **Cancel MC** while a run is in progress. Cancelling does not interrupt passes
-  already in flight, so it takes effect within roughly one pass, and the
-  uncertainties from the passes that did finish are still reported along with
-  how many were used.
+### Changed
+
+- The **Filter** placeholder and tooltip in Data Selector, Data Manipulation,
+  Data Merge and the HDF5 Viewer now come from one shared string and document
+  the regex syntax inline, replacing the previous "text filter…" /
+  "Enter text to filter files..." hints.
 
 ## [1.1.0b3] - 2026-08-03
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ Orientation file for AI agents working in this repository. Read this first; it
 tells you *where* things are and *what rules apply*, not what every function
 does. For details, follow the pointers into `docs/`.
 
-Last update date: 05-08-2026 ; version:1.1.0b3
+Last update date: 06-08-2026 ; version:1.1.0b4
 
 pyIrena is a Python port of the Igor Pro **Irena** small-angle scattering
 package (SAXS/SANS/USAXS analysis). Coded almost entirely by Claude; planned,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,217 @@
+# CLAUDE.md
+
+Orientation file for AI agents working in this repository. Read this first; it
+tells you *where* things are and *what rules apply*, not what every function
+does. For details, follow the pointers into `docs/`.
+
+pyIrena is a Python port of the Igor Pro **Irena** small-angle scattering
+package (SAXS/SANS/USAXS analysis). Coded almost entirely by Claude; planned,
+specified, debugged and validated by Jan Ilavsky. Scientific correctness
+outranks everything else in this codebase.
+
+---
+
+## 1. Commands
+
+```bash
+pip install -e ".[all]"      # dev install (gui + gui3d + mcp + plotting + dev)
+pytest                       # full suite (testpaths = pyirena/tests)
+pytest pyirena/tests/api     # api/mcp layer only
+ruff check pyirena/          # lint (line-length 100, config in pyproject.toml)
+pyirena-gui                  # launch the main GUI
+pyirena-mcp                  # run the MCP server (stdio)
+```
+
+Console entry points are declared in `pyproject.toml` under
+`[project.scripts]` — that is the authoritative list, don't duplicate it here.
+
+Test data lives in `testData/`. Tests must not require a display; Qt-dependent
+tests mock dialogs (see `pyirena/tests/api/conftest.py`).
+
+---
+
+## 2. Architecture — the layer stack
+
+**This is the most important section. Every analysis tool in pyIrena is built
+from the same seven layers.** Learn the stack once and you can find anything.
+
+| Layer | Path | Responsibility | May import |
+|---|---|---|---|
+| **core** | `pyirena/core/<tool>.py` | All math + a serialisable model object | numpy, scipy only |
+| **io** | `pyirena/io/nxcansas_<tool>.py` | Save/load results into NXcanSAS HDF5 at `entry/<tool>_results`, embedding GUI state as `_pyirena_config` | h5py, core |
+| **gui** | `pyirena/gui/<tool>_panel.py` | Thin Qt shell over the core object; full control state round-trips through `StateManager` | Qt (via `gui/_qt.py`), core, io |
+| **batch** | `pyirena/batch/<tool>.py` | Headless execution of the same core from a dict or JSON config section | core, io |
+| **api** | `pyirena/api/` | Stable, JSON-serialisable facade for AI/scripting; read access plus `api/control/` for interactive fitting sessions | core, io |
+| **mcp** | `pyirena/mcp/server.py` | Protocol wrapper exposing `pyirena.api` to MCP clients | api |
+| **plotting** | `pyirena/plotting/` | Headless matplotlib rendering | core, matplotlib |
+
+**The golden rule:** all state lives in the core model object and flows
+`dict → JSON → HDF5` unchanged. A control that exists only as a Qt widget will
+not survive scripting, batch runs, or setup restore — that is a bug, not a
+limitation.
+
+The layer stack is the *target* architecture and older tools do not all reach
+it yet — serialisation helpers are named `to_dict`/`from_dict` in newer core
+modules but not universally, and panel state methods appear as
+`_collect_state`, `collect_state`, `_save_state` and `save_state` depending on
+vintage. Follow the convention in the module you are editing; follow
+`docs/developer_adding_features.md` for anything new. HDF5 group names are
+mostly `entry/<tool>_results` but not mechanically derived — Simple Fits writes
+`entry/simple_fit_results`. Check `pyirena/io/nxcansas_<tool>.py` rather than
+assuming.
+
+Two cross-cutting consumers read the saved HDF5 groups rather than the core
+objects:
+
+- `pyirena/gui/data_selector/` — graphing, reports, CSV tabulation
+- `pyirena/gui/hdf5viewer/` — trend plots, Igor-experiment export
+  (via `io/h5xp_extractor.py` + `io/igor_names.py`)
+
+Support modules that are not tools: `pyirena/state/` (StateManager, setup
+save/restore), `pyirena/core/form_factors.py`, `distributions.py`,
+`fit_metrics.py`, `smearing.py`, `feature_detect.py`, `similarity.py`.
+
+### Layering invariants — do not break these
+
+1. `core/`, `io/`, `api/`, `batch/` **never import Qt.** Verify with
+   `grep -rl "PySide6\|PyQt" pyirena/core pyirena/api pyirena/io pyirena/batch`
+   — it must return nothing. `core/`, `io/` and `batch/` are also
+   matplotlib-free; `api/plotting.py` and `api/control/` are the only
+   non-GUI modules allowed to use matplotlib, and they import it lazily inside
+   functions and force the `Agg` backend.
+2. All Qt imports in `gui/` go through `pyirena/gui/_qt.py` — never
+   `from PySide6 import ...` directly. It normalises the PySide6/PyQt6 fallback.
+3. `pyirena.api` returns JSON-serialisable dicts only. No numpy scalars, no
+   model objects, no file handles.
+4. `from_dict()` must supply defaults for every field so that files written by
+   older versions still load. Backwards compatibility of saved data is not
+   optional.
+5. Optional dependencies (GUI, 3D, MCP, plotting) must degrade gracefully —
+   importing `pyirena` with no extras installed must work. See
+   `pyirena/tests/test_optional_dep_modules.py`.
+
+---
+
+## 3. Tool map
+
+Each analysis tool occupies one row. **When a tool is added, add a row — do not
+restructure this section.** A blank cell means that surface does not exist yet
+for that tool; that is often a legitimate gap worth fixing rather than a
+deliberate choice.
+
+| Tool | core | io | gui | batch | docs |
+|---|---|---|---|---|---|
+| Unified Fit | `unified.py` | `nxcansas_unified.py` | `unified_fit.py` | `unified.py` | `unified_fit_gui.md`, `unified_fit_features.md` |
+| Size Distribution | `sizes.py` | `nxcansas_sizes.py` | `sizes_panel.py` | `sizes.py` | `sizes_methods.md` |
+| Modeling | `modeling.py` | `nxcansas_modeling.py` | `modeling_panel.py` | `modeling.py` | `modeling_gui.md` |
+| Simple Fits | `simple_fits.py` | `nxcansas_simple_fits.py` | `simple_fits_panel.py` | `simple.py` | `simple_fits_gui.md` |
+| Fractals | `fractals.py` | `nxcansas_fractals.py` | `fractals_panel.py` | — | `fractals_gui.md` |
+| SAXS Morph | `saxs_morph.py` | `nxcansas_saxs_morph.py` | `saxs_morph_panel.py` | `saxs_morph.py` | `saxs_morph_gui.md`, `saxs_morph_method_comparison.md` |
+| WAXS Peak Fit | `waxs_peakfit.py` | `nxcansas_waxs_peakfit.py` | `waxs_peakfit_panel.py` | `waxs.py` | `waxs_peakfit_gui.md` |
+| Data Merge | `data_merge.py` | `nxcansas_data_merge.py` | `data_merge_panel.py` | `merge.py` | `data_merge_gui.md` |
+| Data Manipulation | `data_manipulation.py` | `nxcansas_data_manipulation.py` | `data_manipulation_panel.py` | `manipulate.py` | `data_manipulation_gui.md` |
+| Scattering Contrast | `scattering_contrast.py` | `contrast_io.py` | `contrast_panel.py` | — | `scattering_contrast_gui.md` |
+| Slit Smearing | `smearing.py` | — | `slit_smearing_ui.py` | — | `slit_smearing.md` |
+| Feature Identifier | `feature_detect.py` | — | `feature_identifier.py` | — | `feature_identifier.md` |
+| Fit Quality Metrics | `fit_metrics.py` | `nxcansas_fit_quality.py` | `quality_display.py` | — | `fit_quality_metrics.md` |
+
+Paths are relative to `pyirena/core/`, `pyirena/io/`, `pyirena/gui/`,
+`pyirena/batch/` and `docs/` respectively. Note that batch module names are
+occasionally shortened (`simple.py`, `waxs.py`, `merge.py`).
+
+---
+
+## 4. Where to look
+
+Start here rather than grepping. `docs/` has ~33 files; these are the ones that
+change how you should work.
+
+| If you are… | Read |
+|---|---|
+| Adding *any* feature — start here, always | `docs/developer_adding_features.md` (master checklist of every integration surface) |
+| Adding a form factor | `docs/developer_adding_form_factors.md` |
+| Adding a structure factor | `docs/developer_adding_structure_factors.md` |
+| Touching HDF5 read/write | `docs/HDF5_NxcanSAS_structure.md` |
+| Working on the api/MCP layer | `pyirena/api/README.md`, `docs/ai_tools_reference.md`, `docs/ai_integration.md` |
+| Writing or fixing tests | `docs/testing.md` |
+| Working on batch/scripting | `docs/batch_api.md` |
+| Importing Igor `.pxp` files | `docs/igor_pxp_import.md` |
+| Loading or cleaning input data | `docs/data_import_and_cleaning.md` |
+| Packaging or release work | `docs/distribution.md`, `.github/workflows/publish.yml` |
+| Understanding a specific GUI panel | `docs/<tool>_gui.md` (see tool map above) |
+| Looking for design intent on unfinished work | `planning/` and `IMPROVEMENT_PLAN.md` |
+
+`docs/GUI_README.md`, `docs/gui_quickstart.md`, `docs/QUICK_START.md` and
+`docs/usage_guide.md` are user-facing; consult them to keep terminology
+consistent with what users see.
+
+---
+
+## 5. Conventions
+
+**Scientific.** Q is in Å⁻¹ throughout unless a function's docstring says
+otherwise. Intensity is cm⁻¹ (absolute) where calibration exists. Single-letter
+names `I`, `l`, `Q`, `R` are idiomatic here and ruff's `E741` is disabled for
+that reason — keep using the physics notation rather than renaming to
+`intensity_array`. Preserve the Irena/Igor terminology users already know; when
+an algorithm comes from Irena, say so in the docstring and keep the same
+parameter names where practical.
+
+**Code.** Line length 100. Google-style docstrings on public functions. Ruff
+with `E741`, `E701`, `E702`, `E402` intentionally disabled (see the comments in
+`pyproject.toml` — read them before "fixing" a lint suppression). Type hints
+where they help; `py.typed` is shipped. Python 3.9 is the floor, so no
+`match`, no PEP 604 `X | Y` in runtime annotations.
+
+**GUI.** One panel per tool, one file per panel. Panels are thin — if you are
+writing a loop with numpy in a `*_panel.py`, it belongs in `core/`. Every panel
+must expose state collection and a `load_state()` so setup save/restore works.
+
+**Testing.** New math needs a test in `pyirena/tests/`. New HDF5 fields need a
+round-trip test in `test_nxcansas_roundtrips.py`. New api surface needs a test
+in `pyirena/tests/api/`. Tests must be headless and finish well inside the
+300 s per-test timeout.
+
+**Versioning.** `pyproject.toml` version is authoritative and the publish
+workflow refuses to release if the git tag disagrees. Update `CHANGELOG.md` for
+user-visible changes.
+
+---
+
+## 6. Working style in this repo
+
+- Prefer editing the existing tool that already does 80% of the job over adding
+  a parallel implementation. Duplication across the seven layers is expensive.
+- When a change spans layers, work bottom-up: core → io → batch → gui → api.
+  The core model object's `to_dict()` shape is the contract everything else
+  depends on.
+- Do not add dependencies without asking. The dependency set is deliberately
+  small and split across extras.
+- `temp/`, `testData/`, `scripts/` and `planning/` are excluded from ruff and
+  are not part of the shipped package. `scripts/` holds diagnostic one-offs, not
+  supported tooling.
+- Ask before large refactors. The codebase is validated against Igor Irena
+  results; a "cleaner" rewrite that shifts a numerical result is a regression.
+
+---
+
+## 7. Maintaining this file
+
+This file is a map, not documentation. It is deliberately written at a level of
+abstraction that survives ordinary development — most commits should require no
+change here.
+
+**Update it when, and only when:**
+
+- a new analysis tool is added → add one row to §3
+- a new top-level package appears under `pyirena/` → add one row to §2
+- a layering invariant in §2 changes → fix the invariant list
+- a command in §1 changes (test runner, lint tool, entry points)
+- a new `docs/developer_*.md` guide is written → add one row to §4
+
+**Do not add here:** function signatures, parameter lists, model formulas,
+per-release notes, or anything already written in `docs/`. Those rot within
+weeks and belong in the code or in `docs/`.
+
+If §3 or §4 has drifted, regenerate just that table by listing the directories
+rather than rewriting the whole file.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,6 +4,8 @@ Orientation file for AI agents working in this repository. Read this first; it
 tells you *where* things are and *what rules apply*, not what every function
 does. For details, follow the pointers into `docs/`.
 
+Last update date: 05-08-2026 ; version:1.1.0b3
+
 pyIrena is a Python port of the Igor Pro **Irena** small-angle scattering
 package (SAXS/SANS/USAXS analysis). Coded almost entirely by Claude; planned,
 specified, debugged and validated by Jan Ilavsky. Scientific correctness

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -140,6 +140,7 @@ change how you should work.
 | Importing Igor `.pxp` files | `docs/igor_pxp_import.md` |
 | Loading or cleaning input data | `docs/data_import_and_cleaning.md` |
 | Packaging or release work | `docs/distribution.md`, `.github/workflows/publish.yml` |
+| Debugging a user's install/startup failure | `pyirena/diagnostics.py` (`pyirena-doctor`), `docs/installation.md` |
 | Understanding a specific GUI panel | `docs/<tool>_gui.md` (see tool map above) |
 | Looking for design intent on unfinished work | `planning/` and `IMPROVEMENT_PLAN.md` |
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ GUI tools for fitting, modeling, data merging, and visualization of SAXS/SANS/US
 
 **Current release: v1.0.1**
 
-**Current beta release: v1.1.0b3**
+**Current beta release: v1.1.0b4**
 
 [![PyPI version](https://img.shields.io/pypi/v/pyirena.svg)](https://pypi.org/project/pyirena/)
 [![Python Version](https://img.shields.io/badge/python-3.9+-blue.svg)](https://www.python.org/downloads/)
@@ -32,7 +32,7 @@ core library only (no GUI), use `pip install pyirena`.
 
 **Trying a pre-release (beta) version:**
 
-Beta releases (e.g. `1.1.0b3`) are published to PyPI ahead of a stable release
+Beta releases (e.g. `1.1.0b4`) are published to PyPI ahead of a stable release
 for early testing. `pip` does not install pre-releases by default, so pass
 `--pre` explicitly:
 
@@ -43,7 +43,7 @@ pip install --pre "pyirena[gui]"
 To install a specific beta rather than whatever is newest:
 
 ```bash
-pip install "pyirena[gui]==1.1.0b3"
+pip install "pyirena[gui]==1.1.0b4"
 ```
 
 Pre-releases may contain incomplete or breaking changes — see

--- a/docs/GUI_README.md
+++ b/docs/GUI_README.md
@@ -49,7 +49,8 @@ The main GUI provides:
      HDF5 on first use (see [Text File Import and Cleaning](data_import_and_cleaning.md))
    - All supported files
 3. **File List** - View and select files from the folder
-4. **Text Filter** - Grep-like filtering of file names
+4. **Text Filter** - Grep-like filtering of file names, with full regular
+   expression support
 5. **Multi-selection** - Select multiple files (Ctrl/Cmd + click)
 6. **Graphing** - Plot selected files with:
    - Log-log scale
@@ -76,7 +77,10 @@ The main GUI provides:
 
 4. **Filter Files (Optional)**
    - Type in the filter box to search
-   - Works like grep (case-insensitive)
+   - Works like grep: the text is a full regular expression, matched anywhere
+     in the file name, case-insensitively
+   - Plain fragments such as `60C` still work; invalid patterns fall back to a
+     substring match
 
 5. **Select Files**
    - Single click to select one file

--- a/docs/batch_api.md
+++ b/docs/batch_api.md
@@ -480,6 +480,7 @@ result = fit_modeling(
     save_to_nexus=True,     # bool — write results to NXcanSAS HDF5 file
     with_uncertainty=False, # bool — run MC uncertainty estimation after the main fit
     n_mc_runs=10,           # int — number of MC runs (used when with_uncertainty=True)
+    mc_workers=None,        # int — worker processes for the MC passes; None = use the config
 )
 ```
 
@@ -504,7 +505,13 @@ result = fit_modeling(
    fallback to serial if the host cannot start workers.
 5. **MC uncertainty** *(if `with_uncertainty=True`)* — re-fits `n_mc_runs` noise-perturbed
    copies of the data and accumulates per-parameter standard deviations (always
-   using the fast local refinement, even when `fit_method` is `global`).
+   using the fast local refinement, even when `fit_method` is `global`). Passes
+   are independent, so they are spread over worker processes: the `mc_workers`
+   argument, or failing that the config's `"mc_workers"` key, sets how many —
+   `0` = auto (`cpu_count - 2`, the default), `1` = serial, `N > 1` = explicit.
+   Short runs stay serial automatically, and the passes fall back to serial with
+   a warning if the host cannot start workers. Results do not depend on the
+   worker count.
 6. **Saves results** *(if `save_to_nexus=True` and input is HDF5)* — writes
    `entry/modeling_results` to the HDF5 file.
 7. **Returns** a result dict (see below).
@@ -518,6 +525,7 @@ result = fit_modeling(
 | `save_to_nexus` | `bool` | `True` | Save fit results to NXcanSAS HDF5; ignored for text-file inputs |
 | `with_uncertainty` | `bool` | `False` | Run Monte Carlo uncertainty estimation |
 | `n_mc_runs` | `int` | `10` | Number of MC passes for uncertainty estimation |
+| `mc_workers` | `int` or `None` | `None` | Worker processes for the MC passes, overriding the config's `mc_workers`. `0` = auto (`cpu_count - 2`), `1` = serial, `N > 1` = explicit. Keep at `1` when parallelising over files instead — nest one level of parallelism, not two |
 
 ### Population types
 

--- a/docs/data_manipulation_gui.md
+++ b/docs/data_manipulation_gui.md
@@ -74,7 +74,10 @@ The tool is available three ways:
   [Q units](data_import_and_cleaning.md#q-units).
 - **Sort** --- 10 sort options: filename, temperature, time, order number, pressure
   (ascending or descending).
-- **Filter** --- type text to filter filenames (case-insensitive substring match).
+- **Filter** --- type text to filter filenames.  The text is a **regular
+  expression** matched anywhere in the name, case-insensitively (grep
+  semantics): `60C` , `60C|100C` , `0[12]min` , `^sample` , `\.h5$` ,
+  `^(?!.*bkg)` .  An invalid pattern falls back to a plain substring match.
 - **Double-click** a file to load and plot it.
 
 ### Graph (centre)

--- a/docs/data_merge_gui.md
+++ b/docs/data_merge_gui.md
@@ -84,7 +84,10 @@ Three parameters may be free or fixed:
   Text files are assumed to be in the Q unit set in the Data Selector's
   *Configure → Text File Options → Q unit in text files* (default 1/Å) — see
   [Q units](data_import_and_cleaning.md#q-units).
-- Use the **Filter** field to narrow the file list.
+- Use the **Filter** field to narrow the file list.  The text is a **regular
+  expression** matched anywhere in the name, case-insensitively (grep
+  semantics), e.g. `60C|100C` or `^(?!.*bkg)` to exclude backgrounds.  An
+  invalid pattern falls back to a plain substring match.
 - **Double-click** a file to load it and display it on the plot.
 
 ### 2 — Set the overlap region

--- a/docs/gui_quickstart.md
+++ b/docs/gui_quickstart.md
@@ -98,11 +98,21 @@ Use the dropdown to filter by file type:
 #### 3. Filter Files (Optional)
 
 - Type in the **Filter** box to search for files
-- Works like grep (case-insensitive substring match)
+- Works like grep: the text is a **full regular expression**, matched anywhere
+  in the file name, case-insensitively
 - Examples:
   - `sphere` → shows only files containing "sphere"
   - `Rg50` → shows spheres_Rg50.h5
-  - `fractal` → shows fractal files
+  - `60C|100C` → files containing either "60C" or "100C"
+  - `0[12]min` → files with "01min" or "02min"
+  - `^sample` → files whose name starts with "sample"
+  - `\.h5$` → files ending in ".h5"
+  - `^(?!.*bkg)` → files that do **not** contain "bkg"
+- An incomplete or invalid pattern (e.g. while you are still typing) falls back
+  to a plain substring match rather than emptying the list
+
+The same filter syntax applies in Data Selector, Data Manipulation, Data Merge
+and the HDF5 Viewer.
 
 #### 4. Select Files to Plot
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -80,7 +80,7 @@ pip install -e .
 
 ### Trying a pre-release (beta) version from PyPI
 
-Beta releases (e.g. `1.1.0b3`) are published to PyPI ahead of a stable
+Beta releases (e.g. `1.1.0b4`) are published to PyPI ahead of a stable
 release for early testing. `pip` ignores pre-releases by default, so pass
 `--pre` explicitly:
 
@@ -91,7 +91,7 @@ pip install --pre "pyirena[gui]"
 Or pin an exact beta version:
 
 ```bash
-pip install "pyirena[gui]==1.1.0b3"
+pip install "pyirena[gui]==1.1.0b4"
 ```
 
 See [CHANGELOG.md](../CHANGELOG.md) for what changed, and report issues at

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -132,6 +132,9 @@ https://github.com/jilavsky/pyirena/issues.
 # Check the package is importable
 python -c "import pyirena; print('pyirena', pyirena.__version__)"
 
+# Full environment + dependency report
+pyirena-doctor
+
 # Launch the GUI
 pyirena-gui
 ```
@@ -139,6 +142,59 @@ pyirena-gui
 ---
 
 ## Troubleshooting
+
+### Start with `pyirena-doctor`
+
+```bash
+pyirena-doctor
+```
+
+It reports the interpreter in use, every required and optional dependency
+(marking each as installed, missing, or *installed but failing to load*), and
+whether the `pyirena-gui` launcher runs the same Python as your `pip`. Paste
+its output into any bug report — it usually identifies the problem outright.
+
+### "GUI dependencies not installed" — but pip says they are
+
+Almost always one of two things:
+
+**1. `pip` and the launcher are different Pythons.** `pyirena-gui` is a script
+with a hard-coded interpreter path. If you installed with a `pip` belonging to
+a different environment, the packages are invisible to the launcher. Use the
+module form so both always agree:
+
+```bash
+python -m pip install "pyirena[gui]"
+python -m pyirena.gui.launch
+```
+
+`pyirena-doctor` detects this case explicitly and prints both paths.
+
+**2. PySide6 is installed but cannot load.** Reinstalling will not help.
+Common causes:
+
+| Symptom in the error | Cause | Fix |
+|---|---|---|
+| `incompatible architecture` | x86_64 wheel under arm64 Python (or a Rosetta terminal) | Reinstall with a matching interpreter; check `python -c "import platform; print(platform.machine())"` |
+| `libGL.so.1: cannot open shared object file` | Linux missing OpenGL runtime | `sudo apt install libgl1 libglib2.0-0` |
+| `libxkbcommon…` / `xcb` errors | Linux missing X11 libraries | `sudo apt install libxkbcommon-x11-0 libxcb-cursor0` |
+| `DLL load failed` | Windows missing MSVC runtime | Install the Visual C++ Redistributable (x64) |
+| `shiboken6` mismatch | Partial upgrade | `python -m pip install --force-reinstall PySide6 shiboken6` |
+
+pyIrena names the likely cause for each of these automatically.
+
+> **Quote the brackets.** In zsh, `pip install pyirena[gui]` is glob-expanded
+> and fails or silently installs without the extras. Always write
+> `pip install "pyirena[gui]"`.
+
+For the full traceback behind any startup failure:
+
+```bash
+PYIRENA_DEBUG=1 pyirena-gui
+```
+
+Startup failures are also logged with full tracebacks to
+`~/.pyirena/logs/gui.log`.
 
 ### HDF5 / h5py build errors
 

--- a/docs/modeling_gui.md
+++ b/docs/modeling_gui.md
@@ -88,7 +88,7 @@ python -m pyirena.gui.modeling_panel path/to/file.h5
 │  Background: [____] [✓ Fit]        └──────────────────────────────────────────┘
 │  [✓ No limits?]
 │  Qmin: [____]  Qmax: [____]
-│  MC passes: [10]
+│  MC passes: [10]  cores: [auto]
 │
 │  [Graph Model]  [Fit]  [Calc. Uncertainty (MC)]
 │  [Revert]       [Save JSON]  [Load JSON]
@@ -522,6 +522,33 @@ Click **Calc. Uncertainty (MC)** to estimate parameter uncertainties by Monte Ca
 
 Set the number of passes with the **Passes:** spin box (1–500, default 10).
 More passes give better uncertainty estimates at the cost of longer compute time.
+
+**Parallel passes (`cores`).** Each pass is an independent refit, so passes are
+spread over worker processes. The **cores** spin box next to **Passes:** sets how
+many:
+
+- **auto** (default, shown for the value 0) — all cores but two, leaving headroom
+  for the GUI and the OS.
+- **1** — serial, the pre-1.1.0b4 behaviour.
+- **N** — an explicit count, capped at the core count.
+
+This is the setting that matters for slow models. A complex form factor
+(core-shell, core-shell-shell) or several populations can take minutes per pass,
+which made a 20-pass estimate impractical; the same estimate now finishes in
+roughly `1/cores` of the time. Simple models see little or no benefit, so short
+runs stay serial automatically: the first pass is timed, and the worker pool is
+only started when the remaining passes are projected to take more than a few
+seconds. If the host cannot start worker processes, the passes fall back to
+serial with a warning rather than failing.
+
+Uncertainties do not depend on how many cores you use — a given run produces the
+same numbers serially and in parallel.
+
+**Cancelling.** While MC is running the button becomes **Cancel MC**. Cancelling
+does not interrupt passes already in flight, so it takes effect within roughly
+one pass, and the uncertainties from the passes that did finish are still
+reported (the status line says how many were used). At least two passes must
+complete for a standard deviation to exist.
 
 ---
 

--- a/pyirena/batch/modeling.py
+++ b/pyirena/batch/modeling.py
@@ -33,6 +33,7 @@ def fit_modeling(
     save_to_nexus: bool = True,
     with_uncertainty: bool = False,
     n_mc_runs: int = 10,
+    mc_workers: Optional[int] = None,
 ) -> Optional[Dict]:
     """Fit a Modeling (parametric size distribution) model using a pyIrena config file.
 
@@ -57,6 +58,16 @@ def fit_modeling(
     n_mc_runs : int, optional
         Number of MC runs (used only when *with_uncertainty* is True).
         Default 10.
+    mc_workers : int, optional
+        Worker processes for the MC passes, overriding the config file's
+        ``mc_workers``. 0 = auto (cpu_count - 2), 1 = serial, N > 1 = explicit.
+        Each pass is an independent refit, so this scales nearly linearly for
+        slow models. Short runs stay serial automatically, and the passes fall
+        back to serial if the host cannot start worker processes.
+
+        Note that parallelism belongs at one level only: when driving many files
+        through :func:`pyirena.batch.pipeline`, leave this at 1 rather than
+        nesting pools inside a per-file loop.
 
     Returns
     -------
@@ -221,6 +232,8 @@ def fit_modeling(
             n_mc_runs=int(mod_cfg.get('n_mc_runs', n_mc_runs)),
             fit_method=str(mod_cfg.get('fit_method', 'local')),
             de_workers=int(mod_cfg.get('de_workers', 1)),
+            mc_workers=int(mc_workers if mc_workers is not None
+                           else mod_cfg.get('mc_workers', 0)),
             use_slit_smearing=bool(data.get('is_slit_smeared'))
                               or bool(mod_cfg.get('use_slit_smearing', False)),
             slit_length=(float(mod_cfg['slit_length']) if mod_cfg.get('slit_length')

--- a/pyirena/core/modeling.py
+++ b/pyirena/core/modeling.py
@@ -39,6 +39,7 @@ import warnings
 import hashlib
 import json
 import os
+import time
 import contextlib
 from copy import deepcopy
 from dataclasses import dataclass, field
@@ -108,6 +109,150 @@ class _DEObjective:
         if self.log_mask.any():
             x[self.log_mask] = 10.0 ** x[self.log_mask]
         return self.engine._chi2(x, self.keys, self.cfg, self.q, self.I, self.sigma)
+
+
+# ── Monte-Carlo uncertainty: parallel machinery ───────────────────────────────
+#
+# One MC pass = perturb the data, refit, keep the fitted parameters. Passes are
+# independent, so they distribute over worker processes with no coordination.
+# A pool costs roughly a second to start (spawn re-imports numpy/scipy in every
+# worker), so it only pays off once the remaining passes are slow enough; the
+# first pass is timed in-process to decide. See ``_MC_PARALLEL_MIN_SECONDS``.
+
+# Projected serial cost of the remaining passes, below which the pool is skipped.
+_MC_PARALLEL_MIN_SECONDS = 5.0
+
+# Process-local engine, created on first use inside each worker.
+_MC_ENGINE: Optional["ModelingEngine"] = None
+
+
+def _mc_engine() -> "ModelingEngine":
+    """Return this process's reusable ``ModelingEngine``.
+
+    One engine per worker process rather than one per pass, so the cached
+    ``SlitSmearer`` (see :meth:`ModelingEngine._get_smearer`) is built once per
+    process instead of rebuilt for every pass.
+
+    The caller's live engine is deliberately never shipped across the process
+    boundary: the Modeling GUI monkey-patches ``_chi2``/``_residuals`` with
+    closures for "Cancel Fit", and closures cannot be pickled.
+    """
+    global _MC_ENGINE
+    if _MC_ENGINE is None:
+        _MC_ENGINE = ModelingEngine()
+    return _MC_ENGINE
+
+
+class _MCRun:
+    """Picklable single Monte-Carlo pass, for parallel uncertainty estimation.
+
+    Carries only picklable state (a config, the q grid, the uncertainties, and
+    the expected parameter count) and is called with one pre-perturbed intensity
+    array. Must be module-level so ``pickle`` can reference it by qualified name.
+
+    Returns the flat list of fitted parameter values, or ``None`` when the pass
+    failed — matching the serial path, which skips failed passes rather than
+    aborting the whole estimate.
+    """
+
+    def __init__(self, cfg, q, dI, n_keys):
+        self.cfg = cfg
+        self.q = q
+        self.dI = dI
+        self.n_keys = n_keys
+
+    def __call__(self, I_pert):
+        engine = _mc_engine()
+        # Every pass adds one entry to the q-keyed G cache (via the ideal-curve
+        # evaluation in fit()). The engine outlives the pass, so drop them here
+        # rather than growing without bound over a long run. This does not touch
+        # the cached SlitSmearer, which is the whole point of reusing an engine.
+        engine.clear_cache()
+        # fit() writes best-fit values back into the config it is given, so each
+        # pass needs its own copy to read the result out of.
+        cfg_run = deepcopy(self.cfg)
+        try:
+            engine.fit(cfg_run, self.q, I_pert, self.dI)
+            x_final, _, _, _ = engine._pack_params(deepcopy(cfg_run))
+        except Exception:
+            return None
+        if len(x_final) != self.n_keys:
+            return None
+        return [float(v) for v in x_final]
+
+
+def _mc_cancelled(cancel_cb) -> bool:
+    """True when the caller has asked to stop (``cancel_cb`` may be None)."""
+    return cancel_cb is not None and bool(cancel_cb())
+
+
+def _resolve_mc_workers(requested) -> int:
+    """Map the ``mc_workers`` convention onto a real process count.
+
+    ``0`` (or None / negative) → auto: ``cpu_count - 2``, leaving a couple of
+    cores for the GUI and the OS. ``1`` → serial. ``N > 1`` → N, capped at
+    ``cpu_count``.
+    """
+    n_cpu = os.cpu_count() or 1
+    if requested is None or int(requested) <= 0:
+        return max(1, n_cpu - 2)
+    return max(1, min(int(requested), n_cpu))
+
+
+def _run_mc_parallel(run, batch, n_workers, record, cancel_cb):
+    """Distribute MC passes over a process pool.
+
+    ``record(x_final)`` is called once per completed pass, in completion order.
+
+    Returns the entries of *batch* that were **not** completed — empty when the
+    pool handled everything (including a clean cancel). Raises if the pool could
+    not be created or the passes could not be submitted, which happens before
+    anything is recorded so the caller can safely fall back to serial.
+    """
+    from concurrent.futures import ProcessPoolExecutor, as_completed
+    from concurrent.futures.process import BrokenProcessPool
+    from multiprocessing import get_context
+
+    # 'spawn' everywhere: uniform semantics across platforms, and forking a
+    # process that already has Qt loaded is not safe. Workers are created during
+    # submit(), so the BLAS pin has to cover the submission loop — otherwise
+    # every worker re-imports numpy with a full thread pool and oversubscribes.
+    with _limit_blas_threads(1):
+        executor = ProcessPoolExecutor(
+            max_workers=n_workers, mp_context=get_context('spawn'),
+        )
+        try:
+            futures = {executor.submit(run, arr): i for i, arr in enumerate(batch)}
+        except Exception:
+            executor.shutdown(wait=False)
+            raise
+
+    pending = set(range(len(batch)))
+    try:
+        for fut in as_completed(futures):
+            try:
+                x_final = fut.result()
+            except BrokenProcessPool:
+                raise
+            except Exception:
+                x_final = None          # failed pass — skipped, as in serial
+            pending.discard(futures[fut])
+            record(x_final)
+            if _mc_cancelled(cancel_cb):
+                # Passes already running cannot be interrupted; stop handing out
+                # new ones and drop whatever is still queued.
+                pending.clear()
+                break
+    except BrokenProcessPool:
+        warnings.warn(
+            "Monte-Carlo worker pool died; finishing the remaining passes serially.",
+            RuntimeWarning,
+        )
+    finally:
+        executor.shutdown(wait=False, cancel_futures=True)
+
+    return [batch[i] for i in sorted(pending)]
+
 
 from pyirena.core import distributions as D
 from pyirena.core.form_factors import build_g_matrix, bin_widths
@@ -378,6 +523,13 @@ class ModelingConfig:
     # the global method; the serial path is unchanged. Falls back to serial
     # automatically if multiprocessing fails on the host.
     de_workers: int = 1
+    # Worker processes for the Monte-Carlo uncertainty passes (each pass is an
+    # independent refit of noise-perturbed data, so they parallelise cleanly).
+    # 0 = auto (cpu_count - 2, the default); 1 = serial; N > 1 = explicit count.
+    # The first pass always runs in-process and is timed: when the remaining
+    # work is too small to repay pool startup the rest also runs serially.
+    # Falls back to serial automatically if multiprocessing fails on the host.
+    mc_workers: int = 0
     # Slit smearing: when enabled the total model intensity is slit smeared
     # before comparison with (slit-smeared) data, so fitted parameters are
     # ideal-space.  Structure factors are part of the ideal model and are
@@ -1681,45 +1833,113 @@ class ModelingEngine:
         dI: np.ndarray,
         n_runs: int = 10,
         progress_cb=None,
+        cancel_cb=None,
+        workers: Optional[int] = None,
+        seed=None,
     ) -> dict[str, float]:
         """Estimate parameter uncertainty by repeated fitting on perturbed data.
 
         Data is perturbed as I_perturbed = I + dI * N(0,1) for each run.
         Returns a dict of std-dev for each fittable parameter.
 
-        Args:
-            progress_cb: optional callable(run_index, n_runs) called before each run.
-        """
-        rng = np.random.default_rng()
+        Each pass is an independent refit, so passes are spread over worker
+        processes when that is worth doing (see *workers*). All the noise is
+        drawn in *this* process before any pass starts, and workers receive
+        finished arrays rather than a seed. That keeps parallel results
+        bit-identical to serial ones for a given *seed*, and rules out the
+        failure mode where forked workers inherit one RNG state and return N
+        identical passes — which would silently drive every uncertainty to zero.
 
+        Args:
+            progress_cb: optional callable(n_done, n_runs) called as passes
+                complete. Passes finish out of order when running in parallel,
+                so this counts completions rather than reporting a pass index.
+            cancel_cb: optional callable returning True to stop early. Passes
+                already in flight are not interrupted, so a cancel takes effect
+                within roughly one pass; uncertainties from the passes that did
+                finish are still returned.
+            workers: process-count override. None (default) uses
+                ``config.mc_workers``: 0 = auto (cpu_count - 2), 1 = serial,
+                N > 1 = explicit. Falls back to serial if the pool cannot start.
+            seed: seed for the perturbation RNG. None (default) keeps passes
+                nondeterministic; pass an int for reproducible uncertainties.
+        """
         # Collect best-fit values per run
         _, _, _, keys = self._pack_params(deepcopy(config))
         if not keys:
             return {}
 
+        n_runs = int(n_runs)
+        if n_runs < 1:
+            return {}
+
+        # MC perturbs data around the already-found solution, so a fast local
+        # refinement per pass is appropriate — running the global search n_runs
+        # times would be needlessly slow. de_workers is pinned for the same
+        # reason: with fit_method='local' the DE pool is already unreachable,
+        # and pinning it stops a future edit from nesting pools inside this one.
+        cfg_mc = deepcopy(config)
+        cfg_mc.fit_method = 'local'
+        cfg_mc.de_workers = 1
+
+        rng = np.random.default_rng(seed)
+        perturbed = [I + dI * rng.standard_normal(len(I)) for _ in range(n_runs)]
+
+        run = _MCRun(cfg_mc, q, dI, len(keys))
         all_vals: list[list[float]] = [[] for _ in keys]
-        good_runs = 0
+        n_done = 0
 
-        for run_i in range(n_runs):
+        def _record(x_final):
+            nonlocal n_done
+            n_done += 1
+            if x_final is not None:
+                for j, v in enumerate(x_final):
+                    all_vals[j].append(v)
             if progress_cb is not None:
-                progress_cb(run_i + 1, n_runs)
-            I_pert = I + dI * rng.standard_normal(len(I))
-            cfg_run = deepcopy(config)
-            # MC perturbs data around the already-found solution, so a fast
-            # local refinement per run is appropriate — running the global
-            # search n_runs times would be needlessly slow.
-            cfg_run.fit_method = 'local'
-            try:
-                self.fit(cfg_run, q, I_pert, dI)
-                x_final, _, _, keys_run = self._pack_params(deepcopy(cfg_run))
-                if len(x_final) == len(keys):
-                    for j, v in enumerate(x_final):
-                        all_vals[j].append(v)
-                    good_runs += 1
-            except Exception:
-                continue
+                progress_cb(n_done, n_runs)
 
-        if good_runs < 2:
+        # Pass 1 runs here so its cost can be measured: it decides whether the
+        # rest are worth a process pool at all. No work is wasted — it counts
+        # towards n_runs like any other pass — but it does serialise one pass
+        # ahead of the pool. That costs at most one pass of wall time, which is
+        # a shrinking fraction as n_runs grows past the worker count, and it is
+        # what lets cheap models skip the pool entirely.
+        t0 = time.perf_counter()
+        _record(run(perturbed[0]))
+        first_pass_s = time.perf_counter() - t0
+
+        remaining = perturbed[1:]
+        n_workers = _resolve_mc_workers(
+            workers if workers is not None else getattr(config, 'mc_workers', 0)
+        )
+        use_pool = (
+            bool(remaining)
+            and n_workers > 1
+            and first_pass_s * len(remaining) >= _MC_PARALLEL_MIN_SECONDS
+        )
+
+        if remaining and not _mc_cancelled(cancel_cb):
+            leftovers = remaining
+            if use_pool:
+                try:
+                    leftovers = _run_mc_parallel(
+                        run, remaining, n_workers, _record, cancel_cb)
+                except Exception as exc:
+                    # Multiprocessing can fail on some hosts (spawn/pickling/
+                    # frozen apps). Never fail the estimate for it — the pool
+                    # raises before recording anything, so a serial retry of the
+                    # whole batch cannot double-count.
+                    warnings.warn(
+                        f"Parallel Monte-Carlo failed ({exc!r}); running serially.",
+                        RuntimeWarning,
+                    )
+                    leftovers = remaining
+            for I_pert in leftovers:
+                if _mc_cancelled(cancel_cb):
+                    break
+                _record(run(I_pert))
+
+        if len(all_vals[0]) < 2:
             return {}
 
         stds: dict[str, float] = {}

--- a/pyirena/diagnostics.py
+++ b/pyirena/diagnostics.py
@@ -1,0 +1,539 @@
+"""
+Environment and dependency diagnostics for pyIrena.
+
+This module exists because the single most common support request is some
+variant of *"pip says PySide6 is installed but pyIrena says it isn't"*.  That
+report is usually accurate: ``ImportError`` covers two very different
+failures, and the old error message conflated them.
+
+    ModuleNotFoundError   the package really is absent from *this* interpreter
+    ImportError (other)   the package is present but its binaries will not
+                          load — wrong CPU architecture, missing system
+                          libraries, a half-finished install, a shiboken6 /
+                          PySide6 version mismatch
+
+Telling a user to reinstall something that is already installed sends them in
+a circle.  The helpers here identify which failure actually occurred, attach
+the interpreter that hit it, and translate the cryptic dynamic-loader message
+into an actionable hint.
+
+Standard library only, deliberately: this code has to run *when the
+dependencies are broken*.  Nothing here may import numpy, h5py, Qt, or
+matplotlib at module scope.
+
+Entry point: ``pyirena-doctor`` (see :func:`main`).
+"""
+from __future__ import annotations
+
+import importlib
+import importlib.util
+import os
+import platform
+import shutil
+import sys
+import sysconfig
+from dataclasses import dataclass
+from typing import Dict, List, Optional, Sequence, Tuple
+
+__all__ = [
+    "DependencyStatus",
+    "probe",
+    "probe_qt",
+    "explain_import_error",
+    "environment_lines",
+    "format_qt_import_failure",
+    "format_gui_import_failure",
+    "main",
+]
+
+# Python versions this project actually supports.  pyproject.toml allows 3.9+;
+# the GUI stack (PySide6 wheels) is only reliable through 3.13.
+PYTHON_MIN = (3, 9)
+PYTHON_GUI_MAX_TESTED = (3, 13)
+
+# module name -> (extra that provides it, what it is for)
+OPTIONAL_DEPENDENCIES: Dict[str, Tuple[str, str]] = {
+    "PySide6": ("gui", "Qt bindings (preferred)"),
+    "PyQt6": ("gui", "Qt bindings (fallback)"),
+    "pyqtgraph": ("gui", "interactive plots"),
+    "matplotlib": ("plotting", "static/headless plots"),
+    "xraydb": ("gui", "X-ray scattering contrast"),
+    "periodictable": ("gui", "neutron scattering contrast"),
+    "Dans_Diffraction": ("gui", "diffraction line markers"),
+    "pyvista": ("gui3d", "3D voxelgram viewer"),
+    "pyvistaqt": ("gui3d", "3D viewer Qt embedding"),
+    "mcp": ("mcp", "MCP server"),
+    "anthropic": ("gui", "AI advisor (optional)"),
+    "openai": ("gui", "AI advisor (optional)"),
+}
+
+# Required (non-optional) runtime dependencies.
+REQUIRED_DEPENDENCIES: Tuple[str, ...] = ("numpy", "scipy", "h5py", "igor2")
+
+# Substring -> advice.  Matched case-insensitively against the exception text
+# of a *broken* (not missing) import.  Ordered: first match wins.
+_ERROR_HINTS: Sequence[Tuple[str, str]] = (
+    (
+        "incompatible architecture",
+        "Architecture mismatch: the installed wheel was built for a different "
+        "CPU than this Python. On Apple Silicon this usually means an x86_64 "
+        "wheel under an arm64 interpreter (or a terminal running under "
+        "Rosetta). Check `python -c \"import platform; print(platform.machine())\"` "
+        "and reinstall with a matching interpreter.",
+    ),
+    (
+        "mach-o",
+        "The macOS dynamic loader rejected the installed binary — usually an "
+        "architecture mismatch or a truncated download. Try: "
+        "python -m pip install --force-reinstall --no-cache-dir PySide6",
+    ),
+    (
+        "libgl.so.1",
+        "Linux is missing OpenGL runtime libraries. On Debian/Ubuntu: "
+        "sudo apt install libgl1 libglib2.0-0",
+    ),
+    (
+        "libxkbcommon",
+        "Linux is missing X11/keyboard libraries needed by the Qt platform "
+        "plugin. On Debian/Ubuntu: sudo apt install libxkbcommon-x11-0 "
+        "libxcb-cursor0 libxcb-icccm4 libxcb-keysyms1 libxcb-shape0",
+    ),
+    (
+        "libegl",
+        "Linux is missing EGL libraries. On Debian/Ubuntu: "
+        "sudo apt install libegl1",
+    ),
+    (
+        "glibc",
+        "The system C library is older than the wheel requires. Install an "
+        "older PySide6 (e.g. PySide6==6.5.*) or update the OS.",
+    ),
+    (
+        "dll load failed",
+        "Windows could not load the Qt DLLs. Install the Microsoft Visual C++ "
+        "Redistributable (x64), then: "
+        "python -m pip install --force-reinstall PySide6",
+    ),
+    (
+        "shiboken",
+        "shiboken6 does not match the installed PySide6. They must be "
+        "installed together: "
+        "python -m pip install --force-reinstall PySide6 shiboken6",
+    ),
+    (
+        "symbol not found",
+        "A partially upgraded or mixed install. Reinstall the binding cleanly: "
+        "python -m pip uninstall -y PySide6 shiboken6 && "
+        "python -m pip install PySide6",
+    ),
+)
+
+
+@dataclass
+class DependencyStatus:
+    """Result of probing one importable module.
+
+    Attributes:
+        name: Module name as imported.
+        status: ``"ok"``, ``"missing"`` or ``"broken"``.
+        version: ``__version__`` if the module imported and exposes one.
+        path: ``__file__`` of the imported module, or the spec origin when the
+            module was found but failed to load.
+        error: The exception raised, for ``"broken"``.
+    """
+
+    name: str
+    status: str
+    version: Optional[str] = None
+    path: Optional[str] = None
+    error: Optional[BaseException] = None
+
+    @property
+    def ok(self) -> bool:
+        return self.status == "ok"
+
+    def summary(self) -> str:
+        """One-line human-readable status."""
+        if self.status == "ok":
+            return f"{self.name} {self.version or '(version unknown)'}"
+        if self.status == "missing":
+            return f"{self.name} NOT INSTALLED"
+        return f"{self.name} INSTALLED BUT FAILS TO LOAD: {self.error}"
+
+
+def _find_spec(name: str):
+    """``importlib.util.find_spec`` that never raises."""
+    try:
+        return importlib.util.find_spec(name)
+    except (ImportError, AttributeError, ValueError):
+        return None
+
+
+def probe(name: str) -> DependencyStatus:
+    """Determine whether *name* is absent, importable, or present-but-broken.
+
+    Args:
+        name: Module name, e.g. ``"PySide6"``.
+
+    Returns:
+        A :class:`DependencyStatus`. ``"missing"`` means no distribution
+        provides the module for this interpreter; ``"broken"`` means the files
+        are on disk but importing them raised.
+    """
+    spec = _find_spec(name)
+    if spec is None:
+        return DependencyStatus(name=name, status="missing")
+
+    origin = getattr(spec, "origin", None)
+    try:
+        module = importlib.import_module(name)
+    except BaseException as exc:  # noqa: BLE001 - report anything, never crash
+        return DependencyStatus(
+            name=name, status="broken", path=origin, error=exc
+        )
+
+    return DependencyStatus(
+        name=name,
+        status="ok",
+        version=getattr(module, "__version__", None),
+        path=getattr(module, "__file__", origin),
+    )
+
+
+def probe_qt() -> List[DependencyStatus]:
+    """Probe both supported Qt bindings, PySide6 first."""
+    return [probe("PySide6"), probe("PyQt6")]
+
+
+def explain_import_error(exc: BaseException) -> Optional[str]:
+    """Translate a dynamic-loader error message into actionable advice.
+
+    Args:
+        exc: The exception raised by a failed import.
+
+    Returns:
+        A hint string, or ``None`` when the message is not recognised.
+    """
+    text = str(exc).lower()
+    for needle, advice in _ERROR_HINTS:
+        if needle in text:
+            return advice
+    return None
+
+
+def _python_version_warning() -> Optional[str]:
+    """Warn when the interpreter is outside the range the GUI is tested on."""
+    v = sys.version_info[:2]
+    if v < PYTHON_MIN:
+        return (
+            f"Python {v[0]}.{v[1]} is below the minimum supported "
+            f"{PYTHON_MIN[0]}.{PYTHON_MIN[1]}."
+        )
+    if v > PYTHON_GUI_MAX_TESTED:
+        return (
+            f"Python {v[0]}.{v[1]} is newer than the newest version the GUI "
+            f"stack is tested against ({PYTHON_GUI_MAX_TESTED[0]}."
+            f"{PYTHON_GUI_MAX_TESTED[1]}). Qt wheels are often unavailable or "
+            f"unstable on brand-new Python releases — a "
+            f"{PYTHON_GUI_MAX_TESTED[0]}.{PYTHON_GUI_MAX_TESTED[1]} "
+            f"environment is the safe choice."
+        )
+    return None
+
+
+def environment_lines() -> List[str]:
+    """Interpreter/platform facts worth pasting into a bug report."""
+    try:
+        from pyirena import __version__ as pyirena_version
+    except Exception:  # pragma: no cover - only if the package is broken
+        pyirena_version = "unknown"
+
+    lines = [
+        f"pyirena          : {pyirena_version}",
+        f"python           : {platform.python_version()} ({sys.executable})",
+        f"platform         : {platform.platform()}",
+        f"machine          : {platform.machine()}",
+    ]
+
+    # A venv/conda env is the usual reason pip and the launcher disagree.
+    in_venv = sys.prefix != getattr(sys, "base_prefix", sys.prefix)
+    env_name = os.environ.get("CONDA_DEFAULT_ENV")
+    if env_name:
+        lines.append(f"conda env        : {env_name}")
+    lines.append(
+        f"environment      : {'virtualenv/venv' if in_venv else 'system/base'}"
+        f" (prefix {sys.prefix})"
+    )
+    return lines
+
+
+def _launcher_mismatch() -> Optional[str]:
+    """Detect the classic 'pip and the launcher use different Pythons' bug.
+
+    Reads the shebang of the installed ``pyirena-gui`` console script and
+    compares it with the running interpreter.
+
+    Returns:
+        A warning string when they differ, else ``None``.
+    """
+    script = shutil.which("pyirena-gui")
+    if not script:
+        return None
+    # Windows console scripts are .exe wrappers with no readable shebang.
+    if os.name == "nt" or script.lower().endswith(".exe"):
+        return None
+    try:
+        with open(script, "r", encoding="utf-8", errors="replace") as fh:
+            first = fh.readline().strip()
+    except OSError:
+        return None
+    if not first.startswith("#!"):
+        return None
+    interpreter = first[2:].strip().strip('"')
+    # "#!/usr/bin/env python" tells us nothing definite.
+    if not interpreter or interpreter.endswith("env python"):
+        return None
+    if os.path.realpath(interpreter) == os.path.realpath(sys.executable):
+        return None
+    return (
+        "The 'pyirena-gui' launcher runs a DIFFERENT Python than the one you "
+        "are using now:\n"
+        f"    launcher uses : {interpreter}\n"
+        f"    you are using : {sys.executable}\n"
+        "Packages installed with one are invisible to the other. Use\n"
+        "    python -m pip install 'pyirena[gui]'\n"
+        "    python -m pyirena.gui.launch\n"
+        "so that installation and launch always share one interpreter."
+    )
+
+
+def format_qt_import_failure(
+    statuses: Optional[Sequence[DependencyStatus]] = None,
+) -> str:
+    """Build the message raised when no Qt binding can be imported.
+
+    Distinguishes "not installed" from "installed but will not load" — the
+    distinction the old message threw away.
+
+    Args:
+        statuses: Result of :func:`probe_qt`; probed here when omitted.
+
+    Returns:
+        A multi-line message suitable for an ``ImportError``.
+    """
+    statuses = list(statuses) if statuses is not None else probe_qt()
+    broken = [s for s in statuses if s.status == "broken"]
+    parts: List[str] = []
+
+    if broken:
+        first = broken[0]
+        parts.append(
+            f"{first.name} IS installed but could not be loaded — so "
+            f"reinstalling it will probably not help."
+        )
+        parts.append(f"    location : {first.path}")
+        parts.append(f"    error    : {type(first.error).__name__}: {first.error}")
+        hint = explain_import_error(first.error) if first.error else None
+        if hint:
+            parts.append(f"    likely cause: {hint}")
+    else:
+        parts.append(
+            "No Qt bindings found for this Python interpreter. Install with:"
+        )
+        parts.append("    python -m pip install 'pyirena[gui]'")
+        parts.append(
+            "(Use 'python -m pip', not bare 'pip' — that guarantees the "
+            "packages land in the interpreter shown below. Quote the brackets; "
+            "zsh expands them otherwise.)"
+        )
+
+    version_warning = _python_version_warning()
+    if version_warning:
+        parts.append(f"\nNote: {version_warning}")
+
+    mismatch = _launcher_mismatch()
+    if mismatch:
+        parts.append("\n" + mismatch)
+
+    parts.append("\nEnvironment:")
+    parts.extend("    " + line for line in environment_lines())
+    parts.append("\nFull dependency report: run 'pyirena-doctor'")
+    return "\n".join(parts)
+
+
+def format_gui_import_failure(exc: BaseException) -> str:
+    """Build the message shown when launching the GUI fails on an import.
+
+    The failing module may be a Qt binding, another optional GUI dependency,
+    or an internal module (i.e. a genuine bug). These need different advice,
+    so identify which happened rather than blaming "GUI dependencies".
+
+    Args:
+        exc: The ``ImportError`` raised while importing the GUI.
+
+    Returns:
+        A multi-line message for the terminal.
+    """
+    name = getattr(exc, "name", None) or ""
+    root = name.split(".")[0]
+
+    # Already diagnosed by pyirena.gui._qt — pass it through unchanged rather
+    # than wrapping a second header around a complete message.
+    if "Qt binding" in str(exc):
+        return str(exc)
+
+    if root in ("PySide6", "PyQt6"):
+        return "pyIrena could not load a Qt binding.\n\n" + format_qt_import_failure()
+
+    if root in OPTIONAL_DEPENDENCIES:
+        extra, purpose = OPTIONAL_DEPENDENCIES[root]
+        status = probe(root)
+        lines = [
+            f"pyIrena could not start the GUI: '{root}' ({purpose}) is "
+            f"unavailable.",
+            "",
+        ]
+        if status.status == "broken":
+            lines.append(
+                f"{root} is installed at {status.path} but fails to load:"
+            )
+            lines.append(f"    {type(status.error).__name__}: {status.error}")
+            hint = explain_import_error(status.error) if status.error else None
+            if hint:
+                lines.append(f"    likely cause: {hint}")
+        else:
+            lines.append(f"Install it with:  python -m pip install 'pyirena[{extra}]'")
+        lines.append("")
+        lines.append("Environment:")
+        lines.extend("    " + line for line in environment_lines())
+        mismatch = _launcher_mismatch()
+        if mismatch:
+            lines.append("")
+            lines.append(mismatch)
+        lines.append("")
+        lines.append("Full dependency report: run 'pyirena-doctor'")
+        return "\n".join(lines)
+
+    # Not a known dependency: most likely a bug inside pyirena itself.
+    lines = [
+        "pyIrena could not start the GUI because of an unexpected import "
+        "error.",
+        "",
+        f"    {type(exc).__name__}: {exc}",
+        "",
+        "This looks like a bug rather than a missing package. The full "
+        "traceback follows, and is also written to:",
+        f"    {_log_path()}",
+        "",
+        "Please report it at https://github.com/jilavsky/pyirena/issues",
+    ]
+    return "\n".join(lines)
+
+
+def _log_path() -> str:
+    """Best-effort path to the GUI log file."""
+    try:
+        from pyirena.logging_setup import get_log_dir
+
+        return str(get_log_dir() / "gui.log")
+    except Exception:  # pragma: no cover - only if logging setup is broken
+        return "~/.pyirena/logs/gui.log"
+
+
+# --------------------------------------------------------------------------
+# pyirena-doctor
+# --------------------------------------------------------------------------
+
+def _report() -> List[str]:
+    """Assemble the full diagnostic report."""
+    out: List[str] = []
+    out.append("pyIrena environment report")
+    out.append("=" * 60)
+    out.extend(environment_lines())
+
+    try:
+        import pyirena
+
+        out.append(f"package path     : {os.path.dirname(pyirena.__file__)}")
+    except Exception as exc:  # pragma: no cover
+        out.append(f"package path     : UNAVAILABLE ({exc})")
+
+    out.append(f"scripts dir      : {sysconfig.get_path('scripts')}")
+    for tool in ("pyirena-gui", "pyirena-viewer", "pyirena-mcp"):
+        found = shutil.which(tool)
+        out.append(f"  {tool:<16}: {found or 'not on PATH'}")
+
+    out.append("")
+    out.append("Required dependencies")
+    out.append("-" * 60)
+    problems: List[DependencyStatus] = []
+    for name in REQUIRED_DEPENDENCIES:
+        status = probe(name)
+        out.append(f"  {status.summary()}")
+        if not status.ok:
+            problems.append(status)
+
+    out.append("")
+    out.append("Optional dependencies")
+    out.append("-" * 60)
+    for name, (extra, purpose) in OPTIONAL_DEPENDENCIES.items():
+        status = probe(name)
+        marker = "  " if status.ok else "! "
+        out.append(f"{marker}{status.summary()}   [{extra}: {purpose}]")
+        if status.status == "broken":
+            problems.append(status)
+
+    out.append("")
+    out.append("Diagnosis")
+    out.append("-" * 60)
+
+    qt = probe_qt()
+    if any(s.ok for s in qt):
+        binding = next(s for s in qt if s.ok)
+        out.append(f"  OK: Qt bindings available ({binding.name} {binding.version}).")
+    else:
+        out.append("  PROBLEM: no usable Qt binding — the GUI cannot start.")
+        out.append("")
+        out.extend("  " + line for line in format_qt_import_failure(qt).splitlines())
+
+    for status in problems:
+        if status.status != "broken":
+            continue
+        hint = explain_import_error(status.error) if status.error else None
+        if hint:
+            out.append(f"  {status.name}: {hint}")
+
+    version_warning = _python_version_warning()
+    if version_warning:
+        out.append(f"  WARNING: {version_warning}")
+
+    mismatch = _launcher_mismatch()
+    if mismatch:
+        out.append("")
+        out.extend("  " + line for line in mismatch.splitlines())
+
+    if not problems and any(s.ok for s in qt) and not mismatch:
+        out.append("  No problems detected.")
+
+    out.append("")
+    out.append(f"Log files: {os.path.dirname(_log_path())}")
+    return out
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    """Entry point for ``pyirena-doctor``.
+
+    Prints a dependency and environment report. Users can paste the output
+    into a bug report; maintainers can ask for it instead of guessing.
+
+    Returns:
+        Process exit code: 0 when the GUI stack looks usable, 1 otherwise.
+    """
+    del argv  # no options yet; accepted for symmetry with other entry points
+    lines = _report()
+    print("\n".join(lines))
+    return 0 if any(s.ok for s in probe_qt()) else 1
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())

--- a/pyirena/gui/__init__.py
+++ b/pyirena/gui/__init__.py
@@ -11,10 +11,29 @@ Requires:
 try:
     # Single import point for the whole gui package (PySide6 → PyQt6).
     from pyirena.gui._qt import QtWidgets, QtCore, QtGui, QT_BINDING as QT_BACKEND
-except ImportError:
+
+    QT_IMPORT_ERROR = None
+except ImportError as _qt_error:
+    # Degrade gracefully (importing pyirena must work without GUI extras) but
+    # keep the diagnosed failure: callers that need Qt should re-raise this
+    # rather than report a bare "QT_BACKEND is None".
     QT_BACKEND = None
     QtWidgets = None
     QtCore = None
     QtGui = None
+    QT_IMPORT_ERROR = _qt_error
 
-__all__ = ["QT_BACKEND", "QtWidgets", "QtCore", "QtGui"]
+__all__ = ["QT_BACKEND", "QT_IMPORT_ERROR", "QtWidgets", "QtCore", "QtGui"]
+
+
+def require_qt():
+    """Raise the diagnosed Qt import failure if no binding is available.
+
+    Use at the top of any entry point that cannot proceed without Qt, so the
+    user sees the full diagnosis instead of an ``AttributeError`` on ``None``.
+
+    Raises:
+        ImportError: The original, diagnosed failure from ``pyirena.gui._qt``.
+    """
+    if QT_IMPORT_ERROR is not None:
+        raise QT_IMPORT_ERROR

--- a/pyirena/gui/_qt.py
+++ b/pyirena/gui/_qt.py
@@ -13,21 +13,35 @@ Two import styles are supported:
 * submodules — ``from pyirena.gui._qt import QtWidgets, QtCore, QtGui``
 
 ``Signal`` is normalised across bindings (``pyqtSignal`` under PyQt6).
+
+When neither binding can be imported the failure is diagnosed by
+``pyirena.diagnostics`` rather than reported as "not installed" — an
+installed-but-unloadable Qt raises ``ImportError`` too, and telling the user
+to reinstall it sends them in a circle.  Run ``pyirena-doctor`` for the full
+report.
 """
 
 try:
     from PySide6 import QtWidgets, QtCore, QtGui
     from PySide6.QtCore import Signal
     QT_BINDING = "PySide6"
-except ImportError:  # pragma: no cover - exercised only without PySide6
+except ImportError as _pyside_error:  # pragma: no cover - only without PySide6
     try:
         from PyQt6 import QtWidgets, QtCore, QtGui  # type: ignore[no-redef]
         from PyQt6.QtCore import pyqtSignal as Signal  # type: ignore[no-redef]
         QT_BINDING = "PyQt6"
-    except ImportError:  # pragma: no cover
+    except ImportError as _pyqt_error:  # pragma: no cover
+        # Do NOT report this as "not installed": ImportError also covers an
+        # installed-but-unloadable binding (architecture mismatch, missing
+        # system libraries, shiboken6 version skew).  pyirena.diagnostics
+        # tells the two apart and names the interpreter that failed.
+        from pyirena.diagnostics import format_qt_import_failure
+
+        del _pyqt_error  # diagnosed below; PySide6 is the binding we report on
         raise ImportError(
-            "Neither PySide6 nor PyQt6 found. Install with: pip install PySide6"
-        )
+            "pyIrena could not load a Qt binding.\n\n"
+            + format_qt_import_failure()
+        ) from _pyside_error
 
 # --- QtWidgets ---------------------------------------------------------------
 QAbstractItemView = QtWidgets.QAbstractItemView

--- a/pyirena/gui/data_manipulation_panel.py
+++ b/pyirena/gui/data_manipulation_panel.py
@@ -29,6 +29,7 @@ from pyirena.core.data_manipulation import (
     DataManipulation, ManipResult,
     ScaleConfig, TrimConfig, RebinConfig, SubtractConfig, DivideConfig,
 )
+from pyirena.gui.file_filter import FILTER_PLACEHOLDER, FILTER_TOOLTIP, filter_names
 from pyirena.state.state_manager import StateManager
 from pyirena.gui.sas_plot import (
     make_sas_plot, make_cursors, get_cursor_q_range,
@@ -187,7 +188,8 @@ class _ManipFileBrowser(QWidget):
         filt_row = QHBoxLayout()
         filt_row.addWidget(QLabel("Filter:"))
         self.filter_edit = QLineEdit()
-        self.filter_edit.setPlaceholderText("text filter\u2026")
+        self.filter_edit.setPlaceholderText(FILTER_PLACEHOLDER)
+        self.filter_edit.setToolTip(FILTER_TOOLTIP)
         self.filter_edit.textChanged.connect(self._apply_filter)
         filt_row.addWidget(self.filter_edit, stretch=1)
         layout.addLayout(filt_row)
@@ -267,11 +269,10 @@ class _ManipFileBrowser(QWidget):
         self._apply_filter()
 
     def _apply_filter(self) -> None:
-        text = self.filter_edit.text().lower()
+        """Rebuild the visible list using the regex filter (see file_filter)."""
         self.file_list.clear()
-        for f in self._all_files:
-            if text in f.lower():
-                self.file_list.addItem(f)
+        for f in filter_names(self._all_files, self.filter_edit.text()):
+            self.file_list.addItem(f)
         n = self.file_list.count()
         self.count_label.setText(f"{n} file(s)")
 

--- a/pyirena/gui/data_merge_panel.py
+++ b/pyirena/gui/data_merge_panel.py
@@ -32,6 +32,7 @@ from pyirena.gui._qt import (
 import pyqtgraph as pg
 
 from pyirena.core.data_merge import DataMerge, MergeConfig, MergeResult
+from pyirena.gui.file_filter import FILTER_PLACEHOLDER, FILTER_TOOLTIP, filter_names
 from pyirena.state.state_manager import StateManager
 from pyirena.gui.sas_plot import (
     make_sas_plot, set_robust_y_range, _SafeInfiniteLine, SASPlotStyle,
@@ -160,7 +161,8 @@ class _DatasetSelectorWidget(QWidget):
         filt_row = QHBoxLayout()
         filt_row.addWidget(QLabel("Filter:"))
         self.filter_edit = QLineEdit()
-        self.filter_edit.setPlaceholderText("text filter…")
+        self.filter_edit.setPlaceholderText(FILTER_PLACEHOLDER)
+        self.filter_edit.setToolTip(FILTER_TOOLTIP)
         self.filter_edit.textChanged.connect(self._apply_filter)
         filt_row.addWidget(self.filter_edit, stretch=1)
         layout.addLayout(filt_row)
@@ -240,10 +242,7 @@ class _DatasetSelectorWidget(QWidget):
 
     def get_filtered_files(self) -> List[str]:
         """Return the file list after the text filter has been applied."""
-        text = self.filter_edit.text().lower()
-        if not text:
-            return list(self._all_files)
-        return [f for f in self._all_files if text in f.lower()]
+        return filter_names(self._all_files, self.filter_edit.text())
 
     # ------------------------------------------------------------------ #
     #  Private helpers                                                     #
@@ -276,11 +275,10 @@ class _DatasetSelectorWidget(QWidget):
         self._apply_filter()
 
     def _apply_filter(self) -> None:
-        text = self.filter_edit.text().lower()
+        """Rebuild the visible list using the regex filter (see file_filter)."""
         self.file_list.clear()
-        for f in self._all_files:
-            if text in f.lower():
-                self.file_list.addItem(f)
+        for f in filter_names(self._all_files, self.filter_edit.text()):
+            self.file_list.addItem(f)
         if self.filter_changed_callback is not None:
             self.filter_changed_callback()
 

--- a/pyirena/gui/data_selector/_qt.py
+++ b/pyirena/gui/data_selector/_qt.py
@@ -1,6 +1,9 @@
 """
 pyirena.gui.data_selector._qt — single PySide6/PyQt6 import point for the
 data_selector package (PySide6 preferred, PyQt6 fallback).
+
+Failure diagnosis is delegated to ``pyirena.diagnostics``; see
+``pyirena/gui/_qt.py`` for the rationale.
 """
 
 try:
@@ -13,7 +16,7 @@ try:
     )
     from PySide6.QtCore import Qt, QDir, QThread, Signal, QUrl
     from PySide6.QtGui import QAction, QDoubleValidator, QDesktopServices
-except ImportError:
+except ImportError as _pyside_error:
     try:
         from PyQt6.QtWidgets import (  # type: ignore[no-redef]
             QApplication, QWidget, QVBoxLayout, QHBoxLayout, QGridLayout, QPushButton,
@@ -25,9 +28,12 @@ except ImportError:
         from PyQt6.QtCore import Qt, QDir, QThread, pyqtSignal as Signal, QUrl  # type: ignore[no-redef]
         from PyQt6.QtGui import QAction, QDoubleValidator, QDesktopServices  # type: ignore[no-redef]
     except ImportError:
+        from pyirena.diagnostics import format_qt_import_failure
+
         raise ImportError(
-            "Neither PySide6 nor PyQt6 found. Install with: pip install PySide6"
-        )
+            "pyIrena could not load a Qt binding.\n\n"
+            + format_qt_import_failure()
+        ) from _pyside_error
 
 __all__ = [
     "QApplication", "QWidget", "QVBoxLayout", "QHBoxLayout", "QGridLayout",

--- a/pyirena/gui/data_selector/panel.py
+++ b/pyirena/gui/data_selector/panel.py
@@ -38,6 +38,7 @@ from pyirena.gui.data_selector.plot_utils import _gen_colors, _legend_indices
 from pyirena.gui.data_selector.report import _build_report
 from pyirena.gui.data_selector.results_windows import GraphWindow, SimpleFitResultsWindow, SizeDistResultsWindow, TabulateResultsWindow, UnifiedFitResultsWindow, WAXSPeakFitResultsWindow
 from pyirena.gui.data_selector.sorting import _SORT_KEYS
+from pyirena.gui.file_filter import FILTER_PLACEHOLDER, FILTER_TOOLTIP, make_file_matcher
 from pyirena.gui.data_selector.workers import BatchWorker, UpdateCheckWorker
 from pyirena.version_check import is_newer, should_check_now
 
@@ -295,7 +296,8 @@ class DataSelectorPanel(QWidget):
         filter_layout = QHBoxLayout()
         filter_layout.addWidget(QLabel("Filter:"))
         self.filter_input = QLineEdit()
-        self.filter_input.setPlaceholderText("Enter text to filter files...")
+        self.filter_input.setPlaceholderText(FILTER_PLACEHOLDER)
+        self.filter_input.setToolTip(FILTER_TOOLTIP)
         self.filter_input.setMaximumWidth(350)
         self.filter_input.textChanged.connect(self.filter_files)
         filter_layout.addWidget(self.filter_input)
@@ -1035,20 +1037,23 @@ class DataSelectorPanel(QWidget):
             self.status_label.setText(f"Error reading folder: {e}")
 
     def filter_files(self, filter_text: str):
-        """Filter the file list based on search text."""
+        """Filter the file list based on search text.
+
+        The text is a regular expression (grep semantics, case-insensitive);
+        see pyirena.gui.file_filter for the exact rules.
+        """
         if not filter_text:
             # Show all items
             for i in range(self.file_list.count()):
                 self.file_list.item(i).setHidden(False)
             return
 
-        # Use grep-like filtering (case-insensitive substring match)
-        filter_text = filter_text.lower()
+        matches_name = make_file_matcher(filter_text)
         visible_count = 0
 
         for i in range(self.file_list.count()):
             item = self.file_list.item(i)
-            matches = filter_text in item.text().lower()
+            matches = matches_name(item.text())
             item.setHidden(not matches)
             if matches:
                 visible_count += 1

--- a/pyirena/gui/file_filter.py
+++ b/pyirena/gui/file_filter.py
@@ -1,0 +1,104 @@
+"""
+Shared filename-filter logic for every file browser in the GUI.
+
+All of pyIrena's file-listing widgets (Data Selector, Data Manipulation, Data
+Merge, HDF5 Viewer) present a "Filter" box.  Historically only the HDF5 Viewer
+interpreted that text as a regular expression; the others did a plain
+case-insensitive substring test, which surprised users who expected the
+grep-like behaviour the documentation promised and that Igor Irena provided.
+
+This module is the single implementation.  It is deliberately Qt-free and
+matplotlib-free so it can be unit-tested headlessly and reused from any layer.
+
+Semantics
+---------
+- The filter text is treated as a Python regular expression matched with
+  ``re.search`` (i.e. it matches anywhere in the name, like grep) and
+  ``re.IGNORECASE``.
+- A plain fragment such as ``60C`` is a valid regex, so simple substring
+  filtering keeps working exactly as before.
+- If the text is *not* a valid regex — most commonly a half-typed pattern such
+  as ``sample(`` while the user is still typing — the filter silently falls
+  back to a case-insensitive substring test rather than hiding everything or
+  raising.
+- Empty/whitespace-only text matches everything.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Callable, Iterable, List
+
+__all__ = ["make_file_matcher", "filter_names", "is_valid_filter", "FILTER_TOOLTIP",
+           "FILTER_PLACEHOLDER"]
+
+
+# Shared UI strings so every panel advertises the same behaviour.
+FILTER_PLACEHOLDER = "Filter… (regex OK, e.g. 60C|0[12]min)"
+
+FILTER_TOOLTIP = (
+    "Filter filenames.  Regular expressions are supported:\n"
+    "  60C          — names containing '60C'\n"
+    "  0[12]min     — names with '01min' or '02min'\n"
+    "  60C|100C     — names with '60C' or '100C'\n"
+    "  ^sample      — names starting with 'sample'\n"
+    "  \\.h5$        — names ending with '.h5'\n"
+    "  ^(?!.*bkg)   — names NOT containing 'bkg'\n"
+    "Matching is case-insensitive.  Plain text fragments also work; an\n"
+    "incomplete or invalid pattern falls back to a substring match."
+)
+
+
+def make_file_matcher(filter_text: str) -> Callable[[str], bool]:
+    """Build a predicate that decides whether a filename passes the filter.
+
+    Args:
+        filter_text: Raw contents of a Filter box.  May be empty, a plain
+            substring, or any Python regular expression.
+
+    Returns:
+        A callable taking a filename and returning True if it should be shown.
+        Compilation happens once here, not per filename, so the returned
+        predicate is cheap to apply across a large listing.
+    """
+    if filter_text is None:
+        return lambda name: True
+
+    text = filter_text.strip()
+    if not text:
+        return lambda name: True
+
+    try:
+        pattern = re.compile(text, re.IGNORECASE)
+    except re.error:
+        # Half-typed or malformed pattern — degrade to substring matching so
+        # the list stays useful while the user is still typing.
+        lowered = text.lower()
+        return lambda name: lowered in name.lower()
+
+    return lambda name: bool(pattern.search(name))
+
+
+def filter_names(names: Iterable[str], filter_text: str) -> List[str]:
+    """Return the subset of ``names`` matching ``filter_text``.
+
+    Convenience wrapper around :func:`make_file_matcher` for the panels that
+    rebuild their list widget from scratch rather than hiding rows.
+    """
+    matches = make_file_matcher(filter_text)
+    return [n for n in names if matches(n)]
+
+
+def is_valid_filter(filter_text: str) -> bool:
+    """Report whether ``filter_text`` compiles as a regular expression.
+
+    Empty text counts as valid.  Useful if a panel wants to give the user
+    visual feedback about a malformed pattern.
+    """
+    if not filter_text or not filter_text.strip():
+        return True
+    try:
+        re.compile(filter_text.strip())
+    except re.error:
+        return False
+    return True

--- a/pyirena/gui/hdf5viewer/__init__.py
+++ b/pyirena/gui/hdf5viewer/__init__.py
@@ -21,10 +21,9 @@ def main(initial_folder: str | None = None) -> None:
     install_excepthook()
     import sys
 
-    try:
-        from PySide6.QtWidgets import QApplication
-    except ImportError:
-        from PyQt6.QtWidgets import QApplication  # type: ignore[no-redef]
+    # Route through the shared shim so a missing/broken Qt is diagnosed once,
+    # consistently, instead of surfacing as a bare ModuleNotFoundError.
+    from pyirena.gui._qt import QApplication
 
     app = QApplication.instance() or QApplication(sys.argv)
     app.setStyle("Fusion")

--- a/pyirena/gui/hdf5viewer/file_tree.py
+++ b/pyirena/gui/hdf5viewer/file_tree.py
@@ -25,6 +25,7 @@ from typing import Callable
 from pyirena.gui._qt import (
     QBrush, QColor, QComboBox, QFileDialog, QFont, QHBoxLayout, QLabel, QLineEdit, QPushButton, QSizePolicy, QTreeWidget, QTreeWidgetItem, QVBoxLayout, QWidget, Qt, Signal,
 )
+from pyirena.gui.file_filter import FILTER_PLACEHOLDER, FILTER_TOOLTIP, make_file_matcher
 
 # ── Extensions treated as HDF5 files ───────────────────────────────────────
 HDF5_EXTENSIONS = {".h5", ".hdf5", ".hdf", ".nxs", ".h5xp"}
@@ -148,14 +149,8 @@ class FileTreeWidget(QWidget):
 
         # Filter row (below sort)
         self._filter_edit = QLineEdit()
-        self._filter_edit.setPlaceholderText("Filter… (regex OK, e.g. 60C|0[12]min)")
-        self._filter_edit.setToolTip(
-            "Filter filenames.  Regular expressions are supported:\n"
-            "  60C        — files containing '60C'\n"
-            "  0[12]min   — files with '01min' or '02min'\n"
-            "  ^sample    — files starting with 'sample'\n"
-            "Plain text fragments also work."
-        )
+        self._filter_edit.setPlaceholderText(FILTER_PLACEHOLDER)
+        self._filter_edit.setToolTip(FILTER_TOOLTIP)
         self._filter_edit.textChanged.connect(self._on_filter_changed)
         layout.addWidget(self._filter_edit)
 
@@ -338,11 +333,12 @@ class FileTreeWidget(QWidget):
 
     def _apply_filter(self) -> None:
         """Show/hide file items based on the filter text."""
-        flt = self._filter_text
+        # Compile once here rather than per filename inside the recursion.
+        matcher = make_file_matcher(self._filter_text)
         root = self._tree.invisibleRootItem()
-        self._filter_node(root, flt)
+        self._filter_node(root, matcher)
 
-    def _filter_node(self, parent: QTreeWidgetItem, flt: str) -> bool:
+    def _filter_node(self, parent: QTreeWidgetItem, flt: Callable[[str], bool]) -> bool:
         """Recursively filter items; return True if any child is visible."""
         any_visible = False
         for i in range(parent.childCount()):
@@ -361,14 +357,7 @@ class FileTreeWidget(QWidget):
                     any_visible |= child_visible
             else:
                 # File item
-                name = child.text(0)
-                if not flt:
-                    visible = True
-                else:
-                    try:
-                        visible = bool(re.search(flt, name, re.IGNORECASE))
-                    except re.error:
-                        visible = flt.lower() in name.lower()
+                visible = flt(child.text(0))
                 child.setHidden(not visible)
                 any_visible |= visible
         return any_visible

--- a/pyirena/gui/launch.py
+++ b/pyirena/gui/launch.py
@@ -8,6 +8,7 @@ Usage:
     pyirena-gui (if installed)
 """
 
+import logging
 import sys
 
 
@@ -20,10 +21,35 @@ def main():
         from pyirena.gui.data_selector import main as gui_main
         gui_main()
     except ImportError as e:
-        print("Error: GUI dependencies not installed.")
-        print("Install with: pip install pyirena[gui]")
-        print(f"\nDetails: {e}")
+        # An ImportError here is not automatically a missing dependency: it
+        # may be an installed-but-unloadable binary, or a bug in pyirena.
+        # pyirena.diagnostics identifies which, and the traceback always goes
+        # to the log so a user report is actionable.
+        from pyirena.diagnostics import format_gui_import_failure
+
+        # DEBUG, not ERROR: the file handler records DEBUG and above, so the
+        # traceback is preserved for support, while the console shows only the
+        # formatted diagnosis instead of a wall of stack frames.
+        logging.getLogger("pyirena").debug(
+            "GUI failed to start", exc_info=True
+        )
+        print(format_gui_import_failure(e), file=sys.stderr)
+        if _verbose():
+            raise
+        print(
+            "\n(Re-run with PYIRENA_DEBUG=1 to see the full traceback.)",
+            file=sys.stderr,
+        )
         sys.exit(1)
+
+
+def _verbose() -> bool:
+    """True when the user asked for raw tracebacks via PYIRENA_DEBUG."""
+    import os
+
+    return os.environ.get("PYIRENA_DEBUG", "").strip().lower() not in (
+        "", "0", "false", "no",
+    )
 
 
 if __name__ == "__main__":

--- a/pyirena/gui/modeling_panel.py
+++ b/pyirena/gui/modeling_panel.py
@@ -2141,23 +2141,40 @@ class _FitWorker(QThread):
 
 class _MCWorker(QThread):
     """Runs ModelingEngine.calculate_uncertainty_mc() off the GUI thread."""
-    progress = Signal(int, int)  # (current_run, total_runs)
+    progress = Signal(int, int)  # (passes_done, total_runs)
     finished = Signal(dict)      # stds dict
     error    = Signal(str)
 
-    def __init__(self, engine, config, q, I, dI, n_runs, parent=None):
+    def __init__(self, engine, config, q, I, dI, n_runs, workers=None, parent=None):
         super().__init__(parent)
         self._engine = engine
         self._config = config
         self._q, self._I, self._dI = q, I, dI
         self._n_runs = n_runs
+        self._workers = workers
+        self._cancelled = False
+
+    def cancel(self):
+        """Request cancellation — polled between MC passes.
+
+        A pass already in flight is not interrupted, so this takes effect within
+        roughly one pass; the uncertainties from completed passes are kept.
+        """
+        self._cancelled = True
+
+    @property
+    def cancelled(self) -> bool:
+        return self._cancelled
 
     def run(self):
         try:
+            worker = self
             stds = self._engine.calculate_uncertainty_mc(
                 self._config, self._q, self._I, self._dI,
                 n_runs=self._n_runs,
                 progress_cb=lambda i, n: self.progress.emit(i, n),
+                cancel_cb=lambda: worker._cancelled,
+                workers=self._workers,
             )
             self.finished.emit(stds)
         except Exception as exc:
@@ -2187,6 +2204,7 @@ class ModelingPanel(SlitSmearingMixin, QWidget):
         self._state = StateManager()
         self._fit_worker: Optional[_FitWorker] = None
         self._mc_worker: Optional[_MCWorker] = None
+        self._mc_progress: tuple = (0, 0)   # (passes done, total) for the status line
         self._pre_fit_state: Optional[dict] = None   # snapshot for Revert
 
         # Throttled autoupdate (ported from Unified Fit): single-shot timer,
@@ -2565,7 +2583,7 @@ class ModelingPanel(SlitSmearingMixin, QWidget):
         lay.addWidget(_mkbtn('Reset to Defaults', 'orange', self._reset_to_defaults,
                              'Reset all parameters to their default values.'))
 
-        # Row 5: Passes + Calc. Uncertainty (MC)
+        # Row 5: Passes + cores + Calc. Uncertainty (MC)
         out5 = QHBoxLayout()
         out5.addWidget(QLabel('Passes:'))
         self.n_runs_spin = QSpinBox()
@@ -2573,6 +2591,27 @@ class ModelingPanel(SlitSmearingMixin, QWidget):
         self.n_runs_spin.setValue(10)
         self.n_runs_spin.setFixedWidth(60)
         out5.addWidget(self.n_runs_spin)
+
+        # Worker processes for the MC passes. Unlike the Global search 'cores'
+        # spinner this one is always enabled — MC passes are independent of the
+        # fit method. 0 shows as 'auto'.
+        out5.addWidget(QLabel('cores:'))
+        self.mc_workers_spin = QSpinBox()
+        self.mc_workers_spin.setRange(0, max(1, os.cpu_count() or 1))
+        self.mc_workers_spin.setValue(0)
+        self.mc_workers_spin.setSpecialValueText('auto')
+        self.mc_workers_spin.setFixedWidth(56)
+        self.mc_workers_spin.setToolTip(
+            "Worker processes for the Monte-Carlo passes.\n"
+            "auto = all cores but two (the default); 1 = serial.\n"
+            "Each pass is an independent refit, so this scales nearly linearly\n"
+            "for slow models (complex form factors, several populations).\n"
+            "Short runs stay serial automatically — starting worker processes\n"
+            "would cost more than it saves. If the host cannot start workers,\n"
+            "the passes fall back to serial."
+        )
+        out5.addWidget(self.mc_workers_spin)
+
         self.btn_mc = QPushButton('Calc. Uncertainty (MC)')
         self.btn_mc.setMinimumHeight(26)
         self.btn_mc.setStyleSheet(
@@ -2583,7 +2622,9 @@ class ModelingPanel(SlitSmearingMixin, QWidget):
         )
         self.btn_mc.setToolTip(
             "Estimate parameter uncertainties by repeating the fit on noise-perturbed data.\n"
-            "Set 'Passes' to control how many Monte Carlo replicates are used."
+            "Set 'Passes' to control how many Monte Carlo replicates are used, and\n"
+            "'cores' to spread them over worker processes.\n"
+            "Click again while running to cancel; completed passes are still used."
         )
         self.btn_mc.clicked.connect(self.calc_uncertainty_mc)
         self.btn_mc.setEnabled(False)
@@ -2618,6 +2659,10 @@ class ModelingPanel(SlitSmearingMixin, QWidget):
             max(self.de_workers_spin.minimum(),
                 min(dw, self.de_workers_spin.maximum())))
         self.n_runs_spin.setValue(mod_state.get('n_mc_runs', 10))
+        mw = int(mod_state.get('mc_workers', 0))
+        self.mc_workers_spin.setValue(
+            max(self.mc_workers_spin.minimum(),
+                min(mw, self.mc_workers_spin.maximum())))
 
         pops = mod_state.get('populations', [])
         for i, pw in enumerate(self._pop_widgets):
@@ -2650,6 +2695,7 @@ class ModelingPanel(SlitSmearingMixin, QWidget):
             'fit_method':    self.fit_method_combo.currentData() or 'local',
             'de_workers':    self.de_workers_spin.value(),
             'n_mc_runs':     self.n_runs_spin.value(),
+            'mc_workers':    self.mc_workers_spin.value(),
             'q_min':         None,
             'q_max':         None,
             'populations':   [pw.to_full_dict() for pw in self._pop_widgets],
@@ -3013,6 +3059,7 @@ class ModelingPanel(SlitSmearingMixin, QWidget):
             n_mc_runs=self.n_runs_spin.value(),
             fit_method=self._current_fit_method(),
             de_workers=self.de_workers_spin.value(),
+            mc_workers=self.mc_workers_spin.value(),
             use_slit_smearing=self.slit_active(),
             slit_length=self.current_slit_length(),
         )
@@ -3276,21 +3323,36 @@ class ModelingPanel(SlitSmearingMixin, QWidget):
 
     def calc_uncertainty_mc(self):
         """Start Monte-Carlo uncertainty estimation in a background thread."""
+        # If MC is already running, treat the click as a cancel request — same
+        # pattern as the Fit button. Passes already in flight finish, so this
+        # takes effect within roughly one pass.
+        if self._mc_worker is not None and self._mc_worker.isRunning():
+            self._mc_worker.cancel()
+            self.btn_mc.setEnabled(False)
+            self.graph.set_status(
+                'Cancelling MC — waiting for passes in flight …', 'working')
+            return
+
         if self._last_result is None or self._data_q is None:
             QMessageBox.information(self, 'No result', 'Run a fit first.')
             return
 
-        if self._mc_worker is not None and self._mc_worker.isRunning():
-            return
-
         n = self.n_runs_spin.value()
-        self.btn_mc.setEnabled(False)
+        self._mc_progress = (0, n)
+        self.btn_mc.setText('Cancel MC')
+        self.btn_mc.setStyleSheet(
+            'QPushButton {background: #e74c3c; color: white; font-weight: bold;'
+            ' border-radius: 4px;}'
+            'QPushButton:hover {background: #c0392b;}'
+            'QPushButton:disabled {background: #bdc3c7;}'
+        )
         self.btn_fit.setEnabled(False)
         self.graph.set_status(f'Starting MC — 0 / {n} passes …', 'working')
 
         self._mc_worker = _MCWorker(
             self._engine, deepcopy(self._last_result.config),
             self._data_q, self._data_I, self._data_dI, n_runs=n,
+            workers=self.mc_workers_spin.value(),
             parent=self,
         )
         self._mc_worker.progress.connect(self._on_mc_progress)
@@ -3298,22 +3360,47 @@ class ModelingPanel(SlitSmearingMixin, QWidget):
         self._mc_worker.error.connect(self._on_mc_error)
         self._mc_worker.start()
 
-    def _on_mc_progress(self, current: int, total: int):
-        self.graph.set_status(f'MC uncertainty — pass {current} / {total} …', 'working')
+    def _restore_mc_button(self):
+        """Restore the MC button to its normal appearance after a run/cancel."""
+        self.btn_mc.setText('Calc. Uncertainty (MC)')
+        self.btn_mc.setStyleSheet(
+            'QPushButton {background: #16a085; color: white; font-weight: bold;'
+            ' border-radius: 4px;}'
+            'QPushButton:hover {background: #1abc9c;}'
+            'QPushButton:disabled {background: #8ac4bc; color: #f8f8f8;}'
+        )
+        self.btn_mc.setEnabled(True)
+
+    def _on_mc_progress(self, done: int, total: int):
+        # Passes complete out of order when running in parallel, so this is a
+        # completion count rather than a pass index.
+        self._mc_progress = (done, total)
+        self.graph.set_status(f'MC uncertainty — {done} / {total} passes …', 'working')
 
     def _on_mc_done(self, stds: dict):
         if self._last_result is not None:
             self._last_result.params_std = stds
 
-        self.btn_mc.setEnabled(True)
+        cancelled = self._mc_worker is not None and self._mc_worker.cancelled
+        done, total = getattr(self, '_mc_progress', (0, 0))
+        self._restore_mc_button()
         self.btn_fit.setEnabled(True)
 
         if stds:
             from pyirena.gui.fmt_utils import eng_fmt
-            lines = ['MC uncertainties (±1σ):'] + [
+            header = ('MC uncertainties (±1σ, cancelled after '
+                      f'{done} of {total} passes):' if cancelled
+                      else 'MC uncertainties (±1σ):')
+            lines = [header] + [
                 f'  {k}: ± {eng_fmt(v)}' for k, v in sorted(stds.items())
             ]
-            self.graph.set_status('\n'.join(lines), 'success')
+            self.graph.set_status('\n'.join(lines), 'warning' if cancelled else 'success')
+        elif cancelled:
+            self.graph.set_status(
+                f'MC cancelled after {done} of {total} passes — too few to '
+                'estimate uncertainty (need at least 2).',
+                'warning',
+            )
         else:
             self.graph.set_status(
                 'MC uncertainty: no fittable parameters or too few successful runs.',
@@ -3322,7 +3409,7 @@ class ModelingPanel(SlitSmearingMixin, QWidget):
 
     def _on_mc_error(self, msg: str):
         self.graph.set_status(f'MC error: {msg}', 'error')
-        self.btn_mc.setEnabled(True)
+        self._restore_mc_button()
         self.btn_fit.setEnabled(True)
 
     # ── Save / Export ─────────────────────────────────────────────────────────
@@ -3428,6 +3515,7 @@ class ModelingPanel(SlitSmearingMixin, QWidget):
             'fit_method':     mc.fit_method,
             'de_workers':     mc.de_workers,
             'n_mc_runs':      mc.n_mc_runs,
+            'mc_workers':     mc.mc_workers,
             'q_min':          mc.q_min,
             'q_max':          mc.q_max,
             'populations':    [_pop_to_dict(p) for p in mc.populations],

--- a/pyirena/state/state_manager.py
+++ b/pyirena/state/state_manager.py
@@ -327,7 +327,7 @@ class StateManager:
             "similarity_normalize_scale": True,
         },
         "modeling": {
-            "schema_version": 4,
+            "schema_version": 5,
             "q_min": None,
             "q_max": None,
             "background": 0.0,
@@ -336,6 +336,9 @@ class StateManager:
             "fit_method": "local",
             "de_workers": 1,
             "n_mc_runs": 10,
+            # Worker processes for Monte-Carlo uncertainty passes (new in
+            # schema_version 5). 0 = auto (cpu_count - 2), 1 = serial, N = explicit.
+            "mc_workers": 0,
             "populations": [
                 # Population 0 — enabled by default
                 {
@@ -882,6 +885,14 @@ class StateManager:
             modeling.setdefault('de_workers',
                                 self.DEFAULT_STATE['modeling']['de_workers'])
             modeling['schema_version'] = 4
+            self.state['modeling'] = modeling
+
+        if stored_modeling_version < 5 <= target_modeling_version:
+            # schema_version 4 → 5: mc_workers added (parallel Monte-Carlo
+            # uncertainty passes). Old states pick up the auto default (0).
+            modeling.setdefault('mc_workers',
+                                self.DEFAULT_STATE['modeling']['mc_workers'])
+            modeling['schema_version'] = 5
             self.state['modeling'] = modeling
 
     def _merge_state(self, default: Dict, loaded: Dict) -> Dict:

--- a/pyirena/tests/test_diagnostics.py
+++ b/pyirena/tests/test_diagnostics.py
@@ -1,0 +1,232 @@
+"""
+Tests for pyirena.diagnostics — the dependency/environment troubleshooter.
+
+These cover the distinction that motivated the module: a package that is
+*absent* and a package that is *present but unloadable* both raise
+``ImportError``, and pyIrena must not report the second as the first.
+
+Headless and Qt-free: everything is exercised through injected fake modules.
+"""
+import builtins
+import importlib
+import sys
+
+import pytest
+
+from pyirena import diagnostics
+
+
+# --------------------------------------------------------------------------
+# probe()
+# --------------------------------------------------------------------------
+
+def test_probe_reports_ok_for_stdlib_module():
+    status = diagnostics.probe("json")
+    assert status.status == "ok"
+    assert status.ok
+    assert status.path is not None
+
+
+def test_probe_reports_missing_for_absent_module():
+    status = diagnostics.probe("pyirena_definitely_not_a_real_module")
+    assert status.status == "missing"
+    assert not status.ok
+    assert "NOT INSTALLED" in status.summary()
+
+
+def test_probe_reports_broken_when_import_raises(monkeypatch):
+    """A module whose spec exists but whose import fails is 'broken'."""
+    boom = ImportError("dlopen(...): incompatible architecture")
+
+    monkeypatch.setattr(diagnostics, "_find_spec", lambda name: object())
+
+    def fake_import(name):
+        raise boom
+
+    monkeypatch.setattr(diagnostics.importlib, "import_module", fake_import)
+
+    status = diagnostics.probe("PySide6")
+    assert status.status == "broken"
+    assert status.error is boom
+    assert "FAILS TO LOAD" in status.summary()
+
+
+def test_probe_survives_non_importerror(monkeypatch):
+    """A module that raises something exotic must not crash the probe."""
+    monkeypatch.setattr(diagnostics, "_find_spec", lambda name: object())
+
+    def fake_import(name):
+        raise RuntimeError("Qt platform plugin exploded")
+
+    monkeypatch.setattr(diagnostics.importlib, "import_module", fake_import)
+
+    status = diagnostics.probe("PySide6")
+    assert status.status == "broken"
+    assert isinstance(status.error, RuntimeError)
+
+
+# --------------------------------------------------------------------------
+# explain_import_error()
+# --------------------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    "message, expected_fragment",
+    [
+        ("mach-o file, but is an incompatible architecture", "Architecture mismatch"),
+        ("libGL.so.1: cannot open shared object file", "libgl1"),
+        ("libxkbcommon-x11.so.0: cannot open shared object", "libxkbcommon-x11-0"),
+        ("DLL load failed while importing QtCore", "Visual C++"),
+        ("Symbol not found: __ZN9QMetaType", "mixed install"),
+        ("shiboken6 version mismatch", "shiboken6"),
+        ("/lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.28' not found", "C library"),
+    ],
+)
+def test_explain_import_error_recognises_common_causes(message, expected_fragment):
+    hint = diagnostics.explain_import_error(ImportError(message))
+    assert hint is not None
+    assert expected_fragment.lower() in hint.lower()
+
+
+def test_explain_import_error_returns_none_for_unknown_message():
+    assert diagnostics.explain_import_error(ImportError("something novel")) is None
+
+
+# --------------------------------------------------------------------------
+# format_qt_import_failure()
+# --------------------------------------------------------------------------
+
+def test_qt_failure_message_when_truly_missing():
+    statuses = [
+        diagnostics.DependencyStatus("PySide6", "missing"),
+        diagnostics.DependencyStatus("PyQt6", "missing"),
+    ]
+    msg = diagnostics.format_qt_import_failure(statuses)
+    assert "No Qt bindings found" in msg
+    assert "python -m pip install" in msg
+    # The interpreter must be named: this is what resolves wrong-env reports.
+    assert sys.executable in msg
+
+
+def test_qt_failure_message_when_installed_but_broken():
+    """The key regression: do not tell users to install what they have."""
+    broken = diagnostics.DependencyStatus(
+        "PySide6",
+        "broken",
+        path="/some/site-packages/PySide6/__init__.py",
+        error=ImportError("incompatible architecture (have 'x86_64', need 'arm64')"),
+    )
+    msg = diagnostics.format_qt_import_failure(
+        [broken, diagnostics.DependencyStatus("PyQt6", "missing")]
+    )
+    assert "IS installed" in msg
+    assert "reinstalling it will probably not help" in msg
+    assert "/some/site-packages/PySide6/__init__.py" in msg
+    assert "Architecture mismatch" in msg
+    # Must NOT give the misleading install instruction.
+    assert "No Qt bindings found" not in msg
+
+
+def test_qt_failure_message_mentions_doctor():
+    msg = diagnostics.format_qt_import_failure(
+        [
+            diagnostics.DependencyStatus("PySide6", "missing"),
+            diagnostics.DependencyStatus("PyQt6", "missing"),
+        ]
+    )
+    assert "pyirena-doctor" in msg
+
+
+# --------------------------------------------------------------------------
+# format_gui_import_failure()
+# --------------------------------------------------------------------------
+
+def test_gui_failure_names_the_optional_dependency():
+    exc = ModuleNotFoundError("No module named 'pyqtgraph'", name="pyqtgraph")
+    msg = diagnostics.format_gui_import_failure(exc)
+    assert "pyqtgraph" in msg
+    assert "pyirena[gui]" in msg
+
+
+def test_gui_failure_treats_unknown_module_as_a_bug():
+    exc = ModuleNotFoundError(
+        "No module named 'pyirena.gui.typo'", name="pyirena.gui.typo"
+    )
+    msg = diagnostics.format_gui_import_failure(exc)
+    assert "bug" in msg.lower()
+    assert "issues" in msg
+    # Must not blame the user's dependencies for an internal error.
+    assert "pip install" not in msg
+
+
+def test_gui_failure_diagnoses_a_raw_qt_importerror():
+    """A bare PySide6 ImportError gets the full Qt diagnosis attached."""
+    exc = ImportError("No module named 'PySide6'", name="PySide6")
+    msg = diagnostics.format_gui_import_failure(exc)
+    assert "could not load a Qt binding" in msg
+    assert sys.executable in msg
+
+
+def test_gui_failure_passes_existing_qt_diagnosis_through_unchanged():
+    """An already-diagnosed message is not wrapped in a second header."""
+    diagnosed = (
+        "pyIrena could not load a Qt binding.\n\nPySide6 IS installed but ..."
+    )
+    msg = diagnostics.format_gui_import_failure(ImportError(diagnosed))
+    assert msg == diagnosed
+    assert msg.count("could not load a Qt binding") == 1
+
+
+# --------------------------------------------------------------------------
+# environment + report
+# --------------------------------------------------------------------------
+
+def test_environment_lines_include_interpreter_and_platform():
+    lines = "\n".join(diagnostics.environment_lines())
+    assert sys.executable in lines
+    assert "python" in lines
+    assert "machine" in lines
+
+
+def test_report_runs_and_mentions_required_dependencies():
+    text = "\n".join(diagnostics._report())
+    for name in diagnostics.REQUIRED_DEPENDENCIES:
+        assert name in text
+    assert "pyIrena environment report" in text
+
+
+def test_main_returns_exit_code(capsys):
+    code = diagnostics.main()
+    out = capsys.readouterr().out
+    assert "pyIrena environment report" in out
+    # 0 when a Qt binding loads, 1 otherwise — both are valid here since CI
+    # may or may not have the gui extra installed.
+    assert code in (0, 1)
+    assert code == (0 if any(s.ok for s in diagnostics.probe_qt()) else 1)
+
+
+# --------------------------------------------------------------------------
+# _qt.py integration: the shim must not claim "not installed" wrongly
+# --------------------------------------------------------------------------
+
+def test_qt_shim_raises_diagnosed_error_when_bindings_absent(monkeypatch):
+    """Simulate an environment with neither binding and re-import the shim."""
+    real_import = builtins.__import__
+
+    def blocked_import(name, *args, **kwargs):
+        if name.split(".")[0] in ("PySide6", "PyQt6"):
+            raise ImportError(f"No module named {name!r}", name=name)
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", blocked_import)
+    for mod in list(sys.modules):
+        if mod.startswith(("PySide6", "PyQt6", "pyirena.gui._qt")):
+            monkeypatch.delitem(sys.modules, mod, raising=False)
+
+    with pytest.raises(ImportError) as excinfo:
+        importlib.import_module("pyirena.gui._qt")
+
+    message = str(excinfo.value)
+    assert "could not load a Qt binding" in message
+    assert "pyirena-doctor" in message
+    # The old message must be gone — it was the source of the confusion.
+    assert "Neither PySide6 nor PyQt6 found" not in message

--- a/pyirena/tests/test_file_filter.py
+++ b/pyirena/tests/test_file_filter.py
@@ -1,0 +1,123 @@
+"""Tests for the shared filename-filter helper (pyirena.gui.file_filter).
+
+The module is deliberately Qt-free, so these run headless without importing
+PySide6.
+"""
+
+import pytest
+
+from pyirena.gui.file_filter import (
+    filter_names,
+    is_valid_filter,
+    make_file_matcher,
+)
+
+
+NAMES = [
+    "sample_60C_01min.h5",
+    "sample_60C_02min.h5",
+    "sample_100C_01min.h5",
+    "bkg_60C_01min.h5",
+    "Sample_25C_10min.dat",
+    "spheres_Rg50.h5",
+]
+
+
+# ── Empty / trivial filters ────────────────────────────────────────────────
+
+@pytest.mark.parametrize("text", ["", "   ", None])
+def test_empty_filter_matches_everything(text):
+    assert filter_names(NAMES, text) == NAMES
+
+
+def test_plain_substring_still_works():
+    assert filter_names(NAMES, "Rg50") == ["spheres_Rg50.h5"]
+
+
+def test_matching_is_case_insensitive():
+    assert filter_names(NAMES, "sample") == [
+        "sample_60C_01min.h5",
+        "sample_60C_02min.h5",
+        "sample_100C_01min.h5",
+        "Sample_25C_10min.dat",
+    ]
+
+
+# ── Real regex features — the point of the change ──────────────────────────
+
+def test_alternation():
+    got = filter_names(NAMES, "100C|25C")
+    assert got == ["sample_100C_01min.h5", "Sample_25C_10min.dat"]
+
+
+def test_character_class():
+    got = filter_names(NAMES, "0[12]min")
+    assert "sample_60C_01min.h5" in got
+    assert "sample_60C_02min.h5" in got
+    assert "Sample_25C_10min.dat" not in got
+
+
+def test_anchor_start():
+    got = filter_names(NAMES, "^sample")
+    # Case-insensitive, so the capitalised variant is included too.
+    assert "bkg_60C_01min.h5" not in got
+    assert "Sample_25C_10min.dat" in got
+
+
+def test_anchor_end():
+    got = filter_names(NAMES, r"\.h5$")
+    assert "Sample_25C_10min.dat" not in got
+    assert len(got) == 5
+
+
+def test_negative_lookahead_excludes():
+    got = filter_names(NAMES, "^(?!.*bkg)")
+    assert "bkg_60C_01min.h5" not in got
+    assert len(got) == len(NAMES) - 1
+
+
+def test_search_not_fullmatch():
+    """Patterns match anywhere in the name, like grep — not just the whole name."""
+    assert filter_names(NAMES, "60C") == [
+        "sample_60C_01min.h5",
+        "sample_60C_02min.h5",
+        "bkg_60C_01min.h5",
+    ]
+
+
+def test_quantifier_and_group():
+    got = filter_names(NAMES, r"_(\d+)C_0\dmin")
+    assert "Sample_25C_10min.dat" not in got
+    assert "sample_100C_01min.h5" in got
+
+
+# ── Invalid patterns degrade gracefully ────────────────────────────────────
+
+def test_invalid_regex_falls_back_to_substring():
+    # A half-typed group: must not raise, and must not blank the list.
+    got = filter_names(["a(b.h5", "plain.h5"], "a(b")
+    assert got == ["a(b.h5"]
+
+
+def test_invalid_regex_unbalanced_bracket():
+    got = filter_names(["x[1].h5", "y.h5"], "x[1")
+    assert got == ["x[1].h5"]
+
+
+def test_make_file_matcher_returns_callable():
+    m = make_file_matcher("60C")
+    assert callable(m)
+    assert m("sample_60C_01min.h5") is True
+    assert m("sample_25C_01min.h5") is False
+
+
+# ── Validity reporting ─────────────────────────────────────────────────────
+
+@pytest.mark.parametrize("text", ["", "  ", "60C", "0[12]min", "^(?!.*bkg)", r"\.h5$"])
+def test_is_valid_filter_true(text):
+    assert is_valid_filter(text) is True
+
+
+@pytest.mark.parametrize("text", ["a(b", "x[1", "*bad", "(?P<"])
+def test_is_valid_filter_false(text):
+    assert is_valid_filter(text) is False

--- a/pyirena/tests/test_modeling_global_fit.py
+++ b/pyirena/tests/test_modeling_global_fit.py
@@ -253,10 +253,12 @@ class TestStateMigration:
         sm = StateManager(state_file=f)
         assert sm.load() is True
         mod = sm.state['modeling']
-        # 2 → 3 added fit_method, 3 → 4 added de_workers; both default safely.
+        # 2 → 3 added fit_method, 3 → 4 de_workers, 4 → 5 mc_workers; all
+        # default safely.
         assert mod['fit_method'] == 'local'
         assert mod['de_workers'] == 1
-        assert mod['schema_version'] == 4
+        assert mod['mc_workers'] == 0
+        assert mod['schema_version'] == 5
 
 
 # ── Exported JSON config carries fit_method (batch/scripting) ────────────────

--- a/pyirena/tests/test_modeling_global_fit.py
+++ b/pyirena/tests/test_modeling_global_fit.py
@@ -268,14 +268,14 @@ class TestExportJsonCarriesFitMethod:
     batch run (fit_modeling) uses the method the user picked in the GUI."""
 
     def test_export_includes_selected_fit_method(self, tmp_path, monkeypatch):
-        pytest.importorskip("pyirena.gui.modeling_panel")
+        # pytest.importorskip is not enough here: pyirena.gui._qt re-raises a
+        # plain ImportError, which pytest >= 8.2 treats as a broken module
+        # rather than a missing one (same idiom as test_modeling_report_csv).
         try:
-            try:
-                from PySide6.QtWidgets import QApplication
-            except ImportError:
-                from PyQt6.QtWidgets import QApplication
-        except Exception:
-            pytest.skip("Qt not available")
+            import pyirena.gui.modeling_panel  # noqa: F401
+            from pyirena.gui._qt import QApplication
+        except ImportError:
+            pytest.skip("Qt (PySide6/PyQt6) not available")
 
         import os
         os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")

--- a/pyirena/tests/test_modeling_mc_parallel.py
+++ b/pyirena/tests/test_modeling_mc_parallel.py
@@ -1,0 +1,284 @@
+"""
+Unit tests for parallel Monte-Carlo uncertainty estimation in the Modeling tool
+(``ModelingEngine.calculate_uncertainty_mc``), plus its config/state plumbing.
+
+The central guarantee under test is that parallel and serial runs produce
+*identical* uncertainties for a given seed. That holds because every
+perturbation is drawn in the parent process before any pass starts, which also
+rules out the failure mode where workers inherit one RNG state and return N
+identical passes — silently collapsing every uncertainty towards zero.
+"""
+
+import json
+import os
+import pickle
+
+import numpy as np
+import pytest
+
+import pyirena.core.modeling as M
+from pyirena.core.modeling import (
+    ModelingConfig,
+    ModelingEngine,
+    SizeDistPopulation,
+    _MCRun,
+    _resolve_mc_workers,
+)
+
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+def _make_fit_config(start_r=60.0):
+    """One lognormal sphere population with three free parameters + background."""
+    p = SizeDistPopulation()
+    p.enabled = True
+    p.dist_type = 'lognormal'
+    p.dist_params = {'min_size': 10.0, 'mean_size': start_r, 'sdeviation': 0.3}
+    p.dist_params_fit = {'min_size': False, 'mean_size': True, 'sdeviation': True}
+    p.dist_params_limits = {
+        'min_size': (0.0, 1e6), 'mean_size': (1.0, 1e6), 'sdeviation': (0.01, 5.0),
+    }
+    p.form_factor = 'sphere'
+    p.scale = 0.001
+    p.fit_scale = True
+    p.contrast = 1.0
+    p.n_bins = 60                      # small grid — these tests are about plumbing
+    return ModelingConfig(
+        populations=[p], background=0.0, fit_background=True,
+        q_min=1e-3, q_max=0.1,
+    )
+
+
+def _make_dataset(cfg, n_q=60, seed=1):
+    eng = ModelingEngine()
+    q = np.logspace(-3, -1, n_q)
+    I_true, *_ = eng.total_intensity(cfg, q, use_cache=False)
+    rng = np.random.default_rng(seed)
+    dI = 0.03 * I_true + 1e-12
+    return q, I_true + dI * rng.standard_normal(n_q), dI
+
+
+@pytest.fixture
+def mc_case():
+    cfg = _make_fit_config()
+    q, I_obs, dI = _make_dataset(cfg)
+    return ModelingEngine(), cfg, q, I_obs, dI
+
+
+# ── Config / worker-count defaults ───────────────────────────────────────────
+
+class TestConfigDefaults:
+    def test_mc_workers_default_is_auto(self):
+        assert ModelingConfig().mc_workers == 0
+
+    def test_resolve_auto_leaves_headroom(self):
+        n_cpu = os.cpu_count() or 1
+        assert _resolve_mc_workers(0) == max(1, n_cpu - 2)
+        # None and negatives mean "auto" too.
+        assert _resolve_mc_workers(None) == max(1, n_cpu - 2)
+        assert _resolve_mc_workers(-4) == max(1, n_cpu - 2)
+
+    def test_resolve_explicit_counts(self):
+        n_cpu = os.cpu_count() or 1
+        assert _resolve_mc_workers(1) == 1
+        assert _resolve_mc_workers(2) == min(2, n_cpu)
+        # Never hand out more workers than there are cores.
+        assert _resolve_mc_workers(9999) == n_cpu
+
+
+# ── The picklable pass ───────────────────────────────────────────────────────
+
+class TestMCRun:
+    def test_pickles_and_matches_an_inline_fit(self, mc_case):
+        """_MCRun must survive the worker boundary and return exactly what an
+        in-process fit of the same perturbed data would."""
+        eng, cfg, q, I_obs, dI = mc_case
+        _, _, _, keys = eng._pack_params(M.deepcopy(cfg))
+
+        cfg_mc = M.deepcopy(cfg)
+        cfg_mc.fit_method = 'local'
+        cfg_mc.de_workers = 1
+        run = _MCRun(cfg_mc, q, dI, len(keys))
+
+        I_pert = I_obs + dI * np.random.default_rng(7).standard_normal(len(q))
+
+        expected = run(I_pert)
+        assert expected is not None and len(expected) == len(keys)
+
+        revived = pickle.loads(pickle.dumps(run))
+        assert revived(I_pert) == pytest.approx(expected)
+
+    def test_failed_pass_returns_none_rather_than_raising(self, mc_case):
+        """A pass that blows up is skipped, exactly as in the serial loop."""
+        eng, cfg, q, I_obs, dI = mc_case
+        cfg_mc = M.deepcopy(cfg)
+        run = _MCRun(cfg_mc, q, dI, n_keys=4)
+        # Wrong-length intensity → fit() raises inside the pass.
+        assert run(I_obs[:5]) is None
+
+
+# ── Serial vs parallel equivalence ───────────────────────────────────────────
+
+class TestSerialParallelIdentity:
+    def test_same_seed_gives_identical_sigmas(self, mc_case, monkeypatch):
+        """The headline guarantee: with the pool forced on, parallel results are
+        bit-identical to serial ones."""
+        eng, cfg, q, I_obs, dI = mc_case
+        monkeypatch.setattr(M, '_MC_PARALLEL_MIN_SECONDS', 0.0)   # force the pool
+
+        serial = eng.calculate_uncertainty_mc(
+            cfg, q, I_obs, dI, n_runs=4, workers=1, seed=42)
+        parallel = eng.calculate_uncertainty_mc(
+            cfg, q, I_obs, dI, n_runs=4, workers=2, seed=42)
+
+        assert serial, "serial run produced no uncertainties"
+        assert serial == parallel
+
+    def test_progress_counts_every_pass_exactly_once(self, mc_case, monkeypatch):
+        eng, cfg, q, I_obs, dI = mc_case
+        monkeypatch.setattr(M, '_MC_PARALLEL_MIN_SECONDS', 0.0)
+
+        seen = []
+        eng.calculate_uncertainty_mc(
+            cfg, q, I_obs, dI, n_runs=4, workers=2, seed=1,
+            progress_cb=lambda done, total: seen.append((done, total)))
+
+        assert seen == [(1, 4), (2, 4), (3, 4), (4, 4)]
+
+    def test_different_seeds_give_different_sigmas(self, mc_case):
+        """Guards the RNG plumbing: N passes must not share one noise draw."""
+        eng, cfg, q, I_obs, dI = mc_case
+        a = eng.calculate_uncertainty_mc(cfg, q, I_obs, dI, n_runs=4, workers=1, seed=1)
+        b = eng.calculate_uncertainty_mc(cfg, q, I_obs, dI, n_runs=4, workers=1, seed=2)
+        assert a and b and a != b
+        # ...and every σ is a real spread, not a collapsed zero.
+        assert all(v > 0 for v in a.values())
+
+
+# ── Choosing between pool and serial ─────────────────────────────────────────
+
+class TestPoolSelection:
+    def test_short_run_stays_serial(self, mc_case, monkeypatch):
+        """A job too small to repay pool startup must never build one, even when
+        plenty of workers are requested."""
+        eng, cfg, q, I_obs, dI = mc_case
+        monkeypatch.setattr(M, '_MC_PARALLEL_MIN_SECONDS', 1e6)   # nothing qualifies
+
+        called = []
+        monkeypatch.setattr(M, '_run_mc_parallel',
+                            lambda *a, **k: called.append(1) or [])
+
+        stds = eng.calculate_uncertainty_mc(
+            cfg, q, I_obs, dI, n_runs=3, workers=8, seed=3)
+
+        assert called == [], "pool was built for a job that should stay serial"
+        assert stds
+
+    def test_single_worker_never_builds_a_pool(self, mc_case, monkeypatch):
+        eng, cfg, q, I_obs, dI = mc_case
+        monkeypatch.setattr(M, '_MC_PARALLEL_MIN_SECONDS', 0.0)
+
+        called = []
+        monkeypatch.setattr(M, '_run_mc_parallel',
+                            lambda *a, **k: called.append(1) or [])
+
+        eng.calculate_uncertainty_mc(cfg, q, I_obs, dI, n_runs=3, workers=1, seed=3)
+        assert called == []
+
+
+# ── Failure handling ─────────────────────────────────────────────────────────
+
+class TestPoolFailureFallback:
+    def test_unstartable_pool_falls_back_to_serial(self, mc_case, monkeypatch):
+        """If the host cannot start workers the estimate must still complete —
+        and must not double-count the passes it retries serially."""
+        eng, cfg, q, I_obs, dI = mc_case
+        monkeypatch.setattr(M, '_MC_PARALLEL_MIN_SECONDS', 0.0)
+
+        def _boom(*a, **k):
+            raise OSError("simulated: cannot start worker processes")
+
+        monkeypatch.setattr('concurrent.futures.ProcessPoolExecutor', _boom)
+
+        seen = []
+        with pytest.warns(RuntimeWarning, match='running serially'):
+            parallel = eng.calculate_uncertainty_mc(
+                cfg, q, I_obs, dI, n_runs=4, workers=2, seed=42,
+                progress_cb=lambda done, total: seen.append(done))
+
+        # Every pass ran exactly once, and the answer matches a plain serial run.
+        assert seen == [1, 2, 3, 4]
+        serial = eng.calculate_uncertainty_mc(
+            cfg, q, I_obs, dI, n_runs=4, workers=1, seed=42)
+        assert parallel == serial
+
+
+# ── Cancellation ─────────────────────────────────────────────────────────────
+
+class TestCancel:
+    def test_cancel_stops_early_and_keeps_completed_passes(self, mc_case):
+        eng, cfg, q, I_obs, dI = mc_case
+
+        seen = []
+        stds = eng.calculate_uncertainty_mc(
+            cfg, q, I_obs, dI, n_runs=20, workers=1, seed=5,
+            progress_cb=lambda done, total: seen.append(done),
+            cancel_cb=lambda: len(seen) >= 3)
+
+        assert len(seen) < 20, "cancel did not stop the run"
+        assert stds, "uncertainties from completed passes were thrown away"
+
+    def test_cancel_before_two_passes_yields_no_estimate(self, mc_case):
+        """Fewer than two passes cannot give a standard deviation."""
+        eng, cfg, q, I_obs, dI = mc_case
+        stds = eng.calculate_uncertainty_mc(
+            cfg, q, I_obs, dI, n_runs=20, workers=1, seed=5,
+            cancel_cb=lambda: True)
+        assert stds == {}
+
+
+# ── Degenerate inputs ────────────────────────────────────────────────────────
+
+class TestDegenerate:
+    def test_no_fittable_parameters_returns_empty(self, mc_case):
+        eng, cfg, q, I_obs, dI = mc_case
+        cfg.fit_background = False
+        cfg.populations[0].fit_scale = False
+        cfg.populations[0].dist_params_fit = {
+            'min_size': False, 'mean_size': False, 'sdeviation': False,
+        }
+        assert eng.calculate_uncertainty_mc(cfg, q, I_obs, dI, n_runs=4) == {}
+
+    def test_single_pass_cannot_give_a_spread(self, mc_case):
+        eng, cfg, q, I_obs, dI = mc_case
+        assert eng.calculate_uncertainty_mc(
+            cfg, q, I_obs, dI, n_runs=1, workers=1, seed=1) == {}
+
+
+# ── State migration (schema 4 → 5 adds mc_workers) ───────────────────────────
+
+class TestStateMigration:
+    def test_old_modeling_state_gains_mc_workers(self, tmp_path):
+        from pyirena.state.state_manager import StateManager
+
+        old = {
+            'modeling': {
+                'schema_version': 4,
+                'background': 0.0,
+                'fit_background': True,
+                'no_limits': False,
+                'fit_method': 'local',
+                'de_workers': 1,
+                'n_mc_runs': 10,
+                'populations': [],
+            }
+        }
+        f = tmp_path / 'state.json'
+        f.write_text(json.dumps(old))
+
+        sm = StateManager(state_file=f)
+        assert sm.load() is True
+        mod = sm.state['modeling']
+        assert mod['mc_workers'] == 0          # auto
+        assert mod['schema_version'] == 5
+        assert mod['de_workers'] == 1          # untouched by the new migration

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pyirena"
-version = "1.1.0b3"
+version = "1.1.0b4"
 description = "Python tools for small-angle scattering data analysis."
 readme = {file = "README.md", content-type = "text/markdown"}
 requires-python = ">=3.9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,6 +107,7 @@ pyirena-datamanip = "pyirena.gui.data_manipulation_panel:main"
 pyirena-contrast = "pyirena.gui.contrast_panel:main"
 pyirena-saxsmorph = "pyirena.gui.saxs_morph_panel:main"
 pyirena-mcp = "pyirena.mcp.server:main"
+pyirena-doctor = "pyirena.diagnostics:main"
 
 [tool.setuptools.packages.find]
 include = ["pyirena*"]


### PR DESCRIPTION
## [1.1.0b4] - 2026-08-06

### Added

- **Parallel Monte-Carlo uncertainty in the Modeling tool.** Each MC pass is an
  independent refit of noise-perturbed data, so passes now run across worker
  processes instead of one after another. This was impractical before for the
  models that need it most: a complex form factor (core-shell,
  core-shell-shell) or several populations can take minutes per pass, making a
  20-pass estimate a coffee break. A new **cores** spin box next to
  *Modeling → Passes:* controls it — **auto** (the default: all cores but two),
  **1** for the previous serial behaviour, or an explicit count. The same
  setting is available to scripts as `fit_modeling(..., mc_workers=N)` and as
  the `"mc_workers"` key in the exported JSON config. See
  [MC Uncertainty](docs/modeling_gui.md#mc-uncertainty).
  - Uncertainties are unchanged by the worker count: all the noise is drawn in
    the parent process before any pass starts, so a given run produces the same
    numbers serially and in parallel.
  - Short runs stay serial automatically. The first pass is timed and the pool
    is only started when the remaining passes are projected to take more than a
    few seconds, so simple models never pay for worker startup.
  - If the host cannot start worker processes the passes fall back to serial
    with a warning rather than failing.
- **Cancel for Modeling MC runs.** The **Calc. Uncertainty (MC)** button becomes
  **Cancel MC** while a run is in progress. Cancelling does not interrupt passes
  already in flight, so it takes effect within roughly one pass, and the
  uncertainties from the passes that did finish are still reported along with
  how many were used.

- **Regular expressions in every file Filter box.** The documentation promised
  grep-like filtering, but only the HDF5 Viewer actually interpreted the Filter
  text as a regex — Data Selector, Data Manipulation and Data Merge did a plain
  case-insensitive substring test, so patterns like `60C|100C`, `0[12]min`,
  `^sample`, `\.h5$` or `^(?!.*bkg)` silently matched nothing. All four
  browsers now share one implementation (`pyirena.gui.file_filter`) using full
  Python regular expressions matched anywhere in the name, case-insensitively.
  A plain fragment such as `Rg50` behaves exactly as before, and an incomplete
  or invalid pattern (common while typing) falls back to a substring match
  rather than emptying the list.

- **`pyirena-doctor` — installation troubleshooter.** A new console command
  that reports the running interpreter, every required and optional
  dependency, and whether the `pyirena-gui` launcher uses the same Python as
  your `pip`. Each dependency is classified as installed, missing, or
  *installed but failing to load* — the three states that the previous error
  messages collapsed into one. Users can paste its output into a bug report.
  See [Installation → Troubleshooting](docs/installation.md#troubleshooting).

### Fixed

- **"GUI dependencies not installed" when they demonstrably were.** `ImportError`
  covers both a genuinely absent package and one that is present but whose
  binaries will not load (wrong CPU architecture, missing system libraries,
  shiboken6/PySide6 version skew). pyIrena reported the second as the first,
  telling users to reinstall something they already had. Qt import failures are
  now diagnosed: the message says which of the two happened, where the package
  lives, the original loader error, the interpreter that failed, and — for
  recognised errors such as `incompatible architecture` or `libGL.so.1` — the
  likely cause and fix.
- **Wrong-environment installs are now detected.** When the `pyirena-gui`
  launcher script points at a different Python than the one running, both paths
  are printed along with the `python -m pip` / `python -m pyirena.gui.launch`
  form that keeps them in sync. This is the most common cause of the report
  above.
- **GUI startup errors are no longer flattened into a dependency message.** An
  `ImportError` from an internal module is now identified as a probable bug
  (with an issue-tracker pointer) rather than blamed on missing packages, and
  the full traceback is always written to `~/.pyirena/logs/gui.log`.
  `PYIRENA_DEBUG=1` also prints it to the terminal.
- `pyirena-viewer` imported Qt directly instead of going through
  `pyirena.gui._qt`, so it produced a bare `ModuleNotFoundError` instead of the
  diagnosed message.
- A Modeling test (`test_export_includes_selected_fit_method`) failed instead
  of skipping in environments without Qt, because `pytest.importorskip` treats
  a re-raised plain `ImportError` as a broken module rather than a missing one.

### Changed

- The **Filter** placeholder and tooltip in Data Selector, Data Manipulation,
  Data Merge and the HDF5 Viewer now come from one shared string and document
  the regex syntax inline, replacing the previous "text filter…" /
  "Enter text to filter files..." hints.